### PR TITLE
Fix problems with limits after mathop

### DIFF
--- a/lib/texutil.js
+++ b/lib/texutil.js
@@ -654,7 +654,7 @@ module.exports.fun_ar1 = arr2set([
     "\\mathclose",
     "\\mathfrak",
     "\\mathit",
-    "\\mathop",
+//    "\\mathop", // moved to fun_ar1nb
     "\\mathopen",
     "\\mathord",
     "\\mathpunct",
@@ -691,6 +691,7 @@ module.exports.other_fun_ar1 = obj2map({
 
 module.exports.fun_ar1nb = arr2set([
     "\\operatorname",
+    "\\mathop",
     "\\overbrace",
     "\\mathbb",
     "\\mathbf",

--- a/test/all.js
+++ b/test/all.js
@@ -303,7 +303,7 @@ describe('Comprehensive test cases', function() {
                 '{\\ddot {A}}{\\dot {A}}{\\emph {A}}{\\grave {A}}{\\hat {A}}' +
                 '\\mathbb {A} \\mathbf {A} {\\mathbin {A}}{\\mathcal {A}}' +
                 '{\\mathclose {A}}{\\mathfrak {A}}{\\mathit {A}}' +
-                '{\\mathop {A}}{\\mathopen {A}}{\\mathord {A}}' +
+                '\\mathop {A} {\\mathopen {A}}{\\mathord {A}}' +
                 '{\\mathpunct {A}}{\\mathrel {A}}\\mathrm {A} {\\mathsf {A}}' +
                 '{\\mathtt {A}}\\operatorname {A} {\\overleftarrow {A}}' +
                 '{\\overleftrightarrow {A}}{\\overline {A}}' +


### PR DESCRIPTION
Problem: texvcjs converte $\mathop A\limits_a^b$ (which renders
ok in TeX to ${\mathop{A}}\limits_a^b$ (which cannot be rendered
with TeX).

This fix removes the superfluous curly braces by moving mathop
from fun_ar1 to fun_ar1nb.

Bug: T136932