### PR TITLE
T140217 Adjust texvcjs to prevent whitespace modifications in ce-tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
     - "4"
     - "5"
     - "6"
+    - "7"
+    - "8"
 before_install:
   - npm install npm -g
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-    - "0.10"
-    - "0.12"
     - "4"
     - "5"
     - "6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ node_js:
     - "6"
 before_install:
   - npm install npm -g
+after_success:
+  - npm run cover
+  - npm run report-coverage

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ Licensed under GPLv2.
 [NPM1]: https://nodei.co/npm/texvcjs.svg
 [NPM2]: https://nodei.co/npm/texvcjs/
 
-[1]: https://travis-ci.org/manfredschaefer/texvcjs.svg
-[2]: https://travis-ci.org/manfredschaefer/texvcjs
-[3]: https://david-dm.org/manfredschaefer/texvcjs.svg
-[4]: https://david-dm.org/manfredschaefer/texvcjs
-[5]: https://david-dm.org/manfredschaefer/texvcjs/dev-status.svg
-[6]: https://david-dm.org/manfredschaefer/texvcjs#info=devDependencies
+[1]: https://travis-ci.org/wikimedia/texvcjs.svg
+[2]: https://travis-ci.org/wikimedia/texvcjs
+[3]: https://david-dm.org/wikimedia/texvcjs.svg
+[4]: https://david-dm.org/wikimedia/texvcjs
+[5]: https://david-dm.org/wikimedia/texvcjs/dev-status.svg
+[6]: https://david-dm.org/wikimedia/texvcjs#info=devDependencies
 [7]: https://coveralls.io/repos/github/manfredschaefer/texvcjs/badge.svg?branch=master
 [8]: https://coveralls.io/github/manfredschaefer/texvcjs?branch=master

--- a/README.md
+++ b/README.md
@@ -77,6 +77,34 @@ queries on the input source.  An example can be found in `lib/astutil.js`
 which defines a visitor function to test for the presence of specific
 TeX functions in the input.
 
+## mhchem
+
+To use the `\ce` tags from the mhchem package the parser needs to be called
+with the mhchem option. During the parsing if a `\ce` tag is encountered
+its contens is treated according to the [mhchem grammar]. The parsing in
+general and the building up of the AST is done in a similar fashion to the
+math mode but preserves the whitespaces when needed.
+
+As the design of the parser does not allow the usage of the dollar sign in
+the math mode the tags `\begin{math}` and `\end{math}` were introduced to 
+provide the ability to switch to math mode within a chemical formula. The
+undocumented `\color` tag of mhchem is only supported for named colors. 
+The full documentation of the mhchem package can be found on the 
+[mhchem website].
+
+### Examples:
+This example would be typeset wrongly without the extended parser as some
+charges would be typeset as bonds and some addition signs would end up as 
+charges. Running:
+```sh
+bin/texvcjs  --usemhchem \ce{2Na + 2H2O -> 2Na+ + 2OH- + H-H}
+```
+emits:
+```
++{\ce {2Na + 2H2O -> 2Na+ + 2OH- + H-H}}
+```
+More examples can be found on the [mhchem website].
+
 ## License
 
 Copyright (c) 2014 C. Scott Ananian
@@ -89,6 +117,9 @@ Licensed under GPLv2.
 [Collection extension]: https://www.mediawiki.org/wiki/Extension:Collection
 [OCaml]: https://ocaml.org/
 [LaTeX packages]: http://www.ctan.org/
+
+[mhchem grammar]: https://raw.githubusercontent.com/mhchem/MathJax-mhchem-validity-syntax/master/mhchem-strict-simplified.grm
+[mhchem website]: https://mhchem.github.io/MathJax-mhchem/
 
 [NPM1]: https://nodei.co/npm/texvcjs.svg
 [NPM2]: https://nodei.co/npm/texvcjs/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The `texvcjs` library was originally written to be used by the
 
 ## Installation
 
-Node version 0.8 and 0.10 are tested to work.
+Node version 4, 5, 6, 7, and 8 are tested to work.
 
 Install the node package dependencies with:
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # texvcjs
 [![NPM][NPM1]][NPM2]
 
-[![Build Status][1]][2] [![dependency status][3]][4] [![dev dependency status][5]][6]
+[![Build Status][1]][2] [![dependency status][3]][4] [![dev dependency status][5]][6] [![Coverage Status][7]][8]
 
 A TeX/LaTeX validator.
 
@@ -99,3 +99,5 @@ Licensed under GPLv2.
 [4]: https://david-dm.org/wikimedia/texvcjs
 [5]: https://david-dm.org/wikimedia/texvcjs/dev-status.svg
 [6]: https://david-dm.org/wikimedia/texvcjs#info=devDependencies
+[7]: https://coveralls.io/repos/github/manfredschaefer/texvcjs/badge.svg?branch=master
+[8]: https://coveralls.io/github/manfredschaefer/texvcjs?branch=master

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ Licensed under GPLv2.
 [NPM1]: https://nodei.co/npm/texvcjs.svg
 [NPM2]: https://nodei.co/npm/texvcjs/
 
-[1]: https://travis-ci.org/wikimedia/texvcjs.svg
-[2]: https://travis-ci.org/wikimedia/texvcjs
-[3]: https://david-dm.org/wikimedia/texvcjs.svg
-[4]: https://david-dm.org/wikimedia/texvcjs
-[5]: https://david-dm.org/wikimedia/texvcjs/dev-status.svg
-[6]: https://david-dm.org/wikimedia/texvcjs#info=devDependencies
+[1]: https://travis-ci.org/manfredschaefer/texvcjs.svg
+[2]: https://travis-ci.org/manfredschaefer/texvcjs
+[3]: https://david-dm.org/manfredschaefer/texvcjs.svg
+[4]: https://david-dm.org/manfredschaefer/texvcjs
+[5]: https://david-dm.org/manfredschaefer/texvcjs/dev-status.svg
+[6]: https://david-dm.org/manfredschaefer/texvcjs#info=devDependencies
 [7]: https://coveralls.io/repos/github/manfredschaefer/texvcjs/badge.svg?branch=master
 [8]: https://coveralls.io/github/manfredschaefer/texvcjs?branch=master

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -159,6 +159,7 @@ var Tex = module.exports.Tex = new Enum( 'Tex', {
     CHEM_FUN1:{ args: [ 'string', 'self' ] }, // name, expr
     CHEM_FUN2:{ args: [ 'string', 'self', 'self' ] }, // name, expr
     CHEM_FUN2u:{ args: [ 'string', 'self', 'self' ] }, // name, expr
+    CHEM_FUN2c:{ args: [ 'string', 'self' ] }, // name, expr
     FUN1nb:  { args: [ 'string', 'self' ] }, // name, expr
     FUN2:    { args: [ 'string', 'self', 'self' ] },
     FUN2nb:  { args: [ 'string', 'self', 'self' ] },

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -154,12 +154,8 @@ var Tex = module.exports.Tex = new Enum( 'Tex', {
     BIG:     { args: [ 'string', RenderT ] }, // name, contents
     FUN1:    { args: [ 'string', 'self' ] }, // name, expr
     MHCHEM:  { args: [ 'string', 'self' ] }, // name, expr
-    CHEM_BOND:{ args: [ 'string', 'self' ] }, // name, expr
     CHEM_WORD:{ args: [ 'self', 'self' ] }, // name, expr
-    CHEM_FUN1:{ args: [ 'string', 'self' ] }, // name, expr
-    CHEM_FUN2:{ args: [ 'string', 'self', 'self' ] }, // name, expr
     CHEM_FUN2u:{ args: [ 'string', 'self', 'self' ] }, // name, expr
-    CHEM_FUN2c:{ args: [ 'string', 'self' ] }, // name, expr
     FUN1nb:  { args: [ 'string', 'self' ] }, // name, expr
     FUN2:    { args: [ 'string', 'self', 'self' ] },
     FUN2nb:  { args: [ 'string', 'self', 'self' ] },

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -153,6 +153,7 @@ var Tex = module.exports.Tex = new Enum( 'Tex', {
     BIG:     { args: [ 'string', RenderT ] }, // name, contents
     FUN1:    { args: [ 'string', 'self' ] }, // name, expr
     MHCHEM:  { args: [ 'string', 'self' ] }, // name, expr
+    CHEM_BOND:{ args: [ 'string', 'self' ] }, // name, expr
     FUN1nb:  { args: [ 'string', 'self' ] }, // name, expr
     FUN2:    { args: [ 'string', 'self', 'self' ] },
     FUN2nb:  { args: [ 'string', 'self', 'self' ] },

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -142,6 +142,7 @@ var RenderT = module.exports.RenderT = new Enum( 'RenderT', {
 var Tex = module.exports.Tex = new Enum( 'Tex', {
     LITERAL: { args: [ RenderT ] }, // contents
     CURLY:   { args: [ ['self'] ] }, // expr
+    DOLLAR:  { args: [ ['self'] ] }, // expr
     FQ:      { args: [ 'self', 'self', 'self' ] }, // base, down, up
     DQ:      { args: [ 'self', 'self' ] }, // base, down
     UQ:      { args: [ 'self', 'self' ] }, // base, up

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -152,6 +152,7 @@ var Tex = module.exports.Tex = new Enum( 'Tex', {
     BOX:     { args: [ 'string', 'string' ] }, // name, contents
     BIG:     { args: [ 'string', RenderT ] }, // name, contents
     FUN1:    { args: [ 'string', 'self' ] }, // name, expr
+    MHCHEM:  { args: [ 'string', 'self' ] }, // name, expr
     FUN1nb:  { args: [ 'string', 'self' ] }, // name, expr
     FUN2:    { args: [ 'string', 'self', 'self' ] },
     FUN2nb:  { args: [ 'string', 'self', 'self' ] },

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -154,6 +154,10 @@ var Tex = module.exports.Tex = new Enum( 'Tex', {
     FUN1:    { args: [ 'string', 'self' ] }, // name, expr
     MHCHEM:  { args: [ 'string', 'self' ] }, // name, expr
     CHEM_BOND:{ args: [ 'string', 'self' ] }, // name, expr
+    CHEM_WORD:{ args: [ 'self', 'self' ] }, // name, expr
+    CHEM_FUN1:{ args: [ 'string', 'self' ] }, // name, expr
+    CHEM_FUN2:{ args: [ 'string', 'self', 'self' ] }, // name, expr
+    CHEM_FUN2u:{ args: [ 'string', 'self', 'self' ] }, // name, expr
     FUN1nb:  { args: [ 'string', 'self' ] }, // name, expr
     FUN2:    { args: [ 'string', 'self', 'self' ] },
     FUN2nb:  { args: [ 'string', 'self', 'self' ] },

--- a/lib/astutil.js
+++ b/lib/astutil.js
@@ -161,6 +161,10 @@ ast.Tex.defineVisitor("contains_func", {
         // { tl1 tl2 tl3 ... }
         return arr_contains_func(tl, target);
     },
+    DOLLAR: function(target, tl) {
+        // { tl1 tl2 tl3 ... }
+        return arr_contains_func(tl, target);
+    },
     INFIX: function(target, s, ll, rl) {
         // { ll1 ll2 ... \s rl1 rl2 ... } (infix function)
         return match(target, s) ||

--- a/lib/astutil.js
+++ b/lib/astutil.js
@@ -115,6 +115,25 @@ ast.Tex.defineVisitor("contains_func", {
         // {\f{a}}  (function of one argument)
         return match(target, f) || a.contains_func(target);
     },
+    // TODO find correct expression
+    CHEM_WORD: function(target, r, s) {
+        // chem word
+        return true;
+    },
+    CHEM_FUN1: function(target, f, a) {
+        // {\f{a}}  (function of one argument)
+        return match(target, f) || a.contains_func(target);
+    },
+    CHEM_FUN2: function(target, f, a, b) {
+        // {\f{a}{b}}  (function of one argument)
+        return match(target, f) ||
+            a.contains_func(target) || b.contains_func(target);
+    },
+    CHEM_FUN2u: function(target, f, a, b) {
+        // {\underbrace{a}}  (function of two argument)
+        return match(target, f) ||
+            a.contains_func(target) || b.contains_func(target);
+    },
     FUN1nb: function(target, f, a) {
         // \f{a}  (function of one argument, "no braces" around outside)
         return match(target, f) || a.contains_func(target);

--- a/lib/astutil.js
+++ b/lib/astutil.js
@@ -115,10 +115,9 @@ ast.Tex.defineVisitor("contains_func", {
         // {\f{a}}  (function of one argument)
         return match(target, f) || a.contains_func(target);
     },
-    // TODO find correct expression
     CHEM_WORD: function(target, r, s) {
         // chem word
-        return true;
+        return match(target, r + s);
     },
     CHEM_FUN1: function(target, f, a) {
         // {\f{a}}  (function of one argument)
@@ -133,6 +132,10 @@ ast.Tex.defineVisitor("contains_func", {
         // {\underbrace{a}}  (function of two argument)
         return match(target, f) ||
             a.contains_func(target) || b.contains_func(target);
+    },
+    CHEM_FUN2c: function(target, a, b) {
+        // {\color []{a}{b}}
+        return a.contains_func(target) || b.contains_func(target);
     },
     FUN1nb: function(target, f, a) {
         // \f{a}  (function of one argument, "no braces" around outside)

--- a/lib/astutil.js
+++ b/lib/astutil.js
@@ -111,31 +111,14 @@ ast.Tex.defineVisitor("contains_func", {
         // {\f{a}}  (function of one argument)
         return match(target, f) || a.contains_func(target);
     },
-    CHEM_BOND: function(target, f, a) {
-        // {\f{a}}  (function of one argument)
-        return match(target, f) || a.contains_func(target);
-    },
     CHEM_WORD: function(target, r, s) {
         // chem word
         return match(target, r + s);
     },
-    CHEM_FUN1: function(target, f, a) {
-        // {\f{a}}  (function of one argument)
-        return match(target, f) || a.contains_func(target);
-    },
-    CHEM_FUN2: function(target, f, a, b) {
-        // {\f{a}{b}}  (function of one argument)
-        return match(target, f) ||
-            a.contains_func(target) || b.contains_func(target);
-    },
     CHEM_FUN2u: function(target, f, a, b) {
-        // {\underbrace{a}}  (function of two argument)
+        // {\underbrace{a}_{b}}
         return match(target, f) ||
             a.contains_func(target) || b.contains_func(target);
-    },
-    CHEM_FUN2c: function(target, a, b) {
-        // {\color []{a}{b}}
-        return a.contains_func(target) || b.contains_func(target);
     },
     FUN1nb: function(target, f, a) {
         // \f{a}  (function of one argument, "no braces" around outside)

--- a/lib/astutil.js
+++ b/lib/astutil.js
@@ -107,6 +107,10 @@ ast.Tex.defineVisitor("contains_func", {
         // {\f{a}}  (function of one argument)
         return match(target, f) || a.contains_func(target);
     },
+    MHCHEM: function(target, f, a) {
+        // {\f{a}}  (function of one argument)
+        return match(target, f) || a.contains_func(target);
+    },
     FUN1nb: function(target, f, a) {
         // \f{a}  (function of one argument, "no braces" around outside)
         return match(target, f) || a.contains_func(target);

--- a/lib/astutil.js
+++ b/lib/astutil.js
@@ -111,6 +111,10 @@ ast.Tex.defineVisitor("contains_func", {
         // {\f{a}}  (function of one argument)
         return match(target, f) || a.contains_func(target);
     },
+    CHEM_BOND: function(target, f, a) {
+        // {\f{a}}  (function of one argument)
+        return match(target, f) || a.contains_func(target);
+    },
     FUN1nb: function(target, f, a) {
         // \f{a}  (function of one argument, "no braces" around outside)
         return match(target, f) || a.contains_func(target);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -175,218 +175,222 @@ module.exports = /*
         peg$c27 = function(name, e, l) { return ast.Tex.FUN2sq(name, ast.Tex.CURLY(e.toArray()), l); },
         peg$c28 = function(name, l) { return ast.Tex.FUN1(name, l); },
         peg$c29 = function(name, l) { return ast.Tex.FUN1nb(name, l); },
-        peg$c30 = function(name, l1, l2) { return ast.Tex.FUN2(name, l1, l2); },
-        peg$c31 = function(name, l1, l2) { return ast.Tex.FUN2nb(name, l1, l2); },
-        peg$c32 = function(e) { return ast.Tex.CURLY(e.toArray()); },
-        peg$c33 = function(e1, name, e2) { return ast.Tex.INFIX(name, e1.toArray(), e2.toArray()); },
-        peg$c34 = function(e1, f, e2) { return ast.Tex.INFIXh(f[0], f[1], e1.toArray(), e2.toArray()); },
-        peg$c35 = function(m) { return ast.Tex.MATRIX("matrix", lst2arr(m)); },
-        peg$c36 = function(m) { return ast.Tex.MATRIX("pmatrix", lst2arr(m)); },
-        peg$c37 = function(m) { return ast.Tex.MATRIX("bmatrix", lst2arr(m)); },
-        peg$c38 = function(m) { return ast.Tex.MATRIX("Bmatrix", lst2arr(m)); },
-        peg$c39 = function(m) { return ast.Tex.MATRIX("vmatrix", lst2arr(m)); },
-        peg$c40 = function(m) { return ast.Tex.MATRIX("Vmatrix", lst2arr(m)); },
-        peg$c41 = function(m) { return ast.Tex.MATRIX("array", lst2arr(m)); },
-        peg$c42 = function(m) { return ast.Tex.MATRIX("aligned", lst2arr(m)); },
-        peg$c43 = function(m) { return ast.Tex.MATRIX("alignedat", lst2arr(m)); },
-        peg$c44 = function(m) { return ast.Tex.MATRIX("smallmatrix", lst2arr(m)); },
-        peg$c45 = function(m) { return ast.Tex.MATRIX("cases", lst2arr(m)); },
-        peg$c46 = "\\begin{",
-        peg$c47 = peg$literalExpectation("\\begin{", false),
-        peg$c48 = "}",
-        peg$c49 = peg$literalExpectation("}", false),
-        peg$c50 = function() { throw new peg$SyntaxError("Illegal TeX function", [], text(), location()); },
-        peg$c51 = function(f) { return !tu.all_functions[f]; },
-        peg$c52 = function(f) { throw new peg$SyntaxError("Illegal TeX function", [], f, location()); },
-        peg$c53 = function(cs, m) { m.head[0].unshift(cs); return m; },
-        peg$c54 = function(as, m) { m.head[0].unshift(as); return m; },
-        peg$c55 = function(l, m) { return m; },
-        peg$c56 = function(l, tail) { return { head: lst2arr(l), tail: tail }; },
-        peg$c57 = function(f, l) { l.head.unshift(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(f + " "))); return l;},
-        peg$c58 = function(e, l) { return l; },
-        peg$c59 = function(e, tail) { return { head: e.toArray(), tail: tail }; },
-        peg$c60 = function() { return text(); },
-        peg$c61 = function(cs) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs))]); },
-        peg$c62 = /^[lrc]/,
-        peg$c63 = peg$classExpectation(["l", "r", "c"], false, false),
-        peg$c64 = "p",
-        peg$c65 = peg$literalExpectation("p", false),
-        peg$c66 = "*",
-        peg$c67 = peg$literalExpectation("*", false),
-        peg$c68 = /^[0-9]/,
-        peg$c69 = peg$classExpectation([["0", "9"]], false, false),
-        peg$c70 = "||",
-        peg$c71 = peg$literalExpectation("||", false),
-        peg$c72 = "|",
-        peg$c73 = peg$literalExpectation("|", false),
-        peg$c74 = "@",
-        peg$c75 = peg$literalExpectation("@", false),
-        peg$c76 = function(num) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(num))]); },
-        peg$c77 = "[",
-        peg$c78 = peg$literalExpectation("[", false),
-        peg$c79 = /^[tcb]/,
-        peg$c80 = peg$classExpectation(["t", "c", "b"], false, false),
-        peg$c81 = "]",
-        peg$c82 = peg$literalExpectation("]", false),
-        peg$c83 = /^[a-zA-Z]/,
-        peg$c84 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
-        peg$c85 = /^[,:;?!']/,
-        peg$c86 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
-        peg$c87 = /^[().]/,
-        peg$c88 = peg$classExpectation(["(", ")", "."], false, false),
-        peg$c89 = /^[\-+*=]/,
-        peg$c90 = peg$classExpectation(["-", "+", "*", "="], false, false),
-        peg$c91 = /^[\/|]/,
-        peg$c92 = peg$classExpectation(["/", "|"], false, false),
-        peg$c93 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
-        peg$c94 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
-        peg$c95 = /^[\uD800-\uDBFF]/,
-        peg$c96 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
-        peg$c97 = /^[\uDC00-\uDFFF]/,
-        peg$c98 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
-        peg$c99 = function(l, h) { return text(); },
-        peg$c100 = function(b) { return tu.box_functions[b]; },
-        peg$c101 = "{",
-        peg$c102 = peg$literalExpectation("{", false),
-        peg$c103 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
-        peg$c104 = "-",
-        peg$c105 = peg$literalExpectation("-", false),
-        peg$c106 = function(c) { return ast.RenderT.TEX_ONLY(c); },
-        peg$c107 = function(f) { return tu.latex_function_names[f]; },
-        peg$c108 = "(",
-        peg$c109 = peg$literalExpectation("(", false),
-        peg$c110 = "\\{",
-        peg$c111 = peg$literalExpectation("\\{", false),
-        peg$c112 = function(f) { return " ";},
-        peg$c113 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
-        peg$c114 = function(f) { return tu.mediawiki_function_names[f]; },
-        peg$c115 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
-        peg$c116 = function(f) { return tu.other_literals1[f]; },
-        peg$c117 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
-        peg$c118 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c119 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c120 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
-        peg$c121 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c122 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c123 = function(f) { return tu.other_literals2[f]; },
-        peg$c124 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c125 = function(mbox) { return mbox === "\\mbox"; },
-        peg$c126 = function(mbox, f) { return tu.other_literals2[f]; },
-        peg$c127 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c128 = function(f) { return ast.RenderT.TEX_ONLY(f); },
-        peg$c129 = "\\",
-        peg$c130 = peg$literalExpectation("\\", false),
-        peg$c131 = /^[, ;!_#%$&]/,
-        peg$c132 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
-        peg$c133 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
-        peg$c134 = /^[><~]/,
-        peg$c135 = peg$classExpectation([">", "<", "~"], false, false),
-        peg$c136 = /^[%$]/,
-        peg$c137 = peg$classExpectation(["%", "$"], false, false),
-        peg$c138 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */},
-        peg$c139 = /^[{}|]/,
-        peg$c140 = peg$classExpectation(["{", "}", "|"], false, false),
-        peg$c141 = function(f) { return tu.other_delimiters1[f]; },
-        peg$c142 = function(f) { return tu.other_delimiters2[f]; },
-        peg$c143 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
+        peg$c30 = function(name, l) { return ast.Tex.MHCHEM(name, l); },
+        peg$c31 = function(name, l1, l2) { return ast.Tex.FUN2(name, l1, l2); },
+        peg$c32 = function(name, l1, l2) { return ast.Tex.FUN2nb(name, l1, l2); },
+        peg$c33 = function(e) { return ast.Tex.CURLY(e.toArray()); },
+        peg$c34 = function(e1, name, e2) { return ast.Tex.INFIX(name, e1.toArray(), e2.toArray()); },
+        peg$c35 = function(e1, f, e2) { return ast.Tex.INFIXh(f[0], f[1], e1.toArray(), e2.toArray()); },
+        peg$c36 = function(m) { return ast.Tex.MATRIX("matrix", lst2arr(m)); },
+        peg$c37 = function(m) { return ast.Tex.MATRIX("pmatrix", lst2arr(m)); },
+        peg$c38 = function(m) { return ast.Tex.MATRIX("bmatrix", lst2arr(m)); },
+        peg$c39 = function(m) { return ast.Tex.MATRIX("Bmatrix", lst2arr(m)); },
+        peg$c40 = function(m) { return ast.Tex.MATRIX("vmatrix", lst2arr(m)); },
+        peg$c41 = function(m) { return ast.Tex.MATRIX("Vmatrix", lst2arr(m)); },
+        peg$c42 = function(m) { return ast.Tex.MATRIX("array", lst2arr(m)); },
+        peg$c43 = function(m) { return ast.Tex.MATRIX("aligned", lst2arr(m)); },
+        peg$c44 = function(m) { return ast.Tex.MATRIX("alignedat", lst2arr(m)); },
+        peg$c45 = function(m) { return ast.Tex.MATRIX("smallmatrix", lst2arr(m)); },
+        peg$c46 = function(m) { return ast.Tex.MATRIX("cases", lst2arr(m)); },
+        peg$c47 = "\\begin{",
+        peg$c48 = peg$literalExpectation("\\begin{", false),
+        peg$c49 = "}",
+        peg$c50 = peg$literalExpectation("}", false),
+        peg$c51 = function() { throw new peg$SyntaxError("Illegal TeX function", [], text(), location()); },
+        peg$c52 = function(f) { return !tu.all_functions[f]; },
+        peg$c53 = function(f) { throw new peg$SyntaxError("Illegal TeX function", [], f, location()); },
+        peg$c54 = function(cs, m) { m.head[0].unshift(cs); return m; },
+        peg$c55 = function(as, m) { m.head[0].unshift(as); return m; },
+        peg$c56 = function(l, m) { return m; },
+        peg$c57 = function(l, tail) { return { head: lst2arr(l), tail: tail }; },
+        peg$c58 = function(f, l) { l.head.unshift(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(f + " "))); return l;},
+        peg$c59 = function(e, l) { return l; },
+        peg$c60 = function(e, tail) { return { head: e.toArray(), tail: tail }; },
+        peg$c61 = function() { return text(); },
+        peg$c62 = function(cs) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs))]); },
+        peg$c63 = /^[lrc]/,
+        peg$c64 = peg$classExpectation(["l", "r", "c"], false, false),
+        peg$c65 = "p",
+        peg$c66 = peg$literalExpectation("p", false),
+        peg$c67 = "*",
+        peg$c68 = peg$literalExpectation("*", false),
+        peg$c69 = /^[0-9]/,
+        peg$c70 = peg$classExpectation([["0", "9"]], false, false),
+        peg$c71 = "||",
+        peg$c72 = peg$literalExpectation("||", false),
+        peg$c73 = "|",
+        peg$c74 = peg$literalExpectation("|", false),
+        peg$c75 = "@",
+        peg$c76 = peg$literalExpectation("@", false),
+        peg$c77 = function(num) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(num))]); },
+        peg$c78 = "[",
+        peg$c79 = peg$literalExpectation("[", false),
+        peg$c80 = /^[tcb]/,
+        peg$c81 = peg$classExpectation(["t", "c", "b"], false, false),
+        peg$c82 = "]",
+        peg$c83 = peg$literalExpectation("]", false),
+        peg$c84 = function(p, s) { return ast.LList(p,s); },
+        peg$c85 = function(m) { return ast.RenderT.TEX_ONLY(m); },
+        peg$c86 = /^[a-zA-Z]/,
+        peg$c87 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
+        peg$c88 = /^[,:;?!']/,
+        peg$c89 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
+        peg$c90 = /^[().]/,
+        peg$c91 = peg$classExpectation(["(", ")", "."], false, false),
+        peg$c92 = /^[\-+*=]/,
+        peg$c93 = peg$classExpectation(["-", "+", "*", "="], false, false),
+        peg$c94 = /^[\/|]/,
+        peg$c95 = peg$classExpectation(["/", "|"], false, false),
+        peg$c96 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
+        peg$c97 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
+        peg$c98 = /^[\uD800-\uDBFF]/,
+        peg$c99 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
+        peg$c100 = /^[\uDC00-\uDFFF]/,
+        peg$c101 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
+        peg$c102 = function(l, h) { return text(); },
+        peg$c103 = function(b) { return tu.box_functions[b]; },
+        peg$c104 = "{",
+        peg$c105 = peg$literalExpectation("{", false),
+        peg$c106 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
+        peg$c107 = "-",
+        peg$c108 = peg$literalExpectation("-", false),
+        peg$c109 = function(c) { return ast.RenderT.TEX_ONLY(c); },
+        peg$c110 = function(f) { return tu.latex_function_names[f]; },
+        peg$c111 = "(",
+        peg$c112 = peg$literalExpectation("(", false),
+        peg$c113 = "\\{",
+        peg$c114 = peg$literalExpectation("\\{", false),
+        peg$c115 = function(f) { return " ";},
+        peg$c116 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
+        peg$c117 = function(f) { return tu.mediawiki_function_names[f]; },
+        peg$c118 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
+        peg$c119 = function(f) { return tu.other_literals1[f]; },
+        peg$c120 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
+        peg$c121 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c122 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c123 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
+        peg$c124 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c125 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c126 = function(f) { return tu.other_literals2[f]; },
+        peg$c127 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c128 = function(mbox) { return mbox === "\\mbox"; },
+        peg$c129 = function(mbox, f) { return tu.other_literals2[f]; },
+        peg$c130 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c131 = function(f) { return ast.RenderT.TEX_ONLY(f); },
+        peg$c132 = "\\",
+        peg$c133 = peg$literalExpectation("\\", false),
+        peg$c134 = /^[, ;!_#%$&]/,
+        peg$c135 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
+        peg$c136 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
+        peg$c137 = /^[><~]/,
+        peg$c138 = peg$classExpectation([">", "<", "~"], false, false),
+        peg$c139 = /^[%$]/,
+        peg$c140 = peg$classExpectation(["%", "$"], false, false),
+        peg$c141 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */},
+        peg$c142 = /^[{}|]/,
+        peg$c143 = peg$classExpectation(["{", "}", "|"], false, false),
+        peg$c144 = function(f) { return tu.other_delimiters1[f]; },
+        peg$c145 = function(f) { return tu.other_delimiters2[f]; },
+        peg$c146 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
              console.assert(Array.isArray(p) && p.length === 1);
              console.assert(p[0].constructor === ast.Tex.LITERAL);
              console.assert(p[0][0].constructor === ast.RenderT.TEX_ONLY);
              return p[0][0];
            },
-        peg$c144 = function(f) { return tu.fun_ar1nb[f]; },
-        peg$c145 = function(f) { return f; },
-        peg$c146 = function(f) { return tu.fun_ar1opt[f]; },
-        peg$c147 = "&",
-        peg$c148 = peg$literalExpectation("&", false),
-        peg$c149 = "\\\\",
-        peg$c150 = peg$literalExpectation("\\\\", false),
-        peg$c151 = "\\begin",
-        peg$c152 = peg$literalExpectation("\\begin", false),
-        peg$c153 = "\\end",
-        peg$c154 = peg$literalExpectation("\\end", false),
-        peg$c155 = "{matrix}",
-        peg$c156 = peg$literalExpectation("{matrix}", false),
-        peg$c157 = "{pmatrix}",
-        peg$c158 = peg$literalExpectation("{pmatrix}", false),
-        peg$c159 = "{bmatrix}",
-        peg$c160 = peg$literalExpectation("{bmatrix}", false),
-        peg$c161 = "{Bmatrix}",
-        peg$c162 = peg$literalExpectation("{Bmatrix}", false),
-        peg$c163 = "{vmatrix}",
-        peg$c164 = peg$literalExpectation("{vmatrix}", false),
-        peg$c165 = "{Vmatrix}",
-        peg$c166 = peg$literalExpectation("{Vmatrix}", false),
-        peg$c167 = "{array}",
-        peg$c168 = peg$literalExpectation("{array}", false),
-        peg$c169 = "{align}",
-        peg$c170 = peg$literalExpectation("{align}", false),
-        peg$c171 = "{aligned}",
-        peg$c172 = peg$literalExpectation("{aligned}", false),
-        peg$c173 = "{alignat}",
-        peg$c174 = peg$literalExpectation("{alignat}", false),
-        peg$c175 = "{alignedat}",
-        peg$c176 = peg$literalExpectation("{alignedat}", false),
-        peg$c177 = "{smallmatrix}",
-        peg$c178 = peg$literalExpectation("{smallmatrix}", false),
-        peg$c179 = "{cases}",
-        peg$c180 = peg$literalExpectation("{cases}", false),
-        peg$c181 = "^",
-        peg$c182 = peg$literalExpectation("^", false),
-        peg$c183 = "_",
-        peg$c184 = peg$literalExpectation("_", false),
-        peg$c185 = function(f) { return tu.big_literals[f]; },
-        peg$c186 = function(f) { return tu.fun_ar1[f]; },
-        peg$c187 = function(f) { return tu.other_fun_ar1[f]; },
-        peg$c188 = function(f) { return tu.fun_ar2[f]; },
-        peg$c189 = function(f) { return tu.fun_infix[f]; },
-        peg$c190 = function(f) { return tu.declh_function[f]; },
-        peg$c191 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
-        peg$c192 = function(f) { return tu.fun_ar2nb[f]; },
-        peg$c193 = function(f) { return tu.left_function[f]; },
-        peg$c194 = function(f) { return tu.right_function[f]; },
-        peg$c195 = function(f) { return tu.hline_function[f]; },
-        peg$c196 = function(f) { return tu.color_function[f]; },
-        peg$c197 = function(f, cs) { return f + " " + cs; },
-        peg$c198 = function(f) { return tu.definecolor_function[f]; },
-        peg$c199 = "named",
-        peg$c200 = peg$literalExpectation("named", true),
-        peg$c201 = function(f, name, cs) { return "{named}" + cs; },
-        peg$c202 = "gray",
-        peg$c203 = peg$literalExpectation("gray", true),
-        peg$c204 = function(f, name, cs) { return "{gray}" + cs; },
-        peg$c205 = "rgb",
-        peg$c206 = peg$literalExpectation("rgb", false),
-        peg$c207 = function(f, name, cs) { return "{rgb}" + cs; },
-        peg$c208 = "RGB",
-        peg$c209 = peg$literalExpectation("RGB", false),
-        peg$c210 = "cmyk",
-        peg$c211 = peg$literalExpectation("cmyk", true),
-        peg$c212 = function(f, name, cs) { return "{cmyk}" + cs; },
-        peg$c213 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
-        peg$c214 = function(cs) { return "[named]" + cs; },
-        peg$c215 = function(cs) { return "[gray]" + cs; },
-        peg$c216 = function(cs) { return "[rgb]" + cs; },
-        peg$c217 = function(cs) { return "[cmyk]" + cs; },
-        peg$c218 = function(name) { return "{" + name.join('') + "}"; },
-        peg$c219 = function(k) { return "{"+k+"}"; },
-        peg$c220 = ",",
-        peg$c221 = peg$literalExpectation(",", false),
-        peg$c222 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
-        peg$c223 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
-        peg$c224 = "0",
-        peg$c225 = peg$literalExpectation("0", false),
-        peg$c226 = /^[1-9]/,
-        peg$c227 = peg$classExpectation([["1", "9"]], false, false),
-        peg$c228 = function(n) { return parseInt(n, 10) <= 255; },
-        peg$c229 = function(n) { return n / 255; },
-        peg$c230 = ".",
-        peg$c231 = peg$literalExpectation(".", false),
-        peg$c232 = function(n) { return n; },
-        peg$c233 = /^[01]/,
-        peg$c234 = peg$classExpectation(["0", "1"], false, false),
-        peg$c235 = function() { return false; },
-        peg$c236 = function() { return peg$currPos === input.length; },
+        peg$c147 = function(f) { return tu.fun_ar1nb[f]; },
+        peg$c148 = function(f) { return f; },
+        peg$c149 = function(f) { return tu.fun_ar1opt[f]; },
+        peg$c150 = "&",
+        peg$c151 = peg$literalExpectation("&", false),
+        peg$c152 = "\\\\",
+        peg$c153 = peg$literalExpectation("\\\\", false),
+        peg$c154 = "\\begin",
+        peg$c155 = peg$literalExpectation("\\begin", false),
+        peg$c156 = "\\end",
+        peg$c157 = peg$literalExpectation("\\end", false),
+        peg$c158 = "{matrix}",
+        peg$c159 = peg$literalExpectation("{matrix}", false),
+        peg$c160 = "{pmatrix}",
+        peg$c161 = peg$literalExpectation("{pmatrix}", false),
+        peg$c162 = "{bmatrix}",
+        peg$c163 = peg$literalExpectation("{bmatrix}", false),
+        peg$c164 = "{Bmatrix}",
+        peg$c165 = peg$literalExpectation("{Bmatrix}", false),
+        peg$c166 = "{vmatrix}",
+        peg$c167 = peg$literalExpectation("{vmatrix}", false),
+        peg$c168 = "{Vmatrix}",
+        peg$c169 = peg$literalExpectation("{Vmatrix}", false),
+        peg$c170 = "{array}",
+        peg$c171 = peg$literalExpectation("{array}", false),
+        peg$c172 = "{align}",
+        peg$c173 = peg$literalExpectation("{align}", false),
+        peg$c174 = "{aligned}",
+        peg$c175 = peg$literalExpectation("{aligned}", false),
+        peg$c176 = "{alignat}",
+        peg$c177 = peg$literalExpectation("{alignat}", false),
+        peg$c178 = "{alignedat}",
+        peg$c179 = peg$literalExpectation("{alignedat}", false),
+        peg$c180 = "{smallmatrix}",
+        peg$c181 = peg$literalExpectation("{smallmatrix}", false),
+        peg$c182 = "{cases}",
+        peg$c183 = peg$literalExpectation("{cases}", false),
+        peg$c184 = "^",
+        peg$c185 = peg$literalExpectation("^", false),
+        peg$c186 = "_",
+        peg$c187 = peg$literalExpectation("_", false),
+        peg$c188 = function(f) { return tu.big_literals[f]; },
+        peg$c189 = function(f) { return tu.fun_ar1[f]; },
+        peg$c190 = function(f) { return tu.other_fun_ar1[f]; },
+        peg$c191 = function(f) { return tu.fun_mhchem[f]; },
+        peg$c192 = function(f) { return tu.fun_ar2[f]; },
+        peg$c193 = function(f) { return tu.fun_infix[f]; },
+        peg$c194 = function(f) { return tu.declh_function[f]; },
+        peg$c195 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
+        peg$c196 = function(f) { return tu.fun_ar2nb[f]; },
+        peg$c197 = function(f) { return tu.left_function[f]; },
+        peg$c198 = function(f) { return tu.right_function[f]; },
+        peg$c199 = function(f) { return tu.hline_function[f]; },
+        peg$c200 = function(f) { return tu.color_function[f]; },
+        peg$c201 = function(f, cs) { return f + " " + cs; },
+        peg$c202 = function(f) { return tu.definecolor_function[f]; },
+        peg$c203 = "named",
+        peg$c204 = peg$literalExpectation("named", true),
+        peg$c205 = function(f, name, cs) { return "{named}" + cs; },
+        peg$c206 = "gray",
+        peg$c207 = peg$literalExpectation("gray", true),
+        peg$c208 = function(f, name, cs) { return "{gray}" + cs; },
+        peg$c209 = "rgb",
+        peg$c210 = peg$literalExpectation("rgb", false),
+        peg$c211 = function(f, name, cs) { return "{rgb}" + cs; },
+        peg$c212 = "RGB",
+        peg$c213 = peg$literalExpectation("RGB", false),
+        peg$c214 = "cmyk",
+        peg$c215 = peg$literalExpectation("cmyk", true),
+        peg$c216 = function(f, name, cs) { return "{cmyk}" + cs; },
+        peg$c217 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
+        peg$c218 = function(cs) { return "[named]" + cs; },
+        peg$c219 = function(cs) { return "[gray]" + cs; },
+        peg$c220 = function(cs) { return "[rgb]" + cs; },
+        peg$c221 = function(cs) { return "[cmyk]" + cs; },
+        peg$c222 = function(name) { return "{" + name.join('') + "}"; },
+        peg$c223 = function(k) { return "{"+k+"}"; },
+        peg$c224 = ",",
+        peg$c225 = peg$literalExpectation(",", false),
+        peg$c226 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
+        peg$c227 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
+        peg$c228 = "0",
+        peg$c229 = peg$literalExpectation("0", false),
+        peg$c230 = /^[1-9]/,
+        peg$c231 = peg$classExpectation([["1", "9"]], false, false),
+        peg$c232 = function(n) { return parseInt(n, 10) <= 255; },
+        peg$c233 = function(n) { return n / 255; },
+        peg$c234 = ".",
+        peg$c235 = peg$literalExpectation(".", false),
+        peg$c236 = function(n) { return n; },
+        peg$c237 = /^[01]/,
+        peg$c238 = peg$classExpectation(["0", "1"], false, false),
+        peg$c239 = function() { return false; },
+        peg$c240 = function() { return peg$currPos === input.length; },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -529,7 +533,7 @@ module.exports = /*
     function peg$parsestart() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 0,
+      var key    = peg$currPos * 105 + 0,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -563,7 +567,7 @@ module.exports = /*
     function peg$parse_() {
       var s0, s1;
 
-      var key    = peg$currPos * 99 + 1,
+      var key    = peg$currPos * 105 + 1,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -599,7 +603,7 @@ module.exports = /*
     function peg$parsetex_expr() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 99 + 2,
+      var key    = peg$currPos * 105 + 2,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -693,7 +697,7 @@ module.exports = /*
     function peg$parseexpr() {
       var s0, s1;
 
-      var key    = peg$currPos * 99 + 3,
+      var key    = peg$currPos * 105 + 3,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -721,7 +725,7 @@ module.exports = /*
     function peg$parsene_expr() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 4,
+      var key    = peg$currPos * 105 + 4,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -791,7 +795,7 @@ module.exports = /*
     function peg$parselitsq_aq() {
       var s0;
 
-      var key    = peg$currPos * 99 + 5,
+      var key    = peg$currPos * 105 + 5,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -819,7 +823,7 @@ module.exports = /*
     function peg$parselitsq_fq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 6,
+      var key    = peg$currPos * 105 + 6,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -883,7 +887,7 @@ module.exports = /*
     function peg$parselitsq_uq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 7,
+      var key    = peg$currPos * 105 + 7,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -923,7 +927,7 @@ module.exports = /*
     function peg$parselitsq_dq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 8,
+      var key    = peg$currPos * 105 + 8,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -963,7 +967,7 @@ module.exports = /*
     function peg$parselitsq_zq() {
       var s0, s1;
 
-      var key    = peg$currPos * 99 + 9,
+      var key    = peg$currPos * 105 + 9,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -988,7 +992,7 @@ module.exports = /*
     function peg$parseexpr_nosqc() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 10,
+      var key    = peg$currPos * 105 + 10,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1031,7 +1035,7 @@ module.exports = /*
     function peg$parselit_aq() {
       var s0;
 
-      var key    = peg$currPos * 99 + 11,
+      var key    = peg$currPos * 105 + 11,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1065,7 +1069,7 @@ module.exports = /*
     function peg$parselit_fq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 12,
+      var key    = peg$currPos * 105 + 12,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1153,7 +1157,7 @@ module.exports = /*
     function peg$parselit_uq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 13,
+      var key    = peg$currPos * 105 + 13,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1193,7 +1197,7 @@ module.exports = /*
     function peg$parselit_dq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 14,
+      var key    = peg$currPos * 105 + 14,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1233,7 +1237,7 @@ module.exports = /*
     function peg$parselit_uqn() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 15,
+      var key    = peg$currPos * 105 + 15,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1267,7 +1271,7 @@ module.exports = /*
     function peg$parselit_dqn() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 16,
+      var key    = peg$currPos * 105 + 16,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1301,7 +1305,7 @@ module.exports = /*
     function peg$parseleft() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 17,
+      var key    = peg$currPos * 105 + 17,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1353,7 +1357,7 @@ module.exports = /*
     function peg$parseright() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 18,
+      var key    = peg$currPos * 105 + 18,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1405,7 +1409,7 @@ module.exports = /*
     function peg$parselit() {
       var s0, s1, s2, s3, s4, s5;
 
-      var key    = peg$currPos * 99 + 19,
+      var key    = peg$currPos * 105 + 19,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1580,19 +1584,13 @@ module.exports = /*
                       }
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
-                        s1 = peg$parseFUN_AR2();
+                        s1 = peg$parseFUN_MHCHEM();
                         if (s1 !== peg$FAILED) {
-                          s2 = peg$parselit();
+                          s2 = peg$parsechem_lit();
                           if (s2 !== peg$FAILED) {
-                            s3 = peg$parselit();
-                            if (s3 !== peg$FAILED) {
-                              peg$savedPos = s0;
-                              s1 = peg$c30(s1, s2, s3);
-                              s0 = s1;
-                            } else {
-                              peg$currPos = s0;
-                              s0 = peg$FAILED;
-                            }
+                            peg$savedPos = s0;
+                            s1 = peg$c30(s1, s2);
+                            s0 = s1;
                           } else {
                             peg$currPos = s0;
                             s0 = peg$FAILED;
@@ -1603,7 +1601,7 @@ module.exports = /*
                         }
                         if (s0 === peg$FAILED) {
                           s0 = peg$currPos;
-                          s1 = peg$parseFUN_AR2nb();
+                          s1 = peg$parseFUN_AR2();
                           if (s1 !== peg$FAILED) {
                             s2 = peg$parselit();
                             if (s2 !== peg$FAILED) {
@@ -1625,22 +1623,16 @@ module.exports = /*
                             s0 = peg$FAILED;
                           }
                           if (s0 === peg$FAILED) {
-                            s0 = peg$parseBOX();
-                            if (s0 === peg$FAILED) {
-                              s0 = peg$currPos;
-                              s1 = peg$parseCURLY_OPEN();
-                              if (s1 !== peg$FAILED) {
-                                s2 = peg$parseexpr();
-                                if (s2 !== peg$FAILED) {
-                                  s3 = peg$parseCURLY_CLOSE();
-                                  if (s3 !== peg$FAILED) {
-                                    peg$savedPos = s0;
-                                    s1 = peg$c32(s2);
-                                    s0 = s1;
-                                  } else {
-                                    peg$currPos = s0;
-                                    s0 = peg$FAILED;
-                                  }
+                            s0 = peg$currPos;
+                            s1 = peg$parseFUN_AR2nb();
+                            if (s1 !== peg$FAILED) {
+                              s2 = peg$parselit();
+                              if (s2 !== peg$FAILED) {
+                                s3 = peg$parselit();
+                                if (s3 !== peg$FAILED) {
+                                  peg$savedPos = s0;
+                                  s1 = peg$c32(s1, s2, s3);
+                                  s0 = s1;
                                 } else {
                                   peg$currPos = s0;
                                   s0 = peg$FAILED;
@@ -1649,29 +1641,23 @@ module.exports = /*
                                 peg$currPos = s0;
                                 s0 = peg$FAILED;
                               }
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseBOX();
                               if (s0 === peg$FAILED) {
                                 s0 = peg$currPos;
                                 s1 = peg$parseCURLY_OPEN();
                                 if (s1 !== peg$FAILED) {
-                                  s2 = peg$parsene_expr();
+                                  s2 = peg$parseexpr();
                                   if (s2 !== peg$FAILED) {
-                                    s3 = peg$parseFUN_INFIX();
+                                    s3 = peg$parseCURLY_CLOSE();
                                     if (s3 !== peg$FAILED) {
-                                      s4 = peg$parsene_expr();
-                                      if (s4 !== peg$FAILED) {
-                                        s5 = peg$parseCURLY_CLOSE();
-                                        if (s5 !== peg$FAILED) {
-                                          peg$savedPos = s0;
-                                          s1 = peg$c33(s2, s3, s4);
-                                          s0 = s1;
-                                        } else {
-                                          peg$currPos = s0;
-                                          s0 = peg$FAILED;
-                                        }
-                                      } else {
-                                        peg$currPos = s0;
-                                        s0 = peg$FAILED;
-                                      }
+                                      peg$savedPos = s0;
+                                      s1 = peg$c33(s2);
+                                      s0 = s1;
                                     } else {
                                       peg$currPos = s0;
                                       s0 = peg$FAILED;
@@ -1690,7 +1676,7 @@ module.exports = /*
                                   if (s1 !== peg$FAILED) {
                                     s2 = peg$parsene_expr();
                                     if (s2 !== peg$FAILED) {
-                                      s3 = peg$parseimpossible();
+                                      s3 = peg$parseFUN_INFIX();
                                       if (s3 !== peg$FAILED) {
                                         s4 = peg$parsene_expr();
                                         if (s4 !== peg$FAILED) {
@@ -1721,18 +1707,27 @@ module.exports = /*
                                   }
                                   if (s0 === peg$FAILED) {
                                     s0 = peg$currPos;
-                                    s1 = peg$parseBEGIN_MATRIX();
+                                    s1 = peg$parseCURLY_OPEN();
                                     if (s1 !== peg$FAILED) {
-                                      s2 = peg$parsearray();
-                                      if (s2 === peg$FAILED) {
-                                        s2 = peg$parsematrix();
-                                      }
+                                      s2 = peg$parsene_expr();
                                       if (s2 !== peg$FAILED) {
-                                        s3 = peg$parseEND_MATRIX();
+                                        s3 = peg$parseimpossible();
                                         if (s3 !== peg$FAILED) {
-                                          peg$savedPos = s0;
-                                          s1 = peg$c35(s2);
-                                          s0 = s1;
+                                          s4 = peg$parsene_expr();
+                                          if (s4 !== peg$FAILED) {
+                                            s5 = peg$parseCURLY_CLOSE();
+                                            if (s5 !== peg$FAILED) {
+                                              peg$savedPos = s0;
+                                              s1 = peg$c35(s2, s3, s4);
+                                              s0 = s1;
+                                            } else {
+                                              peg$currPos = s0;
+                                              s0 = peg$FAILED;
+                                            }
+                                          } else {
+                                            peg$currPos = s0;
+                                            s0 = peg$FAILED;
+                                          }
                                         } else {
                                           peg$currPos = s0;
                                           s0 = peg$FAILED;
@@ -1747,14 +1742,14 @@ module.exports = /*
                                     }
                                     if (s0 === peg$FAILED) {
                                       s0 = peg$currPos;
-                                      s1 = peg$parseBEGIN_PMATRIX();
+                                      s1 = peg$parseBEGIN_MATRIX();
                                       if (s1 !== peg$FAILED) {
                                         s2 = peg$parsearray();
                                         if (s2 === peg$FAILED) {
                                           s2 = peg$parsematrix();
                                         }
                                         if (s2 !== peg$FAILED) {
-                                          s3 = peg$parseEND_PMATRIX();
+                                          s3 = peg$parseEND_MATRIX();
                                           if (s3 !== peg$FAILED) {
                                             peg$savedPos = s0;
                                             s1 = peg$c36(s2);
@@ -1773,14 +1768,14 @@ module.exports = /*
                                       }
                                       if (s0 === peg$FAILED) {
                                         s0 = peg$currPos;
-                                        s1 = peg$parseBEGIN_BMATRIX();
+                                        s1 = peg$parseBEGIN_PMATRIX();
                                         if (s1 !== peg$FAILED) {
                                           s2 = peg$parsearray();
                                           if (s2 === peg$FAILED) {
                                             s2 = peg$parsematrix();
                                           }
                                           if (s2 !== peg$FAILED) {
-                                            s3 = peg$parseEND_BMATRIX();
+                                            s3 = peg$parseEND_PMATRIX();
                                             if (s3 !== peg$FAILED) {
                                               peg$savedPos = s0;
                                               s1 = peg$c37(s2);
@@ -1799,14 +1794,14 @@ module.exports = /*
                                         }
                                         if (s0 === peg$FAILED) {
                                           s0 = peg$currPos;
-                                          s1 = peg$parseBEGIN_BBMATRIX();
+                                          s1 = peg$parseBEGIN_BMATRIX();
                                           if (s1 !== peg$FAILED) {
                                             s2 = peg$parsearray();
                                             if (s2 === peg$FAILED) {
                                               s2 = peg$parsematrix();
                                             }
                                             if (s2 !== peg$FAILED) {
-                                              s3 = peg$parseEND_BBMATRIX();
+                                              s3 = peg$parseEND_BMATRIX();
                                               if (s3 !== peg$FAILED) {
                                                 peg$savedPos = s0;
                                                 s1 = peg$c38(s2);
@@ -1825,14 +1820,14 @@ module.exports = /*
                                           }
                                           if (s0 === peg$FAILED) {
                                             s0 = peg$currPos;
-                                            s1 = peg$parseBEGIN_VMATRIX();
+                                            s1 = peg$parseBEGIN_BBMATRIX();
                                             if (s1 !== peg$FAILED) {
                                               s2 = peg$parsearray();
                                               if (s2 === peg$FAILED) {
                                                 s2 = peg$parsematrix();
                                               }
                                               if (s2 !== peg$FAILED) {
-                                                s3 = peg$parseEND_VMATRIX();
+                                                s3 = peg$parseEND_BBMATRIX();
                                                 if (s3 !== peg$FAILED) {
                                                   peg$savedPos = s0;
                                                   s1 = peg$c39(s2);
@@ -1851,14 +1846,14 @@ module.exports = /*
                                             }
                                             if (s0 === peg$FAILED) {
                                               s0 = peg$currPos;
-                                              s1 = peg$parseBEGIN_VVMATRIX();
+                                              s1 = peg$parseBEGIN_VMATRIX();
                                               if (s1 !== peg$FAILED) {
                                                 s2 = peg$parsearray();
                                                 if (s2 === peg$FAILED) {
                                                   s2 = peg$parsematrix();
                                                 }
                                                 if (s2 !== peg$FAILED) {
-                                                  s3 = peg$parseEND_VVMATRIX();
+                                                  s3 = peg$parseEND_VMATRIX();
                                                   if (s3 !== peg$FAILED) {
                                                     peg$savedPos = s0;
                                                     s1 = peg$c40(s2);
@@ -1877,21 +1872,18 @@ module.exports = /*
                                               }
                                               if (s0 === peg$FAILED) {
                                                 s0 = peg$currPos;
-                                                s1 = peg$parseBEGIN_ARRAY();
+                                                s1 = peg$parseBEGIN_VVMATRIX();
                                                 if (s1 !== peg$FAILED) {
-                                                  s2 = peg$parseopt_pos();
+                                                  s2 = peg$parsearray();
+                                                  if (s2 === peg$FAILED) {
+                                                    s2 = peg$parsematrix();
+                                                  }
                                                   if (s2 !== peg$FAILED) {
-                                                    s3 = peg$parsearray();
+                                                    s3 = peg$parseEND_VVMATRIX();
                                                     if (s3 !== peg$FAILED) {
-                                                      s4 = peg$parseEND_ARRAY();
-                                                      if (s4 !== peg$FAILED) {
-                                                        peg$savedPos = s0;
-                                                        s1 = peg$c41(s3);
-                                                        s0 = s1;
-                                                      } else {
-                                                        peg$currPos = s0;
-                                                        s0 = peg$FAILED;
-                                                      }
+                                                      peg$savedPos = s0;
+                                                      s1 = peg$c41(s2);
+                                                      s0 = s1;
                                                     } else {
                                                       peg$currPos = s0;
                                                       s0 = peg$FAILED;
@@ -1906,13 +1898,13 @@ module.exports = /*
                                                 }
                                                 if (s0 === peg$FAILED) {
                                                   s0 = peg$currPos;
-                                                  s1 = peg$parseBEGIN_ALIGN();
+                                                  s1 = peg$parseBEGIN_ARRAY();
                                                   if (s1 !== peg$FAILED) {
                                                     s2 = peg$parseopt_pos();
                                                     if (s2 !== peg$FAILED) {
-                                                      s3 = peg$parsematrix();
+                                                      s3 = peg$parsearray();
                                                       if (s3 !== peg$FAILED) {
-                                                        s4 = peg$parseEND_ALIGN();
+                                                        s4 = peg$parseEND_ARRAY();
                                                         if (s4 !== peg$FAILED) {
                                                           peg$savedPos = s0;
                                                           s1 = peg$c42(s3);
@@ -1935,16 +1927,16 @@ module.exports = /*
                                                   }
                                                   if (s0 === peg$FAILED) {
                                                     s0 = peg$currPos;
-                                                    s1 = peg$parseBEGIN_ALIGNED();
+                                                    s1 = peg$parseBEGIN_ALIGN();
                                                     if (s1 !== peg$FAILED) {
                                                       s2 = peg$parseopt_pos();
                                                       if (s2 !== peg$FAILED) {
                                                         s3 = peg$parsematrix();
                                                         if (s3 !== peg$FAILED) {
-                                                          s4 = peg$parseEND_ALIGNED();
+                                                          s4 = peg$parseEND_ALIGN();
                                                           if (s4 !== peg$FAILED) {
                                                             peg$savedPos = s0;
-                                                            s1 = peg$c42(s3);
+                                                            s1 = peg$c43(s3);
                                                             s0 = s1;
                                                           } else {
                                                             peg$currPos = s0;
@@ -1964,15 +1956,21 @@ module.exports = /*
                                                     }
                                                     if (s0 === peg$FAILED) {
                                                       s0 = peg$currPos;
-                                                      s1 = peg$parseBEGIN_ALIGNAT();
+                                                      s1 = peg$parseBEGIN_ALIGNED();
                                                       if (s1 !== peg$FAILED) {
-                                                        s2 = peg$parsealignat();
+                                                        s2 = peg$parseopt_pos();
                                                         if (s2 !== peg$FAILED) {
-                                                          s3 = peg$parseEND_ALIGNAT();
+                                                          s3 = peg$parsematrix();
                                                           if (s3 !== peg$FAILED) {
-                                                            peg$savedPos = s0;
-                                                            s1 = peg$c43(s2);
-                                                            s0 = s1;
+                                                            s4 = peg$parseEND_ALIGNED();
+                                                            if (s4 !== peg$FAILED) {
+                                                              peg$savedPos = s0;
+                                                              s1 = peg$c43(s3);
+                                                              s0 = s1;
+                                                            } else {
+                                                              peg$currPos = s0;
+                                                              s0 = peg$FAILED;
+                                                            }
                                                           } else {
                                                             peg$currPos = s0;
                                                             s0 = peg$FAILED;
@@ -1987,14 +1985,14 @@ module.exports = /*
                                                       }
                                                       if (s0 === peg$FAILED) {
                                                         s0 = peg$currPos;
-                                                        s1 = peg$parseBEGIN_ALIGNEDAT();
+                                                        s1 = peg$parseBEGIN_ALIGNAT();
                                                         if (s1 !== peg$FAILED) {
                                                           s2 = peg$parsealignat();
                                                           if (s2 !== peg$FAILED) {
-                                                            s3 = peg$parseEND_ALIGNEDAT();
+                                                            s3 = peg$parseEND_ALIGNAT();
                                                             if (s3 !== peg$FAILED) {
                                                               peg$savedPos = s0;
-                                                              s1 = peg$c43(s2);
+                                                              s1 = peg$c44(s2);
                                                               s0 = s1;
                                                             } else {
                                                               peg$currPos = s0;
@@ -2010,14 +2008,11 @@ module.exports = /*
                                                         }
                                                         if (s0 === peg$FAILED) {
                                                           s0 = peg$currPos;
-                                                          s1 = peg$parseBEGIN_SMALLMATRIX();
+                                                          s1 = peg$parseBEGIN_ALIGNEDAT();
                                                           if (s1 !== peg$FAILED) {
-                                                            s2 = peg$parsearray();
-                                                            if (s2 === peg$FAILED) {
-                                                              s2 = peg$parsematrix();
-                                                            }
+                                                            s2 = peg$parsealignat();
                                                             if (s2 !== peg$FAILED) {
-                                                              s3 = peg$parseEND_SMALLMATRIX();
+                                                              s3 = peg$parseEND_ALIGNEDAT();
                                                               if (s3 !== peg$FAILED) {
                                                                 peg$savedPos = s0;
                                                                 s1 = peg$c44(s2);
@@ -2036,11 +2031,14 @@ module.exports = /*
                                                           }
                                                           if (s0 === peg$FAILED) {
                                                             s0 = peg$currPos;
-                                                            s1 = peg$parseBEGIN_CASES();
+                                                            s1 = peg$parseBEGIN_SMALLMATRIX();
                                                             if (s1 !== peg$FAILED) {
-                                                              s2 = peg$parsematrix();
+                                                              s2 = peg$parsearray();
+                                                              if (s2 === peg$FAILED) {
+                                                                s2 = peg$parsematrix();
+                                                              }
                                                               if (s2 !== peg$FAILED) {
-                                                                s3 = peg$parseEND_CASES();
+                                                                s3 = peg$parseEND_SMALLMATRIX();
                                                                 if (s3 !== peg$FAILED) {
                                                                   peg$savedPos = s0;
                                                                   s1 = peg$c45(s2);
@@ -2059,35 +2057,14 @@ module.exports = /*
                                                             }
                                                             if (s0 === peg$FAILED) {
                                                               s0 = peg$currPos;
-                                                              if (input.substr(peg$currPos, 7) === peg$c46) {
-                                                                s1 = peg$c46;
-                                                                peg$currPos += 7;
-                                                              } else {
-                                                                s1 = peg$FAILED;
-                                                                if (peg$silentFails === 0) { peg$fail(peg$c47); }
-                                                              }
+                                                              s1 = peg$parseBEGIN_CASES();
                                                               if (s1 !== peg$FAILED) {
-                                                                s2 = [];
-                                                                s3 = peg$parsealpha();
-                                                                if (s3 !== peg$FAILED) {
-                                                                  while (s3 !== peg$FAILED) {
-                                                                    s2.push(s3);
-                                                                    s3 = peg$parsealpha();
-                                                                  }
-                                                                } else {
-                                                                  s2 = peg$FAILED;
-                                                                }
+                                                                s2 = peg$parsematrix();
                                                                 if (s2 !== peg$FAILED) {
-                                                                  if (input.charCodeAt(peg$currPos) === 125) {
-                                                                    s3 = peg$c48;
-                                                                    peg$currPos++;
-                                                                  } else {
-                                                                    s3 = peg$FAILED;
-                                                                    if (peg$silentFails === 0) { peg$fail(peg$c49); }
-                                                                  }
+                                                                  s3 = peg$parseEND_CASES();
                                                                   if (s3 !== peg$FAILED) {
                                                                     peg$savedPos = s0;
-                                                                    s1 = peg$c50();
+                                                                    s1 = peg$c46(s2);
                                                                     s0 = s1;
                                                                   } else {
                                                                     peg$currPos = s0;
@@ -2103,19 +2080,40 @@ module.exports = /*
                                                               }
                                                               if (s0 === peg$FAILED) {
                                                                 s0 = peg$currPos;
-                                                                s1 = peg$parsegeneric_func();
+                                                                if (input.substr(peg$currPos, 7) === peg$c47) {
+                                                                  s1 = peg$c47;
+                                                                  peg$currPos += 7;
+                                                                } else {
+                                                                  s1 = peg$FAILED;
+                                                                  if (peg$silentFails === 0) { peg$fail(peg$c48); }
+                                                                }
                                                                 if (s1 !== peg$FAILED) {
-                                                                  peg$savedPos = peg$currPos;
-                                                                  s2 = peg$c51(s1);
-                                                                  if (s2) {
-                                                                    s2 = void 0;
+                                                                  s2 = [];
+                                                                  s3 = peg$parsealpha();
+                                                                  if (s3 !== peg$FAILED) {
+                                                                    while (s3 !== peg$FAILED) {
+                                                                      s2.push(s3);
+                                                                      s3 = peg$parsealpha();
+                                                                    }
                                                                   } else {
                                                                     s2 = peg$FAILED;
                                                                   }
                                                                   if (s2 !== peg$FAILED) {
-                                                                    peg$savedPos = s0;
-                                                                    s1 = peg$c52(s1);
-                                                                    s0 = s1;
+                                                                    if (input.charCodeAt(peg$currPos) === 125) {
+                                                                      s3 = peg$c49;
+                                                                      peg$currPos++;
+                                                                    } else {
+                                                                      s3 = peg$FAILED;
+                                                                      if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                                                                    }
+                                                                    if (s3 !== peg$FAILED) {
+                                                                      peg$savedPos = s0;
+                                                                      s1 = peg$c51();
+                                                                      s0 = s1;
+                                                                    } else {
+                                                                      peg$currPos = s0;
+                                                                      s0 = peg$FAILED;
+                                                                    }
                                                                   } else {
                                                                     peg$currPos = s0;
                                                                     s0 = peg$FAILED;
@@ -2123,6 +2121,30 @@ module.exports = /*
                                                                 } else {
                                                                   peg$currPos = s0;
                                                                   s0 = peg$FAILED;
+                                                                }
+                                                                if (s0 === peg$FAILED) {
+                                                                  s0 = peg$currPos;
+                                                                  s1 = peg$parsegeneric_func();
+                                                                  if (s1 !== peg$FAILED) {
+                                                                    peg$savedPos = peg$currPos;
+                                                                    s2 = peg$c52(s1);
+                                                                    if (s2) {
+                                                                      s2 = void 0;
+                                                                    } else {
+                                                                      s2 = peg$FAILED;
+                                                                    }
+                                                                    if (s2 !== peg$FAILED) {
+                                                                      peg$savedPos = s0;
+                                                                      s1 = peg$c53(s1);
+                                                                      s0 = s1;
+                                                                    } else {
+                                                                      peg$currPos = s0;
+                                                                      s0 = peg$FAILED;
+                                                                    }
+                                                                  } else {
+                                                                    peg$currPos = s0;
+                                                                    s0 = peg$FAILED;
+                                                                  }
                                                                 }
                                                               }
                                                             }
@@ -2162,7 +2184,7 @@ module.exports = /*
     function peg$parsearray() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 20,
+      var key    = peg$currPos * 105 + 20,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2173,40 +2195,6 @@ module.exports = /*
 
       s0 = peg$currPos;
       s1 = peg$parsecolumn_spec();
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parsematrix();
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c53(s1, s2);
-          s0 = s1;
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parsealignat() {
-      var s0, s1, s2;
-
-      var key    = peg$currPos * 99 + 21,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      s1 = peg$parsealignat_spec();
       if (s1 !== peg$FAILED) {
         s2 = peg$parsematrix();
         if (s2 !== peg$FAILED) {
@@ -2227,10 +2215,44 @@ module.exports = /*
       return s0;
     }
 
+    function peg$parsealignat() {
+      var s0, s1, s2;
+
+      var key    = peg$currPos * 105 + 21,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsealignat_spec();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsematrix();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c55(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
     function peg$parsematrix() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 99 + 22,
+      var key    = peg$currPos * 105 + 22,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2248,7 +2270,7 @@ module.exports = /*
           s4 = peg$parsematrix();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c55(s1, s4);
+            s3 = peg$c56(s1, s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -2263,7 +2285,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c56(s1, s2);
+          s1 = peg$c57(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2282,7 +2304,7 @@ module.exports = /*
     function peg$parseline_start() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 23,
+      var key    = peg$currPos * 105 + 23,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2297,7 +2319,7 @@ module.exports = /*
         s2 = peg$parseline_start();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c57(s1, s2);
+          s1 = peg$c58(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2319,7 +2341,7 @@ module.exports = /*
     function peg$parseline() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 99 + 24,
+      var key    = peg$currPos * 105 + 24,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2337,7 +2359,7 @@ module.exports = /*
           s4 = peg$parseline();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c58(s1, s4);
+            s3 = peg$c59(s1, s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -2352,7 +2374,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c59(s1, s2);
+          s1 = peg$c60(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2371,7 +2393,7 @@ module.exports = /*
     function peg$parsecolumn_spec() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 99 + 25,
+      var key    = peg$currPos * 105 + 25,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2396,14 +2418,14 @@ module.exports = /*
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c60();
+          s3 = peg$c61();
         }
         s2 = s3;
         if (s2 !== peg$FAILED) {
           s3 = peg$parseCURLY_CLOSE();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c61(s2);
+            s1 = peg$c62(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2426,7 +2448,7 @@ module.exports = /*
     function peg$parseone_col() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-      var key    = peg$currPos * 99 + 26,
+      var key    = peg$currPos * 105 + 26,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2436,12 +2458,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (peg$c62.test(input.charAt(peg$currPos))) {
+      if (peg$c63.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c63); }
+        if (peg$silentFails === 0) { peg$fail(peg$c64); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -2459,11 +2481,11 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 112) {
-          s1 = peg$c64;
+          s1 = peg$c65;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
+          if (peg$silentFails === 0) { peg$fail(peg$c66); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseCURLY_OPEN();
@@ -2502,32 +2524,32 @@ module.exports = /*
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 42) {
-            s1 = peg$c66;
+            s1 = peg$c67;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c67); }
+            if (peg$silentFails === 0) { peg$fail(peg$c68); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseCURLY_OPEN();
             if (s2 !== peg$FAILED) {
               s3 = [];
-              if (peg$c68.test(input.charAt(peg$currPos))) {
+              if (peg$c69.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c69); }
+                if (peg$silentFails === 0) { peg$fail(peg$c70); }
               }
               if (s4 !== peg$FAILED) {
                 while (s4 !== peg$FAILED) {
                   s3.push(s4);
-                  if (peg$c68.test(input.charAt(peg$currPos))) {
+                  if (peg$c69.test(input.charAt(peg$currPos))) {
                     s4 = input.charAt(peg$currPos);
                     peg$currPos++;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c69); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c70); }
                   }
                 }
               } else {
@@ -2600,12 +2622,12 @@ module.exports = /*
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c70) {
-              s1 = peg$c70;
+            if (input.substr(peg$currPos, 2) === peg$c71) {
+              s1 = peg$c71;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c71); }
+              if (peg$silentFails === 0) { peg$fail(peg$c72); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$parse_();
@@ -2623,11 +2645,11 @@ module.exports = /*
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 124) {
-                s1 = peg$c72;
+                s1 = peg$c73;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c73); }
+                if (peg$silentFails === 0) { peg$fail(peg$c74); }
               }
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse_();
@@ -2645,11 +2667,11 @@ module.exports = /*
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 64) {
-                  s1 = peg$c74;
+                  s1 = peg$c75;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c75); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c76); }
                 }
                 if (s1 !== peg$FAILED) {
                   s2 = peg$parse_();
@@ -2705,7 +2727,7 @@ module.exports = /*
     function peg$parsealignat_spec() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 99 + 27,
+      var key    = peg$currPos * 105 + 27,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2719,22 +2741,22 @@ module.exports = /*
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         s3 = [];
-        if (peg$c68.test(input.charAt(peg$currPos))) {
+        if (peg$c69.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c69); }
+          if (peg$silentFails === 0) { peg$fail(peg$c70); }
         }
         if (s4 !== peg$FAILED) {
           while (s4 !== peg$FAILED) {
             s3.push(s4);
-            if (peg$c68.test(input.charAt(peg$currPos))) {
+            if (peg$c69.test(input.charAt(peg$currPos))) {
               s4 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c69); }
+              if (peg$silentFails === 0) { peg$fail(peg$c70); }
             }
           }
         } else {
@@ -2742,7 +2764,7 @@ module.exports = /*
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c60();
+          s3 = peg$c61();
         }
         s2 = s3;
         if (s2 !== peg$FAILED) {
@@ -2751,7 +2773,7 @@ module.exports = /*
             s4 = peg$parseCURLY_CLOSE();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c76(s2);
+              s1 = peg$c77(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2778,7 +2800,7 @@ module.exports = /*
     function peg$parseopt_pos() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 99 + 28,
+      var key    = peg$currPos * 105 + 28,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2789,31 +2811,31 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c77;
+        s1 = peg$c78;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c78); }
+        if (peg$silentFails === 0) { peg$fail(peg$c79); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
-          if (peg$c79.test(input.charAt(peg$currPos))) {
+          if (peg$c80.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+            if (peg$silentFails === 0) { peg$fail(peg$c81); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse_();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c81;
+                s5 = peg$c82;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c82); }
+                if (peg$silentFails === 0) { peg$fail(peg$c83); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = peg$parse_();
@@ -2853,10 +2875,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parsealpha() {
-      var s0;
+    function peg$parsechem_lit() {
+      var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 29,
+      var key    = peg$currPos * 105 + 29,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2865,12 +2887,164 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c83.test(input.charAt(peg$currPos))) {
+      s0 = peg$currPos;
+      s1 = peg$parseCURLY_OPEN();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsechem_sentence();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseCURLY_CLOSE();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c33(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_sentence() {
+      var s0, s1;
+
+      var key    = peg$currPos * 105 + 30,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$parsechem_nt_sentence();
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$c6;
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c7();
+        }
+        s0 = s1;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_nt_sentence() {
+      var s0, s1, s2;
+
+      var key    = peg$currPos * 105 + 31,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsechem_phrase();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsechem_sentence();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c84(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_phrase() {
+      var s0, s1;
+
+      var key    = peg$currPos * 105 + 32,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsechem_word();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c21(s1);
+      }
+      s0 = s1;
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_word() {
+      var s0, s1;
+
+      var key    = peg$currPos * 105 + 33,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsealpha();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c85(s1);
+      }
+      s0 = s1;
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsealpha() {
+      var s0;
+
+      var key    = peg$currPos * 105 + 34,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (peg$c86.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c84); }
+        if (peg$silentFails === 0) { peg$fail(peg$c87); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -2881,7 +3055,7 @@ module.exports = /*
     function peg$parseliteral_id() {
       var s0;
 
-      var key    = peg$currPos * 99 + 30,
+      var key    = peg$currPos * 105 + 35,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2890,12 +3064,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c83.test(input.charAt(peg$currPos))) {
+      if (peg$c86.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c84); }
+        if (peg$silentFails === 0) { peg$fail(peg$c87); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -2906,7 +3080,7 @@ module.exports = /*
     function peg$parseliteral_mn() {
       var s0;
 
-      var key    = peg$currPos * 99 + 31,
+      var key    = peg$currPos * 105 + 36,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2915,12 +3089,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c68.test(input.charAt(peg$currPos))) {
+      if (peg$c69.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c69); }
+        if (peg$silentFails === 0) { peg$fail(peg$c70); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -2931,7 +3105,7 @@ module.exports = /*
     function peg$parseliteral_uf_lt() {
       var s0;
 
-      var key    = peg$currPos * 99 + 32,
+      var key    = peg$currPos * 105 + 37,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2940,12 +3114,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c85.test(input.charAt(peg$currPos))) {
+      if (peg$c88.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c86); }
+        if (peg$silentFails === 0) { peg$fail(peg$c89); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -2956,7 +3130,7 @@ module.exports = /*
     function peg$parsedelimiter_uf_lt() {
       var s0;
 
-      var key    = peg$currPos * 99 + 33,
+      var key    = peg$currPos * 105 + 38,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2965,12 +3139,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c87.test(input.charAt(peg$currPos))) {
+      if (peg$c90.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c88); }
+        if (peg$silentFails === 0) { peg$fail(peg$c91); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -2981,7 +3155,7 @@ module.exports = /*
     function peg$parseliteral_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 99 + 34,
+      var key    = peg$currPos * 105 + 39,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2990,12 +3164,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c89.test(input.charAt(peg$currPos))) {
+      if (peg$c92.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c90); }
+        if (peg$silentFails === 0) { peg$fail(peg$c93); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3006,7 +3180,7 @@ module.exports = /*
     function peg$parsedelimiter_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 99 + 35,
+      var key    = peg$currPos * 105 + 40,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3015,12 +3189,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c91.test(input.charAt(peg$currPos))) {
+      if (peg$c94.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c92); }
+        if (peg$silentFails === 0) { peg$fail(peg$c95); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3031,7 +3205,7 @@ module.exports = /*
     function peg$parseboxchars() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 36,
+      var key    = peg$currPos * 105 + 41,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3040,33 +3214,33 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c93.test(input.charAt(peg$currPos))) {
+      if (peg$c96.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c94); }
+        if (peg$silentFails === 0) { peg$fail(peg$c97); }
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (peg$c95.test(input.charAt(peg$currPos))) {
+        if (peg$c98.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c96); }
+          if (peg$silentFails === 0) { peg$fail(peg$c99); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c97.test(input.charAt(peg$currPos))) {
+          if (peg$c100.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c98); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c99(s1, s2);
+            s1 = peg$c102(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3086,7 +3260,7 @@ module.exports = /*
     function peg$parseBOX() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
-      var key    = peg$currPos * 99 + 37,
+      var key    = peg$currPos * 105 + 42,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3099,7 +3273,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c100(s1);
+        s2 = peg$c103(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -3109,11 +3283,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c101;
+              s4 = peg$c104;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c102); }
+              if (peg$silentFails === 0) { peg$fail(peg$c105); }
             }
             if (s4 !== peg$FAILED) {
               s5 = [];
@@ -3128,17 +3302,17 @@ module.exports = /*
               }
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 125) {
-                  s6 = peg$c48;
+                  s6 = peg$c49;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c50); }
                 }
                 if (s6 !== peg$FAILED) {
                   s7 = peg$parse_();
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c103(s1, s5);
+                    s1 = peg$c106(s1, s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3177,7 +3351,7 @@ module.exports = /*
     function peg$parseLITERAL() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-      var key    = peg$currPos * 99 + 38,
+      var key    = peg$currPos * 105 + 43,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3194,11 +3368,11 @@ module.exports = /*
           s1 = peg$parseliteral_uf_lt();
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 45) {
-              s1 = peg$c104;
+              s1 = peg$c107;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c105); }
+              if (peg$silentFails === 0) { peg$fail(peg$c108); }
             }
             if (s1 === peg$FAILED) {
               s1 = peg$parseliteral_uf_op();
@@ -3210,7 +3384,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c106(s1);
+          s1 = peg$c109(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3225,7 +3399,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c107(s1);
+          s2 = peg$c110(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -3235,34 +3409,34 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s4 = peg$c108;
+                s4 = peg$c111;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c109); }
+                if (peg$silentFails === 0) { peg$fail(peg$c112); }
               }
               if (s4 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 91) {
-                  s4 = peg$c77;
+                  s4 = peg$c78;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c78); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c79); }
                 }
                 if (s4 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c110) {
-                    s4 = peg$c110;
+                  if (input.substr(peg$currPos, 2) === peg$c113) {
+                    s4 = peg$c113;
                     peg$currPos += 2;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c111); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c114); }
                   }
                   if (s4 === peg$FAILED) {
                     s4 = peg$currPos;
                     s5 = peg$c6;
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s4;
-                      s5 = peg$c112(s1);
+                      s5 = peg$c115(s1);
                     }
                     s4 = s5;
                   }
@@ -3272,7 +3446,7 @@ module.exports = /*
                 s5 = peg$parse_();
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c113(s1, s4);
+                  s1 = peg$c116(s1, s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3299,7 +3473,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c114(s1);
+            s2 = peg$c117(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -3309,34 +3483,34 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s4 = peg$c108;
+                  s4 = peg$c111;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c109); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c112); }
                 }
                 if (s4 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 91) {
-                    s4 = peg$c77;
+                    s4 = peg$c78;
                     peg$currPos++;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c78); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c79); }
                   }
                   if (s4 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 2) === peg$c110) {
-                      s4 = peg$c110;
+                    if (input.substr(peg$currPos, 2) === peg$c113) {
+                      s4 = peg$c113;
                       peg$currPos += 2;
                     } else {
                       s4 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c111); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c114); }
                     }
                     if (s4 === peg$FAILED) {
                       s4 = peg$currPos;
                       s5 = peg$c6;
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s4;
-                        s5 = peg$c112(s1);
+                        s5 = peg$c115(s1);
                       }
                       s4 = s5;
                     }
@@ -3346,7 +3520,7 @@ module.exports = /*
                   s5 = peg$parse_();
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c115(s1, s4);
+                    s1 = peg$c118(s1, s4);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3373,7 +3547,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c116(s1);
+              s2 = peg$c119(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -3383,7 +3557,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c117(s1);
+                  s1 = peg$c120(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3402,7 +3576,7 @@ module.exports = /*
               s1 = peg$parsegeneric_func();
               if (s1 !== peg$FAILED) {
                 peg$savedPos = peg$currPos;
-                s2 = peg$c118(s1);
+                s2 = peg$c121(s1);
                 if (s2) {
                   s2 = void 0;
                 } else {
@@ -3412,7 +3586,7 @@ module.exports = /*
                   s3 = peg$parse_();
                   if (s3 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c119(s1);
+                    s1 = peg$c122(s1);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3431,7 +3605,7 @@ module.exports = /*
                 s1 = peg$parsegeneric_func();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = peg$currPos;
-                  s2 = peg$c120(s1);
+                  s2 = peg$c123(s1);
                   if (s2) {
                     s2 = void 0;
                   } else {
@@ -3441,17 +3615,17 @@ module.exports = /*
                     s3 = peg$parse_();
                     if (s3 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 123) {
-                        s4 = peg$c101;
+                        s4 = peg$c104;
                         peg$currPos++;
                       } else {
                         s4 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c105); }
                       }
                       if (s4 !== peg$FAILED) {
                         s5 = peg$parsegeneric_func();
                         if (s5 !== peg$FAILED) {
                           peg$savedPos = peg$currPos;
-                          s6 = peg$c121(s1, s5);
+                          s6 = peg$c124(s1, s5);
                           if (s6) {
                             s6 = void 0;
                           } else {
@@ -3461,17 +3635,17 @@ module.exports = /*
                             s7 = peg$parse_();
                             if (s7 !== peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 125) {
-                                s8 = peg$c48;
+                                s8 = peg$c49;
                                 peg$currPos++;
                               } else {
                                 s8 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c50); }
                               }
                               if (s8 !== peg$FAILED) {
                                 s9 = peg$parse_();
                                 if (s9 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c122(s1, s5);
+                                  s1 = peg$c125(s1, s5);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -3514,7 +3688,7 @@ module.exports = /*
                   s1 = peg$parsegeneric_func();
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = peg$currPos;
-                    s2 = peg$c123(s1);
+                    s2 = peg$c126(s1);
                     if (s2) {
                       s2 = void 0;
                     } else {
@@ -3524,7 +3698,7 @@ module.exports = /*
                       s3 = peg$parse_();
                       if (s3 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c124(s1);
+                        s1 = peg$c127(s1);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3543,7 +3717,7 @@ module.exports = /*
                     s1 = peg$parsegeneric_func();
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = peg$currPos;
-                      s2 = peg$c125(s1);
+                      s2 = peg$c128(s1);
                       if (s2) {
                         s2 = void 0;
                       } else {
@@ -3553,17 +3727,17 @@ module.exports = /*
                         s3 = peg$parse_();
                         if (s3 !== peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 123) {
-                            s4 = peg$c101;
+                            s4 = peg$c104;
                             peg$currPos++;
                           } else {
                             s4 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c102); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c105); }
                           }
                           if (s4 !== peg$FAILED) {
                             s5 = peg$parsegeneric_func();
                             if (s5 !== peg$FAILED) {
                               peg$savedPos = peg$currPos;
-                              s6 = peg$c126(s1, s5);
+                              s6 = peg$c129(s1, s5);
                               if (s6) {
                                 s6 = void 0;
                               } else {
@@ -3573,17 +3747,17 @@ module.exports = /*
                                 s7 = peg$parse_();
                                 if (s7 !== peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 125) {
-                                    s8 = peg$c48;
+                                    s8 = peg$c49;
                                     peg$currPos++;
                                   } else {
                                     s8 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c50); }
                                   }
                                   if (s8 !== peg$FAILED) {
                                     s9 = peg$parse_();
                                     if (s9 !== peg$FAILED) {
                                       peg$savedPos = s0;
-                                      s1 = peg$c127(s1, s5);
+                                      s1 = peg$c130(s1, s5);
                                       s0 = s1;
                                     } else {
                                       peg$currPos = s0;
@@ -3629,31 +3803,31 @@ module.exports = /*
                       }
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c128(s1);
+                        s1 = peg$c131(s1);
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
                         if (input.charCodeAt(peg$currPos) === 92) {
-                          s1 = peg$c129;
+                          s1 = peg$c132;
                           peg$currPos++;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c130); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c133); }
                         }
                         if (s1 !== peg$FAILED) {
-                          if (peg$c131.test(input.charAt(peg$currPos))) {
+                          if (peg$c134.test(input.charAt(peg$currPos))) {
                             s2 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s2 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c132); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c135); }
                           }
                           if (s2 !== peg$FAILED) {
                             s3 = peg$parse_();
                             if (s3 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c133(s2);
+                              s1 = peg$c136(s2);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -3669,18 +3843,18 @@ module.exports = /*
                         }
                         if (s0 === peg$FAILED) {
                           s0 = peg$currPos;
-                          if (peg$c134.test(input.charAt(peg$currPos))) {
+                          if (peg$c137.test(input.charAt(peg$currPos))) {
                             s1 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c135); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c138); }
                           }
                           if (s1 !== peg$FAILED) {
                             s2 = peg$parse_();
                             if (s2 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c106(s1);
+                              s1 = peg$c109(s1);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -3692,18 +3866,18 @@ module.exports = /*
                           }
                           if (s0 === peg$FAILED) {
                             s0 = peg$currPos;
-                            if (peg$c136.test(input.charAt(peg$currPos))) {
+                            if (peg$c139.test(input.charAt(peg$currPos))) {
                               s1 = input.charAt(peg$currPos);
                               peg$currPos++;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c137); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c140); }
                             }
                             if (s1 !== peg$FAILED) {
                               s2 = peg$parse_();
                               if (s2 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c138(s1);
+                                s1 = peg$c141(s1);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -3733,7 +3907,7 @@ module.exports = /*
     function peg$parseDELIMITER() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 39,
+      var key    = peg$currPos * 105 + 44,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3748,11 +3922,11 @@ module.exports = /*
         s1 = peg$parsedelimiter_uf_op();
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c77;
+            s1 = peg$c78;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c78); }
+            if (peg$silentFails === 0) { peg$fail(peg$c79); }
           }
         }
       }
@@ -3760,7 +3934,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c106(s1);
+          s1 = peg$c109(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3773,25 +3947,25 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c129;
+          s1 = peg$c132;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c130); }
+          if (peg$silentFails === 0) { peg$fail(peg$c133); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c139.test(input.charAt(peg$currPos))) {
+          if (peg$c142.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c140); }
+            if (peg$silentFails === 0) { peg$fail(peg$c143); }
           }
           if (s2 !== peg$FAILED) {
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c133(s2);
+              s1 = peg$c136(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3810,7 +3984,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c141(s1);
+            s2 = peg$c144(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -3820,7 +3994,7 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c117(s1);
+                s1 = peg$c120(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3839,7 +4013,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c142(s1);
+              s2 = peg$c145(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -3849,7 +4023,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c143(s1);
+                  s1 = peg$c146(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3875,7 +4049,7 @@ module.exports = /*
     function peg$parseFUN_AR1nb() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 40,
+      var key    = peg$currPos * 105 + 45,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3888,7 +4062,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c144(s1);
+        s2 = peg$c147(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -3898,7 +4072,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c145(s1);
+            s1 = peg$c148(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3921,7 +4095,7 @@ module.exports = /*
     function peg$parseFUN_AR1opt() {
       var s0, s1, s2, s3, s4, s5;
 
-      var key    = peg$currPos * 99 + 41,
+      var key    = peg$currPos * 105 + 46,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3934,7 +4108,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c146(s1);
+        s2 = peg$c149(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -3944,17 +4118,17 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 91) {
-              s4 = peg$c77;
+              s4 = peg$c78;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c78); }
+              if (peg$silentFails === 0) { peg$fail(peg$c79); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c145(s1);
+                s1 = peg$c148(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3985,7 +4159,7 @@ module.exports = /*
     function peg$parseNEXT_CELL() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 42,
+      var key    = peg$currPos * 105 + 47,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3996,11 +4170,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 38) {
-        s1 = peg$c147;
+        s1 = peg$c150;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c148); }
+        if (peg$silentFails === 0) { peg$fail(peg$c151); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4024,7 +4198,7 @@ module.exports = /*
     function peg$parseNEXT_ROW() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 43,
+      var key    = peg$currPos * 105 + 48,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4034,12 +4208,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c149) {
-        s1 = peg$c149;
+      if (input.substr(peg$currPos, 2) === peg$c152) {
+        s1 = peg$c152;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c150); }
+        if (peg$silentFails === 0) { peg$fail(peg$c153); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4063,7 +4237,7 @@ module.exports = /*
     function peg$parseBEGIN() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 44,
+      var key    = peg$currPos * 105 + 49,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4073,12 +4247,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c151) {
-        s1 = peg$c151;
+      if (input.substr(peg$currPos, 6) === peg$c154) {
+        s1 = peg$c154;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c152); }
+        if (peg$silentFails === 0) { peg$fail(peg$c155); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4102,7 +4276,7 @@ module.exports = /*
     function peg$parseEND() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 45,
+      var key    = peg$currPos * 105 + 50,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4112,12 +4286,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c153) {
-        s1 = peg$c153;
+      if (input.substr(peg$currPos, 4) === peg$c156) {
+        s1 = peg$c156;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c154); }
+        if (peg$silentFails === 0) { peg$fail(peg$c157); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4141,7 +4315,7 @@ module.exports = /*
     function peg$parseBEGIN_MATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 46,
+      var key    = peg$currPos * 105 + 51,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4153,12 +4327,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c155) {
-          s2 = peg$c155;
+        if (input.substr(peg$currPos, 8) === peg$c158) {
+          s2 = peg$c158;
           peg$currPos += 8;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c156); }
+          if (peg$silentFails === 0) { peg$fail(peg$c159); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4186,7 +4360,7 @@ module.exports = /*
     function peg$parseEND_MATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 47,
+      var key    = peg$currPos * 105 + 52,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4198,12 +4372,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c155) {
-          s2 = peg$c155;
+        if (input.substr(peg$currPos, 8) === peg$c158) {
+          s2 = peg$c158;
           peg$currPos += 8;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c156); }
+          if (peg$silentFails === 0) { peg$fail(peg$c159); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4231,7 +4405,7 @@ module.exports = /*
     function peg$parseBEGIN_PMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 48,
+      var key    = peg$currPos * 105 + 53,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4243,12 +4417,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c157) {
-          s2 = peg$c157;
+        if (input.substr(peg$currPos, 9) === peg$c160) {
+          s2 = peg$c160;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c158); }
+          if (peg$silentFails === 0) { peg$fail(peg$c161); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4276,7 +4450,7 @@ module.exports = /*
     function peg$parseEND_PMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 49,
+      var key    = peg$currPos * 105 + 54,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4288,12 +4462,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c157) {
-          s2 = peg$c157;
+        if (input.substr(peg$currPos, 9) === peg$c160) {
+          s2 = peg$c160;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c158); }
+          if (peg$silentFails === 0) { peg$fail(peg$c161); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4321,7 +4495,7 @@ module.exports = /*
     function peg$parseBEGIN_BMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 50,
+      var key    = peg$currPos * 105 + 55,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4333,12 +4507,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c159) {
-          s2 = peg$c159;
+        if (input.substr(peg$currPos, 9) === peg$c162) {
+          s2 = peg$c162;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c160); }
+          if (peg$silentFails === 0) { peg$fail(peg$c163); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4366,7 +4540,7 @@ module.exports = /*
     function peg$parseEND_BMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 51,
+      var key    = peg$currPos * 105 + 56,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4378,12 +4552,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c159) {
-          s2 = peg$c159;
+        if (input.substr(peg$currPos, 9) === peg$c162) {
+          s2 = peg$c162;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c160); }
+          if (peg$silentFails === 0) { peg$fail(peg$c163); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4411,7 +4585,7 @@ module.exports = /*
     function peg$parseBEGIN_BBMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 52,
+      var key    = peg$currPos * 105 + 57,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4423,12 +4597,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c161) {
-          s2 = peg$c161;
+        if (input.substr(peg$currPos, 9) === peg$c164) {
+          s2 = peg$c164;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c162); }
+          if (peg$silentFails === 0) { peg$fail(peg$c165); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4456,7 +4630,7 @@ module.exports = /*
     function peg$parseEND_BBMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 53,
+      var key    = peg$currPos * 105 + 58,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4468,12 +4642,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c161) {
-          s2 = peg$c161;
+        if (input.substr(peg$currPos, 9) === peg$c164) {
+          s2 = peg$c164;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c162); }
+          if (peg$silentFails === 0) { peg$fail(peg$c165); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4501,7 +4675,7 @@ module.exports = /*
     function peg$parseBEGIN_VMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 54,
+      var key    = peg$currPos * 105 + 59,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4513,12 +4687,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c163) {
-          s2 = peg$c163;
+        if (input.substr(peg$currPos, 9) === peg$c166) {
+          s2 = peg$c166;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c164); }
+          if (peg$silentFails === 0) { peg$fail(peg$c167); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4546,7 +4720,7 @@ module.exports = /*
     function peg$parseEND_VMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 55,
+      var key    = peg$currPos * 105 + 60,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4558,12 +4732,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c163) {
-          s2 = peg$c163;
+        if (input.substr(peg$currPos, 9) === peg$c166) {
+          s2 = peg$c166;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c164); }
+          if (peg$silentFails === 0) { peg$fail(peg$c167); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4591,7 +4765,7 @@ module.exports = /*
     function peg$parseBEGIN_VVMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 56,
+      var key    = peg$currPos * 105 + 61,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4603,12 +4777,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c165) {
-          s2 = peg$c165;
+        if (input.substr(peg$currPos, 9) === peg$c168) {
+          s2 = peg$c168;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c166); }
+          if (peg$silentFails === 0) { peg$fail(peg$c169); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4636,7 +4810,7 @@ module.exports = /*
     function peg$parseEND_VVMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 57,
+      var key    = peg$currPos * 105 + 62,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4648,12 +4822,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c165) {
-          s2 = peg$c165;
+        if (input.substr(peg$currPos, 9) === peg$c168) {
+          s2 = peg$c168;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c166); }
+          if (peg$silentFails === 0) { peg$fail(peg$c169); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4681,7 +4855,7 @@ module.exports = /*
     function peg$parseBEGIN_ARRAY() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 58,
+      var key    = peg$currPos * 105 + 63,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4693,12 +4867,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c167) {
-          s2 = peg$c167;
+        if (input.substr(peg$currPos, 7) === peg$c170) {
+          s2 = peg$c170;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c168); }
+          if (peg$silentFails === 0) { peg$fail(peg$c171); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4726,7 +4900,7 @@ module.exports = /*
     function peg$parseEND_ARRAY() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 59,
+      var key    = peg$currPos * 105 + 64,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4738,12 +4912,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c167) {
-          s2 = peg$c167;
+        if (input.substr(peg$currPos, 7) === peg$c170) {
+          s2 = peg$c170;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c168); }
+          if (peg$silentFails === 0) { peg$fail(peg$c171); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4771,7 +4945,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGN() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 60,
+      var key    = peg$currPos * 105 + 65,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4783,12 +4957,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c169) {
-          s2 = peg$c169;
+        if (input.substr(peg$currPos, 7) === peg$c172) {
+          s2 = peg$c172;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c170); }
+          if (peg$silentFails === 0) { peg$fail(peg$c173); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4816,7 +4990,7 @@ module.exports = /*
     function peg$parseEND_ALIGN() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 61,
+      var key    = peg$currPos * 105 + 66,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4828,12 +5002,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c169) {
-          s2 = peg$c169;
+        if (input.substr(peg$currPos, 7) === peg$c172) {
+          s2 = peg$c172;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c170); }
+          if (peg$silentFails === 0) { peg$fail(peg$c173); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4861,7 +5035,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNED() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 62,
+      var key    = peg$currPos * 105 + 67,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4873,12 +5047,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c171) {
-          s2 = peg$c171;
+        if (input.substr(peg$currPos, 9) === peg$c174) {
+          s2 = peg$c174;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c172); }
+          if (peg$silentFails === 0) { peg$fail(peg$c175); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4906,7 +5080,7 @@ module.exports = /*
     function peg$parseEND_ALIGNED() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 63,
+      var key    = peg$currPos * 105 + 68,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4918,12 +5092,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c171) {
-          s2 = peg$c171;
+        if (input.substr(peg$currPos, 9) === peg$c174) {
+          s2 = peg$c174;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c172); }
+          if (peg$silentFails === 0) { peg$fail(peg$c175); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4951,7 +5125,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 64,
+      var key    = peg$currPos * 105 + 69,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4963,12 +5137,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c173) {
-          s2 = peg$c173;
+        if (input.substr(peg$currPos, 9) === peg$c176) {
+          s2 = peg$c176;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c174); }
+          if (peg$silentFails === 0) { peg$fail(peg$c177); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4996,7 +5170,7 @@ module.exports = /*
     function peg$parseEND_ALIGNAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 65,
+      var key    = peg$currPos * 105 + 70,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5008,12 +5182,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c173) {
-          s2 = peg$c173;
+        if (input.substr(peg$currPos, 9) === peg$c176) {
+          s2 = peg$c176;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c174); }
+          if (peg$silentFails === 0) { peg$fail(peg$c177); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5041,7 +5215,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNEDAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 66,
+      var key    = peg$currPos * 105 + 71,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5053,12 +5227,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c175) {
-          s2 = peg$c175;
+        if (input.substr(peg$currPos, 11) === peg$c178) {
+          s2 = peg$c178;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c176); }
+          if (peg$silentFails === 0) { peg$fail(peg$c179); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5086,7 +5260,7 @@ module.exports = /*
     function peg$parseEND_ALIGNEDAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 67,
+      var key    = peg$currPos * 105 + 72,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5098,12 +5272,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c175) {
-          s2 = peg$c175;
+        if (input.substr(peg$currPos, 11) === peg$c178) {
+          s2 = peg$c178;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c176); }
+          if (peg$silentFails === 0) { peg$fail(peg$c179); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5131,7 +5305,7 @@ module.exports = /*
     function peg$parseBEGIN_SMALLMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 68,
+      var key    = peg$currPos * 105 + 73,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5143,12 +5317,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c177) {
-          s2 = peg$c177;
+        if (input.substr(peg$currPos, 13) === peg$c180) {
+          s2 = peg$c180;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c178); }
+          if (peg$silentFails === 0) { peg$fail(peg$c181); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5176,7 +5350,7 @@ module.exports = /*
     function peg$parseEND_SMALLMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 69,
+      var key    = peg$currPos * 105 + 74,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5188,12 +5362,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c177) {
-          s2 = peg$c177;
+        if (input.substr(peg$currPos, 13) === peg$c180) {
+          s2 = peg$c180;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c178); }
+          if (peg$silentFails === 0) { peg$fail(peg$c181); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5221,7 +5395,7 @@ module.exports = /*
     function peg$parseBEGIN_CASES() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 70,
+      var key    = peg$currPos * 105 + 75,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5233,12 +5407,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c179) {
-          s2 = peg$c179;
+        if (input.substr(peg$currPos, 7) === peg$c182) {
+          s2 = peg$c182;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c180); }
+          if (peg$silentFails === 0) { peg$fail(peg$c183); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5266,7 +5440,7 @@ module.exports = /*
     function peg$parseEND_CASES() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 71,
+      var key    = peg$currPos * 105 + 76,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5278,12 +5452,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c179) {
-          s2 = peg$c179;
+        if (input.substr(peg$currPos, 7) === peg$c182) {
+          s2 = peg$c182;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c180); }
+          if (peg$silentFails === 0) { peg$fail(peg$c183); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5311,7 +5485,7 @@ module.exports = /*
     function peg$parseSQ_CLOSE() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 72,
+      var key    = peg$currPos * 105 + 77,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5322,11 +5496,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 93) {
-        s1 = peg$c81;
+        s1 = peg$c82;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+        if (peg$silentFails === 0) { peg$fail(peg$c83); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -5350,7 +5524,7 @@ module.exports = /*
     function peg$parseCURLY_OPEN() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 73,
+      var key    = peg$currPos * 105 + 78,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5361,11 +5535,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c101;
+        s1 = peg$c104;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c105); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -5389,7 +5563,7 @@ module.exports = /*
     function peg$parseCURLY_CLOSE() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 74,
+      var key    = peg$currPos * 105 + 79,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5400,11 +5574,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 125) {
-        s1 = peg$c48;
+        s1 = peg$c49;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c49); }
+        if (peg$silentFails === 0) { peg$fail(peg$c50); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -5428,7 +5602,7 @@ module.exports = /*
     function peg$parseSUP() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 75,
+      var key    = peg$currPos * 105 + 80,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5439,11 +5613,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 94) {
-        s1 = peg$c181;
+        s1 = peg$c184;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c182); }
+        if (peg$silentFails === 0) { peg$fail(peg$c185); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -5467,7 +5641,7 @@ module.exports = /*
     function peg$parseSUB() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 76,
+      var key    = peg$currPos * 105 + 81,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5478,11 +5652,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 95) {
-        s1 = peg$c183;
+        s1 = peg$c186;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c184); }
+        if (peg$silentFails === 0) { peg$fail(peg$c187); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -5506,7 +5680,7 @@ module.exports = /*
     function peg$parsegeneric_func() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 77,
+      var key    = peg$currPos * 105 + 82,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5517,11 +5691,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c129;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c130); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -5536,7 +5710,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c60();
+          s1 = peg$c61();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5555,129 +5729,7 @@ module.exports = /*
     function peg$parseBIG() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 78,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      s1 = peg$parsegeneric_func();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = peg$currPos;
-        s2 = peg$c185(s1);
-        if (s2) {
-          s2 = void 0;
-        } else {
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c145(s1);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseFUN_AR1() {
-      var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 99 + 79,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      s1 = peg$parsegeneric_func();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = peg$currPos;
-        s2 = peg$c186(s1);
-        if (s2) {
-          s2 = void 0;
-        } else {
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c145(s1);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parsegeneric_func();
-        if (s1 !== peg$FAILED) {
-          peg$savedPos = peg$currPos;
-          s2 = peg$c187(s1);
-          if (s2) {
-            s2 = void 0;
-          } else {
-            s2 = peg$FAILED;
-          }
-          if (s2 !== peg$FAILED) {
-            s3 = peg$parse_();
-            if (s3 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c187(s1);
-              s0 = s1;
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseFUN_AR2() {
-      var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 99 + 80,
+      var key    = peg$currPos * 105 + 83,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5700,7 +5752,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c145(s1);
+            s1 = peg$c148(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5720,10 +5772,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseFUN_INFIX() {
+    function peg$parseFUN_AR1() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 81,
+      var key    = peg$currPos * 105 + 84,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5746,7 +5798,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c145(s1);
+            s1 = peg$c148(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5760,16 +5812,46 @@ module.exports = /*
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parsegeneric_func();
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = peg$currPos;
+          s2 = peg$c190(s1);
+          if (s2) {
+            s2 = void 0;
+          } else {
+            s2 = peg$FAILED;
+          }
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parse_();
+            if (s3 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c190(s1);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
 
-    function peg$parseDECLh() {
-      var s0, s1, s2, s3;
+    function peg$parseFUN_MHCHEM() {
+      var s0, s1, s2;
 
-      var key    = peg$currPos * 99 + 82,
+      var key    = peg$currPos * 105 + 85,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5782,22 +5864,16 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c190(s1);
+        s2 = peg$c191(s1);
         if (s2) {
           s2 = void 0;
         } else {
           s2 = peg$FAILED;
         }
         if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c191(s1);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
+          peg$savedPos = s0;
+          s1 = peg$c148(s1);
+          s0 = s1;
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -5812,10 +5888,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseFUN_AR2nb() {
+    function peg$parseFUN_AR2() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 83,
+      var key    = peg$currPos * 105 + 86,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5838,7 +5914,145 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c145(s1);
+            s1 = peg$c148(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseFUN_INFIX() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 105 + 87,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c193(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c148(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseDECLh() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 105 + 88,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c194(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c195(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseFUN_AR2nb() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 105 + 89,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c196(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c148(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5861,7 +6075,7 @@ module.exports = /*
     function peg$parseLEFT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 84,
+      var key    = peg$currPos * 105 + 90,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5874,7 +6088,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c193(s1);
+        s2 = peg$c197(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -5906,7 +6120,7 @@ module.exports = /*
     function peg$parseRIGHT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 85,
+      var key    = peg$currPos * 105 + 91,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5919,7 +6133,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c194(s1);
+        s2 = peg$c198(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -5951,7 +6165,7 @@ module.exports = /*
     function peg$parseHLINE() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 99 + 86,
+      var key    = peg$currPos * 105 + 92,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5964,7 +6178,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c195(s1);
+        s2 = peg$c199(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -5974,7 +6188,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c145(s1);
+            s1 = peg$c148(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5997,7 +6211,7 @@ module.exports = /*
     function peg$parseCOLOR() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 99 + 87,
+      var key    = peg$currPos * 105 + 93,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6010,7 +6224,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c196(s1);
+        s2 = peg$c200(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6022,7 +6236,7 @@ module.exports = /*
             s4 = peg$parseCOLOR_SPEC();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c197(s1, s4);
+              s1 = peg$c201(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6049,7 +6263,7 @@ module.exports = /*
     function peg$parseDEFINECOLOR() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17;
 
-      var key    = peg$currPos * 99 + 88,
+      var key    = peg$currPos * 105 + 94,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6062,7 +6276,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c198(s1);
+        s2 = peg$c202(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6072,11 +6286,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c101;
+              s4 = peg$c104;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c102); }
+              if (peg$silentFails === 0) { peg$fail(peg$c105); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -6095,42 +6309,42 @@ module.exports = /*
                   s7 = peg$parse_();
                   if (s7 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 125) {
-                      s8 = peg$c48;
+                      s8 = peg$c49;
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c50); }
                     }
                     if (s8 !== peg$FAILED) {
                       s9 = peg$parse_();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 123) {
-                          s10 = peg$c101;
+                          s10 = peg$c104;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c102); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c105); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             s12 = peg$currPos;
-                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c199) {
+                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c203) {
                               s13 = input.substr(peg$currPos, 5);
                               peg$currPos += 5;
                             } else {
                               s13 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c200); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c204); }
                             }
                             if (s13 !== peg$FAILED) {
                               s14 = peg$parse_();
                               if (s14 !== peg$FAILED) {
                                 if (input.charCodeAt(peg$currPos) === 125) {
-                                  s15 = peg$c48;
+                                  s15 = peg$c49;
                                   peg$currPos++;
                                 } else {
                                   s15 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c50); }
                                 }
                                 if (s15 !== peg$FAILED) {
                                   s16 = peg$parse_();
@@ -6138,7 +6352,7 @@ module.exports = /*
                                     s17 = peg$parseCOLOR_SPEC_NAMED();
                                     if (s17 !== peg$FAILED) {
                                       peg$savedPos = s12;
-                                      s13 = peg$c201(s1, s6, s17);
+                                      s13 = peg$c205(s1, s6, s17);
                                       s12 = s13;
                                     } else {
                                       peg$currPos = s12;
@@ -6162,22 +6376,22 @@ module.exports = /*
                             }
                             if (s12 === peg$FAILED) {
                               s12 = peg$currPos;
-                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c202) {
+                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c206) {
                                 s13 = input.substr(peg$currPos, 4);
                                 peg$currPos += 4;
                               } else {
                                 s13 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c203); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c207); }
                               }
                               if (s13 !== peg$FAILED) {
                                 s14 = peg$parse_();
                                 if (s14 !== peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 125) {
-                                    s15 = peg$c48;
+                                    s15 = peg$c49;
                                     peg$currPos++;
                                   } else {
                                     s15 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c50); }
                                   }
                                   if (s15 !== peg$FAILED) {
                                     s16 = peg$parse_();
@@ -6185,7 +6399,7 @@ module.exports = /*
                                       s17 = peg$parseCOLOR_SPEC_GRAY();
                                       if (s17 !== peg$FAILED) {
                                         peg$savedPos = s12;
-                                        s13 = peg$c204(s1, s6, s17);
+                                        s13 = peg$c208(s1, s6, s17);
                                         s12 = s13;
                                       } else {
                                         peg$currPos = s12;
@@ -6209,22 +6423,22 @@ module.exports = /*
                               }
                               if (s12 === peg$FAILED) {
                                 s12 = peg$currPos;
-                                if (input.substr(peg$currPos, 3) === peg$c205) {
-                                  s13 = peg$c205;
+                                if (input.substr(peg$currPos, 3) === peg$c209) {
+                                  s13 = peg$c209;
                                   peg$currPos += 3;
                                 } else {
                                   s13 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c206); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c210); }
                                 }
                                 if (s13 !== peg$FAILED) {
                                   s14 = peg$parse_();
                                   if (s14 !== peg$FAILED) {
                                     if (input.charCodeAt(peg$currPos) === 125) {
-                                      s15 = peg$c48;
+                                      s15 = peg$c49;
                                       peg$currPos++;
                                     } else {
                                       s15 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c50); }
                                     }
                                     if (s15 !== peg$FAILED) {
                                       s16 = peg$parse_();
@@ -6232,7 +6446,7 @@ module.exports = /*
                                         s17 = peg$parseCOLOR_SPEC_rgb();
                                         if (s17 !== peg$FAILED) {
                                           peg$savedPos = s12;
-                                          s13 = peg$c207(s1, s6, s17);
+                                          s13 = peg$c211(s1, s6, s17);
                                           s12 = s13;
                                         } else {
                                           peg$currPos = s12;
@@ -6256,22 +6470,22 @@ module.exports = /*
                                 }
                                 if (s12 === peg$FAILED) {
                                   s12 = peg$currPos;
-                                  if (input.substr(peg$currPos, 3) === peg$c208) {
-                                    s13 = peg$c208;
+                                  if (input.substr(peg$currPos, 3) === peg$c212) {
+                                    s13 = peg$c212;
                                     peg$currPos += 3;
                                   } else {
                                     s13 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c209); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c213); }
                                   }
                                   if (s13 !== peg$FAILED) {
                                     s14 = peg$parse_();
                                     if (s14 !== peg$FAILED) {
                                       if (input.charCodeAt(peg$currPos) === 125) {
-                                        s15 = peg$c48;
+                                        s15 = peg$c49;
                                         peg$currPos++;
                                       } else {
                                         s15 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c50); }
                                       }
                                       if (s15 !== peg$FAILED) {
                                         s16 = peg$parse_();
@@ -6279,7 +6493,7 @@ module.exports = /*
                                           s17 = peg$parseCOLOR_SPEC_RGB();
                                           if (s17 !== peg$FAILED) {
                                             peg$savedPos = s12;
-                                            s13 = peg$c207(s1, s6, s17);
+                                            s13 = peg$c211(s1, s6, s17);
                                             s12 = s13;
                                           } else {
                                             peg$currPos = s12;
@@ -6303,22 +6517,22 @@ module.exports = /*
                                   }
                                   if (s12 === peg$FAILED) {
                                     s12 = peg$currPos;
-                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c210) {
+                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c214) {
                                       s13 = input.substr(peg$currPos, 4);
                                       peg$currPos += 4;
                                     } else {
                                       s13 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c211); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c215); }
                                     }
                                     if (s13 !== peg$FAILED) {
                                       s14 = peg$parse_();
                                       if (s14 !== peg$FAILED) {
                                         if (input.charCodeAt(peg$currPos) === 125) {
-                                          s15 = peg$c48;
+                                          s15 = peg$c49;
                                           peg$currPos++;
                                         } else {
                                           s15 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c50); }
                                         }
                                         if (s15 !== peg$FAILED) {
                                           s16 = peg$parse_();
@@ -6326,7 +6540,7 @@ module.exports = /*
                                             s17 = peg$parseCOLOR_SPEC_CMYK();
                                             if (s17 !== peg$FAILED) {
                                               peg$savedPos = s12;
-                                              s13 = peg$c212(s1, s6, s17);
+                                              s13 = peg$c216(s1, s6, s17);
                                               s12 = s13;
                                             } else {
                                               peg$currPos = s12;
@@ -6354,7 +6568,7 @@ module.exports = /*
                             }
                             if (s12 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c213(s1, s6, s12);
+                              s1 = peg$c217(s1, s6, s12);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -6413,7 +6627,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
-      var key    = peg$currPos * 99 + 89,
+      var key    = peg$currPos * 105 + 95,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6426,31 +6640,31 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c77;
+          s1 = peg$c78;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c78); }
+          if (peg$silentFails === 0) { peg$fail(peg$c79); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c199) {
+            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c203) {
               s3 = input.substr(peg$currPos, 5);
               peg$currPos += 5;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c200); }
+              if (peg$silentFails === 0) { peg$fail(peg$c204); }
             }
             if (s3 !== peg$FAILED) {
               s4 = peg$parse_();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s5 = peg$c81;
+                  s5 = peg$c82;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c82); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c83); }
                 }
                 if (s5 !== peg$FAILED) {
                   s6 = peg$parse_();
@@ -6458,7 +6672,7 @@ module.exports = /*
                     s7 = peg$parseCOLOR_SPEC_NAMED();
                     if (s7 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c214(s7);
+                      s1 = peg$c218(s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6491,31 +6705,31 @@ module.exports = /*
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c77;
+            s1 = peg$c78;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c78); }
+            if (peg$silentFails === 0) { peg$fail(peg$c79); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c202) {
+              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c206) {
                 s3 = input.substr(peg$currPos, 4);
                 peg$currPos += 4;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c203); }
+                if (peg$silentFails === 0) { peg$fail(peg$c207); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s5 = peg$c81;
+                    s5 = peg$c82;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c82); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c83); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse_();
@@ -6523,7 +6737,7 @@ module.exports = /*
                       s7 = peg$parseCOLOR_SPEC_GRAY();
                       if (s7 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c215(s7);
+                        s1 = peg$c219(s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -6556,31 +6770,31 @@ module.exports = /*
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 91) {
-              s1 = peg$c77;
+              s1 = peg$c78;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c78); }
+              if (peg$silentFails === 0) { peg$fail(peg$c79); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$parse_();
               if (s2 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 3) === peg$c205) {
-                  s3 = peg$c205;
+                if (input.substr(peg$currPos, 3) === peg$c209) {
+                  s3 = peg$c209;
                   peg$currPos += 3;
                 } else {
                   s3 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c206); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c210); }
                 }
                 if (s3 !== peg$FAILED) {
                   s4 = peg$parse_();
                   if (s4 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 93) {
-                      s5 = peg$c81;
+                      s5 = peg$c82;
                       peg$currPos++;
                     } else {
                       s5 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c82); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c83); }
                     }
                     if (s5 !== peg$FAILED) {
                       s6 = peg$parse_();
@@ -6588,7 +6802,7 @@ module.exports = /*
                         s7 = peg$parseCOLOR_SPEC_rgb();
                         if (s7 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c216(s7);
+                          s1 = peg$c220(s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -6621,31 +6835,31 @@ module.exports = /*
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 91) {
-                s1 = peg$c77;
+                s1 = peg$c78;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c78); }
+                if (peg$silentFails === 0) { peg$fail(peg$c79); }
               }
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse_();
                 if (s2 !== peg$FAILED) {
-                  if (input.substr(peg$currPos, 3) === peg$c208) {
-                    s3 = peg$c208;
+                  if (input.substr(peg$currPos, 3) === peg$c212) {
+                    s3 = peg$c212;
                     peg$currPos += 3;
                   } else {
                     s3 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c209); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c213); }
                   }
                   if (s3 !== peg$FAILED) {
                     s4 = peg$parse_();
                     if (s4 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 93) {
-                        s5 = peg$c81;
+                        s5 = peg$c82;
                         peg$currPos++;
                       } else {
                         s5 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c83); }
                       }
                       if (s5 !== peg$FAILED) {
                         s6 = peg$parse_();
@@ -6653,7 +6867,7 @@ module.exports = /*
                           s7 = peg$parseCOLOR_SPEC_RGB();
                           if (s7 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c216(s7);
+                            s1 = peg$c220(s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -6686,31 +6900,31 @@ module.exports = /*
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 91) {
-                  s1 = peg$c77;
+                  s1 = peg$c78;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c78); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c79); }
                 }
                 if (s1 !== peg$FAILED) {
                   s2 = peg$parse_();
                   if (s2 !== peg$FAILED) {
-                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c210) {
+                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c214) {
                       s3 = input.substr(peg$currPos, 4);
                       peg$currPos += 4;
                     } else {
                       s3 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c211); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c215); }
                     }
                     if (s3 !== peg$FAILED) {
                       s4 = peg$parse_();
                       if (s4 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 93) {
-                          s5 = peg$c81;
+                          s5 = peg$c82;
                           peg$currPos++;
                         } else {
                           s5 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c82); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c83); }
                         }
                         if (s5 !== peg$FAILED) {
                           s6 = peg$parse_();
@@ -6718,7 +6932,7 @@ module.exports = /*
                             s7 = peg$parseCOLOR_SPEC_CMYK();
                             if (s7 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c217(s7);
+                              s1 = peg$c221(s7);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -6762,7 +6976,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_NAMED() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 99 + 90,
+      var key    = peg$currPos * 105 + 96,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6773,11 +6987,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c101;
+        s1 = peg$c104;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c105); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6796,17 +7010,17 @@ module.exports = /*
             s4 = peg$parse_();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 125) {
-                s5 = peg$c48;
+                s5 = peg$c49;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                if (peg$silentFails === 0) { peg$fail(peg$c50); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = peg$parse_();
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c218(s3);
+                  s1 = peg$c222(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -6841,7 +7055,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_GRAY() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 99 + 91,
+      var key    = peg$currPos * 105 + 97,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6852,11 +7066,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c101;
+        s1 = peg$c104;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c105); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6873,15 +7087,15 @@ module.exports = /*
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c48;
+              s4 = peg$c49;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c49); }
+              if (peg$silentFails === 0) { peg$fail(peg$c50); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c219(s3);
+              s1 = peg$c223(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6908,7 +7122,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_rgb() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-      var key    = peg$currPos * 99 + 92,
+      var key    = peg$currPos * 105 + 98,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6919,11 +7133,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c101;
+        s1 = peg$c104;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c105); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6931,11 +7145,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c220;
+              s4 = peg$c224;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c221); }
+              if (peg$silentFails === 0) { peg$fail(peg$c225); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -6943,11 +7157,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c220;
+                    s7 = peg$c224;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c221); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c225); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -6955,17 +7169,17 @@ module.exports = /*
                       s9 = peg$parseCNUM();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 125) {
-                          s10 = peg$c48;
+                          s10 = peg$c49;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c50); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c222(s3, s6, s9);
+                            s1 = peg$c226(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7020,7 +7234,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_RGB() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-      var key    = peg$currPos * 99 + 93,
+      var key    = peg$currPos * 105 + 99,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7031,11 +7245,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c101;
+        s1 = peg$c104;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c105); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7043,11 +7257,11 @@ module.exports = /*
           s3 = peg$parseCNUM255();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c220;
+              s4 = peg$c224;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c221); }
+              if (peg$silentFails === 0) { peg$fail(peg$c225); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7055,11 +7269,11 @@ module.exports = /*
                 s6 = peg$parseCNUM255();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c220;
+                    s7 = peg$c224;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c221); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c225); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -7067,17 +7281,17 @@ module.exports = /*
                       s9 = peg$parseCNUM255();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 125) {
-                          s10 = peg$c48;
+                          s10 = peg$c49;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c50); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c222(s3, s6, s9);
+                            s1 = peg$c226(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7132,7 +7346,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_CMYK() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14;
 
-      var key    = peg$currPos * 99 + 94,
+      var key    = peg$currPos * 105 + 100,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7143,11 +7357,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c101;
+        s1 = peg$c104;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+        if (peg$silentFails === 0) { peg$fail(peg$c105); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7155,11 +7369,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c220;
+              s4 = peg$c224;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c221); }
+              if (peg$silentFails === 0) { peg$fail(peg$c225); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7167,11 +7381,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c220;
+                    s7 = peg$c224;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c221); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c225); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -7179,11 +7393,11 @@ module.exports = /*
                       s9 = peg$parseCNUM();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 44) {
-                          s10 = peg$c220;
+                          s10 = peg$c224;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c221); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c225); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
@@ -7191,17 +7405,17 @@ module.exports = /*
                             s12 = peg$parseCNUM();
                             if (s12 !== peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 125) {
-                                s13 = peg$c48;
+                                s13 = peg$c49;
                                 peg$currPos++;
                               } else {
                                 s13 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c50); }
                               }
                               if (s13 !== peg$FAILED) {
                                 s14 = peg$parse_();
                                 if (s14 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c223(s3, s6, s9, s12);
+                                  s1 = peg$c227(s3, s6, s9, s12);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -7268,7 +7482,7 @@ module.exports = /*
     function peg$parseCNUM255() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 99 + 95,
+      var key    = peg$currPos * 105 + 101,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7280,37 +7494,37 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s2 = peg$c224;
+        s2 = peg$c228;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c225); }
+        if (peg$silentFails === 0) { peg$fail(peg$c229); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$currPos;
-        if (peg$c226.test(input.charAt(peg$currPos))) {
+        if (peg$c230.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c227); }
+          if (peg$silentFails === 0) { peg$fail(peg$c231); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
-          if (peg$c68.test(input.charAt(peg$currPos))) {
+          if (peg$c69.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c69); }
+            if (peg$silentFails === 0) { peg$fail(peg$c70); }
           }
           if (s5 !== peg$FAILED) {
-            if (peg$c68.test(input.charAt(peg$currPos))) {
+            if (peg$c69.test(input.charAt(peg$currPos))) {
               s6 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c69); }
+              if (peg$silentFails === 0) { peg$fail(peg$c70); }
             }
             if (s6 === peg$FAILED) {
               s6 = null;
@@ -7348,7 +7562,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c228(s1);
+        s2 = peg$c232(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -7358,7 +7572,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c229(s1);
+            s1 = peg$c233(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7381,7 +7595,7 @@ module.exports = /*
     function peg$parseCNUM() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 99 + 96,
+      var key    = peg$currPos * 105 + 102,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7394,41 +7608,41 @@ module.exports = /*
       s1 = peg$currPos;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s3 = peg$c224;
+        s3 = peg$c228;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c225); }
+        if (peg$silentFails === 0) { peg$fail(peg$c229); }
       }
       if (s3 === peg$FAILED) {
         s3 = null;
       }
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c230;
+          s4 = peg$c234;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c231); }
+          if (peg$silentFails === 0) { peg$fail(peg$c235); }
         }
         if (s4 !== peg$FAILED) {
           s5 = [];
-          if (peg$c68.test(input.charAt(peg$currPos))) {
+          if (peg$c69.test(input.charAt(peg$currPos))) {
             s6 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c69); }
+            if (peg$silentFails === 0) { peg$fail(peg$c70); }
           }
           if (s6 !== peg$FAILED) {
             while (s6 !== peg$FAILED) {
               s5.push(s6);
-              if (peg$c68.test(input.charAt(peg$currPos))) {
+              if (peg$c69.test(input.charAt(peg$currPos))) {
                 s6 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c69); }
+                if (peg$silentFails === 0) { peg$fail(peg$c70); }
               }
             }
           } else {
@@ -7458,7 +7672,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c232(s1);
+          s1 = peg$c236(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7472,20 +7686,20 @@ module.exports = /*
         s0 = peg$currPos;
         s1 = peg$currPos;
         s2 = peg$currPos;
-        if (peg$c233.test(input.charAt(peg$currPos))) {
+        if (peg$c237.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c234); }
+          if (peg$silentFails === 0) { peg$fail(peg$c238); }
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c230;
+            s4 = peg$c234;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c231); }
+            if (peg$silentFails === 0) { peg$fail(peg$c235); }
           }
           if (s4 === peg$FAILED) {
             s4 = null;
@@ -7510,7 +7724,7 @@ module.exports = /*
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c232(s1);
+            s1 = peg$c236(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7530,7 +7744,7 @@ module.exports = /*
     function peg$parseimpossible() {
       var s0;
 
-      var key    = peg$currPos * 99 + 97,
+      var key    = peg$currPos * 105 + 103,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7540,7 +7754,7 @@ module.exports = /*
       }
 
       peg$savedPos = peg$currPos;
-      s0 = peg$c235();
+      s0 = peg$c239();
       if (s0) {
         s0 = void 0;
       } else {
@@ -7555,7 +7769,7 @@ module.exports = /*
     function peg$parseEOF() {
       var s0;
 
-      var key    = peg$currPos * 99 + 98,
+      var key    = peg$currPos * 105 + 104,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7565,7 +7779,7 @@ module.exports = /*
       }
 
       peg$savedPos = peg$currPos;
-      s0 = peg$c236();
+      s0 = peg$c240();
       if (s0) {
         s0 = void 0;
       } else {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -241,222 +241,224 @@ module.exports = /*
         peg$c93 = "^",
         peg$c94 = peg$literalExpectation("^", false),
         peg$c95 = function(m, n) { return ast.Tex.CHEM_WORD(m, n); },
-        peg$c96 = function(m, n) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)), n); },
+        peg$c96 = function(m, n, o) { return ast.Tex.CHEM_WORD(ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)), n), o); },
         peg$c97 = function() { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("")); },
         peg$c98 = function(m) { return m;},
-        peg$c99 = function(c) { return ast.Tex.CURLY([c]); },
-        peg$c100 = function(c) { return ast.Tex.DOLLAR(c.toArray()); },
-        peg$c101 = function(name, l) { return ast.Tex.CHEM_BOND(name, l); },
-        peg$c102 = function(c) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) },
+        peg$c99 = function(c) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) },
+        peg$c100 = function(c) { return ast.Tex.CURLY([c]); },
+        peg$c101 = function(c) { return ast.Tex.DOLLAR(c.toArray()); },
+        peg$c102 = function(name, l) { return ast.Tex.CHEM_BOND(name, l); },
         peg$c103 = function(e) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(e))]); },
         peg$c104 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(b))); },
         peg$c105 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), b); },
-        peg$c106 = function(a, b) { return a + "$" + b + "$"; },
+        peg$c106 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.DOLLAR(b.toArray())); },
         peg$c107 = "_",
         peg$c108 = peg$literalExpectation("_", false),
         peg$c109 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2u(name, l1, l2); },
-        peg$c110 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2(name, l1, l2); },
-        peg$c111 = function(name, l) { return ast.Tex.CHEM_FUN1(name, l); },
-        peg$c112 = function(cs) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); },
-        peg$c113 = /^[a-zA-Z]/,
-        peg$c114 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
-        peg$c115 = /^[,:;?!']/,
-        peg$c116 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
-        peg$c117 = /^[().]/,
-        peg$c118 = peg$classExpectation(["(", ")", "."], false, false),
-        peg$c119 = /^[\-+*=]/,
-        peg$c120 = peg$classExpectation(["-", "+", "*", "="], false, false),
-        peg$c121 = /^[\/|]/,
-        peg$c122 = peg$classExpectation(["/", "|"], false, false),
-        peg$c123 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
-        peg$c124 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
-        peg$c125 = /^[\uD800-\uDBFF]/,
-        peg$c126 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
-        peg$c127 = /^[\uDC00-\uDFFF]/,
-        peg$c128 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
-        peg$c129 = function(l, h) { return text(); },
-        peg$c130 = function(b) { return tu.box_functions[b]; },
-        peg$c131 = "{",
-        peg$c132 = peg$literalExpectation("{", false),
-        peg$c133 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
-        peg$c134 = "-",
-        peg$c135 = peg$literalExpectation("-", false),
-        peg$c136 = function(c) { return ast.RenderT.TEX_ONLY(c); },
-        peg$c137 = function(f) { return tu.latex_function_names[f]; },
-        peg$c138 = "(",
-        peg$c139 = peg$literalExpectation("(", false),
-        peg$c140 = "\\{",
-        peg$c141 = peg$literalExpectation("\\{", false),
-        peg$c142 = function(f) { return " ";},
-        peg$c143 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
-        peg$c144 = function(f) { return tu.mediawiki_function_names[f]; },
-        peg$c145 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
-        peg$c146 = function(f) { return tu.other_literals1[f]; },
-        peg$c147 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
-        peg$c148 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c149 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c150 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
-        peg$c151 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c152 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c153 = function(f) { return tu.other_literals2[f]; },
-        peg$c154 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c155 = function(mbox) { return mbox === "\\mbox"; },
-        peg$c156 = function(mbox, f) { return tu.other_literals2[f]; },
-        peg$c157 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c158 = function(f) { return ast.RenderT.TEX_ONLY(f); },
-        peg$c159 = "\\",
-        peg$c160 = peg$literalExpectation("\\", false),
-        peg$c161 = /^[, ;!_#%$&]/,
-        peg$c162 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
-        peg$c163 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
-        peg$c164 = /^[><~]/,
-        peg$c165 = peg$classExpectation([">", "<", "~"], false, false),
-        peg$c166 = /^[%$]/,
-        peg$c167 = peg$classExpectation(["%", "$"], false, false),
-        peg$c168 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */},
-        peg$c169 = /^[{}|]/,
-        peg$c170 = peg$classExpectation(["{", "}", "|"], false, false),
-        peg$c171 = function(f) { return tu.other_delimiters1[f]; },
-        peg$c172 = function(f) { return tu.other_delimiters2[f]; },
-        peg$c173 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
+        peg$c110 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2c(l1, l2); },
+        peg$c111 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2(name, l1, l2); },
+        peg$c112 = function(name, l) { return ast.Tex.CHEM_FUN1(name, l); },
+        peg$c113 = function(cs) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); },
+        peg$c114 = /^[a-zA-Z]/,
+        peg$c115 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
+        peg$c116 = /^[,:;?!']/,
+        peg$c117 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
+        peg$c118 = /^[().]/,
+        peg$c119 = peg$classExpectation(["(", ")", "."], false, false),
+        peg$c120 = /^[\-+*=]/,
+        peg$c121 = peg$classExpectation(["-", "+", "*", "="], false, false),
+        peg$c122 = /^[\/|]/,
+        peg$c123 = peg$classExpectation(["/", "|"], false, false),
+        peg$c124 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
+        peg$c125 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
+        peg$c126 = /^[\uD800-\uDBFF]/,
+        peg$c127 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
+        peg$c128 = /^[\uDC00-\uDFFF]/,
+        peg$c129 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
+        peg$c130 = function(l, h) { return text(); },
+        peg$c131 = function(b) { return tu.box_functions[b]; },
+        peg$c132 = "{",
+        peg$c133 = peg$literalExpectation("{", false),
+        peg$c134 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
+        peg$c135 = "-",
+        peg$c136 = peg$literalExpectation("-", false),
+        peg$c137 = function(c) { return ast.RenderT.TEX_ONLY(c); },
+        peg$c138 = function(f) { return tu.latex_function_names[f]; },
+        peg$c139 = "(",
+        peg$c140 = peg$literalExpectation("(", false),
+        peg$c141 = "\\{",
+        peg$c142 = peg$literalExpectation("\\{", false),
+        peg$c143 = function(f) { return " ";},
+        peg$c144 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
+        peg$c145 = function(f) { return tu.mediawiki_function_names[f]; },
+        peg$c146 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
+        peg$c147 = function(f) { return tu.other_literals1[f]; },
+        peg$c148 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
+        peg$c149 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c150 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c151 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
+        peg$c152 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c153 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c154 = function(f) { return tu.other_literals2[f]; },
+        peg$c155 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c156 = function(mbox) { return mbox === "\\mbox"; },
+        peg$c157 = function(mbox, f) { return tu.other_literals2[f]; },
+        peg$c158 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c159 = function(f) { return ast.RenderT.TEX_ONLY(f); },
+        peg$c160 = "\\",
+        peg$c161 = peg$literalExpectation("\\", false),
+        peg$c162 = /^[, ;!_#%$&]/,
+        peg$c163 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
+        peg$c164 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
+        peg$c165 = /^[><~]/,
+        peg$c166 = peg$classExpectation([">", "<", "~"], false, false),
+        peg$c167 = /^[%$]/,
+        peg$c168 = peg$classExpectation(["%", "$"], false, false),
+        peg$c169 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */},
+        peg$c170 = /^[{}|]/,
+        peg$c171 = peg$classExpectation(["{", "}", "|"], false, false),
+        peg$c172 = function(f) { return tu.other_delimiters1[f]; },
+        peg$c173 = function(f) { return tu.other_delimiters2[f]; },
+        peg$c174 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
              console.assert(Array.isArray(p) && p.length === 1);
              console.assert(p[0].constructor === ast.Tex.LITERAL);
              console.assert(p[0][0].constructor === ast.RenderT.TEX_ONLY);
              return p[0][0];
            },
-        peg$c174 = function(f) { return tu.fun_ar1nb[f]; },
-        peg$c175 = function(f) { return f; },
-        peg$c176 = function(f) { return tu.fun_ar1opt[f]; },
-        peg$c177 = "&",
-        peg$c178 = peg$literalExpectation("&", false),
-        peg$c179 = "\\\\",
-        peg$c180 = peg$literalExpectation("\\\\", false),
-        peg$c181 = "\\begin",
-        peg$c182 = peg$literalExpectation("\\begin", false),
-        peg$c183 = "\\end",
-        peg$c184 = peg$literalExpectation("\\end", false),
-        peg$c185 = "{matrix}",
-        peg$c186 = peg$literalExpectation("{matrix}", false),
-        peg$c187 = "{pmatrix}",
-        peg$c188 = peg$literalExpectation("{pmatrix}", false),
-        peg$c189 = "{bmatrix}",
-        peg$c190 = peg$literalExpectation("{bmatrix}", false),
-        peg$c191 = "{Bmatrix}",
-        peg$c192 = peg$literalExpectation("{Bmatrix}", false),
-        peg$c193 = "{vmatrix}",
-        peg$c194 = peg$literalExpectation("{vmatrix}", false),
-        peg$c195 = "{Vmatrix}",
-        peg$c196 = peg$literalExpectation("{Vmatrix}", false),
-        peg$c197 = "{array}",
-        peg$c198 = peg$literalExpectation("{array}", false),
-        peg$c199 = "{align}",
-        peg$c200 = peg$literalExpectation("{align}", false),
-        peg$c201 = "{aligned}",
-        peg$c202 = peg$literalExpectation("{aligned}", false),
-        peg$c203 = "{alignat}",
-        peg$c204 = peg$literalExpectation("{alignat}", false),
-        peg$c205 = "{alignedat}",
-        peg$c206 = peg$literalExpectation("{alignedat}", false),
-        peg$c207 = "{smallmatrix}",
-        peg$c208 = peg$literalExpectation("{smallmatrix}", false),
-        peg$c209 = "{cases}",
-        peg$c210 = peg$literalExpectation("{cases}", false),
-        peg$c211 = function(f) { return tu.big_literals[f]; },
-        peg$c212 = function(f) { return tu.fun_ar1[f]; },
-        peg$c213 = function(f) { return tu.other_fun_ar1[f]; },
-        peg$c214 = function(f) { return tu.fun_mhchem[f]; },
-        peg$c215 = function(f) { return tu.fun_ar2[f]; },
-        peg$c216 = function(f) { return tu.fun_infix[f]; },
-        peg$c217 = function(f) { return tu.declh_function[f]; },
-        peg$c218 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
-        peg$c219 = function(f) { return tu.fun_ar2nb[f]; },
-        peg$c220 = function(f) { return tu.left_function[f]; },
-        peg$c221 = function(f) { return tu.right_function[f]; },
-        peg$c222 = function(f) { return tu.hline_function[f]; },
-        peg$c223 = function(f) { return tu.color_function[f]; },
-        peg$c224 = function(f, cs) { return f + " " + cs; },
-        peg$c225 = function(f) { return tu.definecolor_function[f]; },
-        peg$c226 = "named",
-        peg$c227 = peg$literalExpectation("named", true),
-        peg$c228 = function(f, name, cs) { return "{named}" + cs; },
-        peg$c229 = "gray",
-        peg$c230 = peg$literalExpectation("gray", true),
-        peg$c231 = function(f, name, cs) { return "{gray}" + cs; },
-        peg$c232 = "rgb",
-        peg$c233 = peg$literalExpectation("rgb", false),
-        peg$c234 = function(f, name, cs) { return "{rgb}" + cs; },
-        peg$c235 = "RGB",
-        peg$c236 = peg$literalExpectation("RGB", false),
-        peg$c237 = "cmyk",
-        peg$c238 = peg$literalExpectation("cmyk", true),
-        peg$c239 = function(f, name, cs) { return "{cmyk}" + cs; },
-        peg$c240 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
-        peg$c241 = function(cs) { return "[named]" + cs; },
-        peg$c242 = function(cs) { return "[gray]" + cs; },
-        peg$c243 = function(cs) { return "[rgb]" + cs; },
-        peg$c244 = function(cs) { return "[cmyk]" + cs; },
-        peg$c245 = function(name) { return "{" + name.join('') + "}"; },
-        peg$c246 = function(k) { return "{"+k+"}"; },
-        peg$c247 = ",",
-        peg$c248 = peg$literalExpectation(",", false),
-        peg$c249 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
-        peg$c250 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
-        peg$c251 = "0",
-        peg$c252 = peg$literalExpectation("0", false),
-        peg$c253 = /^[1-9]/,
-        peg$c254 = peg$classExpectation([["1", "9"]], false, false),
-        peg$c255 = function(n) { return parseInt(n, 10) <= 255; },
-        peg$c256 = function(n) { return n / 255; },
-        peg$c257 = ".",
-        peg$c258 = peg$literalExpectation(".", false),
-        peg$c259 = function(n) { return n; },
-        peg$c260 = /^[01]/,
-        peg$c261 = peg$classExpectation(["0", "1"], false, false),
-        peg$c262 = function() { return false; },
-        peg$c263 = function() { return peg$currPos === input.length; },
-        peg$c264 = function(f) { return tu.mhchem_single_macro[f]; },
-        peg$c265 = /^[+-.*']/,
-        peg$c266 = peg$classExpectation([["+", "."], "*", "'"], false, false),
-        peg$c267 = "=",
-        peg$c268 = peg$literalExpectation("=", false),
-        peg$c269 = "#",
-        peg$c270 = peg$literalExpectation("#", false),
-        peg$c271 = "~--",
-        peg$c272 = peg$literalExpectation("~--", false),
-        peg$c273 = "~-",
-        peg$c274 = peg$literalExpectation("~-", false),
-        peg$c275 = "~=",
-        peg$c276 = peg$literalExpectation("~=", false),
-        peg$c277 = "~",
-        peg$c278 = peg$literalExpectation("~", false),
-        peg$c279 = "-~-",
-        peg$c280 = peg$literalExpectation("-~-", false),
-        peg$c281 = "....",
-        peg$c282 = peg$literalExpectation("....", false),
-        peg$c283 = "...",
-        peg$c284 = peg$literalExpectation("...", false),
-        peg$c285 = "<-",
-        peg$c286 = peg$literalExpectation("<-", false),
-        peg$c287 = "->",
-        peg$c288 = peg$literalExpectation("->", false),
-        peg$c289 = "1",
-        peg$c290 = peg$literalExpectation("1", false),
-        peg$c291 = "2",
-        peg$c292 = peg$literalExpectation("2", false),
-        peg$c293 = "3",
-        peg$c294 = peg$literalExpectation("3", false),
-        peg$c295 = "\xA7",
-        peg$c296 = peg$literalExpectation("\xA7", false),
-        peg$c297 = function(f) { return tu.mhchem_bond[f]; },
-        peg$c298 = function(c) { return c; },
-        peg$c299 = "\\}",
-        peg$c300 = peg$literalExpectation("\\}", false),
-        peg$c301 = /^[+-=#().,;\/*<>|@&'[\]]/,
-        peg$c302 = peg$classExpectation([["+", "="], "#", "(", ")", ".", ",", ";", "/", "*", "<", ">", "|", "@", "&", "'", "[", "]"], false, false),
-        peg$c303 = function() { return "{}"; },
-        peg$c304 = function(f) { return tu.mhchem_macro_1p[f]; },
-        peg$c305 = function(f) { return tu.mhchem_macro_2p[f]; },
-        peg$c306 = function(f) { return tu.mhchem_macro_2pu[f]; },
+        peg$c175 = function(f) { return tu.fun_ar1nb[f]; },
+        peg$c176 = function(f) { return f; },
+        peg$c177 = function(f) { return tu.fun_ar1opt[f]; },
+        peg$c178 = "&",
+        peg$c179 = peg$literalExpectation("&", false),
+        peg$c180 = "\\\\",
+        peg$c181 = peg$literalExpectation("\\\\", false),
+        peg$c182 = "\\begin",
+        peg$c183 = peg$literalExpectation("\\begin", false),
+        peg$c184 = "\\end",
+        peg$c185 = peg$literalExpectation("\\end", false),
+        peg$c186 = "{matrix}",
+        peg$c187 = peg$literalExpectation("{matrix}", false),
+        peg$c188 = "{pmatrix}",
+        peg$c189 = peg$literalExpectation("{pmatrix}", false),
+        peg$c190 = "{bmatrix}",
+        peg$c191 = peg$literalExpectation("{bmatrix}", false),
+        peg$c192 = "{Bmatrix}",
+        peg$c193 = peg$literalExpectation("{Bmatrix}", false),
+        peg$c194 = "{vmatrix}",
+        peg$c195 = peg$literalExpectation("{vmatrix}", false),
+        peg$c196 = "{Vmatrix}",
+        peg$c197 = peg$literalExpectation("{Vmatrix}", false),
+        peg$c198 = "{array}",
+        peg$c199 = peg$literalExpectation("{array}", false),
+        peg$c200 = "{align}",
+        peg$c201 = peg$literalExpectation("{align}", false),
+        peg$c202 = "{aligned}",
+        peg$c203 = peg$literalExpectation("{aligned}", false),
+        peg$c204 = "{alignat}",
+        peg$c205 = peg$literalExpectation("{alignat}", false),
+        peg$c206 = "{alignedat}",
+        peg$c207 = peg$literalExpectation("{alignedat}", false),
+        peg$c208 = "{smallmatrix}",
+        peg$c209 = peg$literalExpectation("{smallmatrix}", false),
+        peg$c210 = "{cases}",
+        peg$c211 = peg$literalExpectation("{cases}", false),
+        peg$c212 = function(f) { return tu.big_literals[f]; },
+        peg$c213 = function(f) { return tu.fun_ar1[f]; },
+        peg$c214 = function(f) { return tu.other_fun_ar1[f]; },
+        peg$c215 = function(f) { return tu.fun_mhchem[f]; },
+        peg$c216 = function(f) { return tu.fun_ar2[f]; },
+        peg$c217 = function(f) { return tu.fun_infix[f]; },
+        peg$c218 = function(f) { return tu.declh_function[f]; },
+        peg$c219 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
+        peg$c220 = function(f) { return tu.fun_ar2nb[f]; },
+        peg$c221 = function(f) { return tu.left_function[f]; },
+        peg$c222 = function(f) { return tu.right_function[f]; },
+        peg$c223 = function(f) { return tu.hline_function[f]; },
+        peg$c224 = function(f) { return tu.color_function[f]; },
+        peg$c225 = function(f, cs) { return f + " " + cs; },
+        peg$c226 = function(f) { return tu.definecolor_function[f]; },
+        peg$c227 = "named",
+        peg$c228 = peg$literalExpectation("named", true),
+        peg$c229 = function(f, name, cs) { return "{named}" + cs; },
+        peg$c230 = "gray",
+        peg$c231 = peg$literalExpectation("gray", true),
+        peg$c232 = function(f, name, cs) { return "{gray}" + cs; },
+        peg$c233 = "rgb",
+        peg$c234 = peg$literalExpectation("rgb", false),
+        peg$c235 = function(f, name, cs) { return "{rgb}" + cs; },
+        peg$c236 = "RGB",
+        peg$c237 = peg$literalExpectation("RGB", false),
+        peg$c238 = "cmyk",
+        peg$c239 = peg$literalExpectation("cmyk", true),
+        peg$c240 = function(f, name, cs) { return "{cmyk}" + cs; },
+        peg$c241 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
+        peg$c242 = function(cs) { return "[named]" + cs; },
+        peg$c243 = function(cs) { return "[gray]" + cs; },
+        peg$c244 = function(cs) { return "[rgb]" + cs; },
+        peg$c245 = function(cs) { return "[cmyk]" + cs; },
+        peg$c246 = function(name) { return "{" + name.join('') + "}"; },
+        peg$c247 = function(k) { return "{"+k+"}"; },
+        peg$c248 = ",",
+        peg$c249 = peg$literalExpectation(",", false),
+        peg$c250 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
+        peg$c251 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
+        peg$c252 = "0",
+        peg$c253 = peg$literalExpectation("0", false),
+        peg$c254 = /^[1-9]/,
+        peg$c255 = peg$classExpectation([["1", "9"]], false, false),
+        peg$c256 = function(n) { return parseInt(n, 10) <= 255; },
+        peg$c257 = function(n) { return n / 255; },
+        peg$c258 = ".",
+        peg$c259 = peg$literalExpectation(".", false),
+        peg$c260 = function(n) { return n; },
+        peg$c261 = /^[01]/,
+        peg$c262 = peg$classExpectation(["0", "1"], false, false),
+        peg$c263 = function(f) { return tu.mhchem_single_macro[f]; },
+        peg$c264 = function(f) { return tu.mhchem_bond[f]; },
+        peg$c265 = function(f) { return tu.mhchem_macro_1p[f]; },
+        peg$c266 = function(f) { return tu.mhchem_macro_2p[f]; },
+        peg$c267 = function(f) { return tu.mhchem_macro_2pu[f]; },
+        peg$c268 = function(f) { return tu.mhchem_macro_2pc[f]; },
+        peg$c269 = /^[+-.*']/,
+        peg$c270 = peg$classExpectation([["+", "."], "*", "'"], false, false),
+        peg$c271 = "=",
+        peg$c272 = peg$literalExpectation("=", false),
+        peg$c273 = "#",
+        peg$c274 = peg$literalExpectation("#", false),
+        peg$c275 = "~--",
+        peg$c276 = peg$literalExpectation("~--", false),
+        peg$c277 = "~-",
+        peg$c278 = peg$literalExpectation("~-", false),
+        peg$c279 = "~=",
+        peg$c280 = peg$literalExpectation("~=", false),
+        peg$c281 = "~",
+        peg$c282 = peg$literalExpectation("~", false),
+        peg$c283 = "-~-",
+        peg$c284 = peg$literalExpectation("-~-", false),
+        peg$c285 = "....",
+        peg$c286 = peg$literalExpectation("....", false),
+        peg$c287 = "...",
+        peg$c288 = peg$literalExpectation("...", false),
+        peg$c289 = "<-",
+        peg$c290 = peg$literalExpectation("<-", false),
+        peg$c291 = "->",
+        peg$c292 = peg$literalExpectation("->", false),
+        peg$c293 = "1",
+        peg$c294 = peg$literalExpectation("1", false),
+        peg$c295 = "2",
+        peg$c296 = peg$literalExpectation("2", false),
+        peg$c297 = "3",
+        peg$c298 = peg$literalExpectation("3", false),
+        peg$c299 = "{math}",
+        peg$c300 = peg$literalExpectation("{math}", false),
+        peg$c301 = function(c) { return c; },
+        peg$c302 = "\\}",
+        peg$c303 = peg$literalExpectation("\\}", false),
+        peg$c304 = /^[+-=#().,;\/*<>|@&'[\]]/,
+        peg$c305 = peg$classExpectation([["+", "="], "#", "(", ")", ".", ",", ";", "/", "*", "<", ">", "|", "@", "&", "'", "[", "]"], false, false),
+        peg$c306 = function() { return "{}"; },
+        peg$c307 = function() { return false; },
+        peg$c308 = function() { return peg$currPos === input.length; },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -599,7 +601,7 @@ module.exports = /*
     function peg$parsestart() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 0,
+      var key    = peg$currPos * 124 + 0,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -633,7 +635,7 @@ module.exports = /*
     function peg$parse_() {
       var s0, s1;
 
-      var key    = peg$currPos * 123 + 1,
+      var key    = peg$currPos * 124 + 1,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -669,7 +671,7 @@ module.exports = /*
     function peg$parsetex_expr() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 123 + 2,
+      var key    = peg$currPos * 124 + 2,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -763,7 +765,7 @@ module.exports = /*
     function peg$parseexpr() {
       var s0, s1;
 
-      var key    = peg$currPos * 123 + 3,
+      var key    = peg$currPos * 124 + 3,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -791,7 +793,7 @@ module.exports = /*
     function peg$parsene_expr() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 4,
+      var key    = peg$currPos * 124 + 4,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -861,7 +863,7 @@ module.exports = /*
     function peg$parselitsq_aq() {
       var s0;
 
-      var key    = peg$currPos * 123 + 5,
+      var key    = peg$currPos * 124 + 5,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -889,7 +891,7 @@ module.exports = /*
     function peg$parselitsq_fq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 6,
+      var key    = peg$currPos * 124 + 6,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -953,7 +955,7 @@ module.exports = /*
     function peg$parselitsq_uq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 7,
+      var key    = peg$currPos * 124 + 7,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -993,7 +995,7 @@ module.exports = /*
     function peg$parselitsq_dq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 8,
+      var key    = peg$currPos * 124 + 8,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1033,7 +1035,7 @@ module.exports = /*
     function peg$parselitsq_zq() {
       var s0, s1;
 
-      var key    = peg$currPos * 123 + 9,
+      var key    = peg$currPos * 124 + 9,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1058,7 +1060,7 @@ module.exports = /*
     function peg$parseexpr_nosqc() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 10,
+      var key    = peg$currPos * 124 + 10,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1101,7 +1103,7 @@ module.exports = /*
     function peg$parselit_aq() {
       var s0;
 
-      var key    = peg$currPos * 123 + 11,
+      var key    = peg$currPos * 124 + 11,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1135,7 +1137,7 @@ module.exports = /*
     function peg$parselit_fq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 12,
+      var key    = peg$currPos * 124 + 12,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1223,7 +1225,7 @@ module.exports = /*
     function peg$parselit_uq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 13,
+      var key    = peg$currPos * 124 + 13,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1263,7 +1265,7 @@ module.exports = /*
     function peg$parselit_dq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 14,
+      var key    = peg$currPos * 124 + 14,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1303,7 +1305,7 @@ module.exports = /*
     function peg$parselit_uqn() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 15,
+      var key    = peg$currPos * 124 + 15,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1337,7 +1339,7 @@ module.exports = /*
     function peg$parselit_dqn() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 16,
+      var key    = peg$currPos * 124 + 16,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1371,7 +1373,7 @@ module.exports = /*
     function peg$parseleft() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 17,
+      var key    = peg$currPos * 124 + 17,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1423,7 +1425,7 @@ module.exports = /*
     function peg$parseright() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 18,
+      var key    = peg$currPos * 124 + 18,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1475,7 +1477,7 @@ module.exports = /*
     function peg$parselit() {
       var s0, s1, s2, s3, s4, s5;
 
-      var key    = peg$currPos * 123 + 19,
+      var key    = peg$currPos * 124 + 19,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2250,7 +2252,7 @@ module.exports = /*
     function peg$parsearray() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 20,
+      var key    = peg$currPos * 124 + 20,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2284,7 +2286,7 @@ module.exports = /*
     function peg$parsealignat() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 21,
+      var key    = peg$currPos * 124 + 21,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2318,7 +2320,7 @@ module.exports = /*
     function peg$parsematrix() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 123 + 22,
+      var key    = peg$currPos * 124 + 22,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2370,7 +2372,7 @@ module.exports = /*
     function peg$parseline_start() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 23,
+      var key    = peg$currPos * 124 + 23,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2407,7 +2409,7 @@ module.exports = /*
     function peg$parseline() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 123 + 24,
+      var key    = peg$currPos * 124 + 24,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2459,7 +2461,7 @@ module.exports = /*
     function peg$parsecolumn_spec() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 123 + 25,
+      var key    = peg$currPos * 124 + 25,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2514,7 +2516,7 @@ module.exports = /*
     function peg$parseone_col() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-      var key    = peg$currPos * 123 + 26,
+      var key    = peg$currPos * 124 + 26,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2793,7 +2795,7 @@ module.exports = /*
     function peg$parsealignat_spec() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 123 + 27,
+      var key    = peg$currPos * 124 + 27,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2866,7 +2868,7 @@ module.exports = /*
     function peg$parseopt_pos() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 123 + 28,
+      var key    = peg$currPos * 124 + 28,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2944,7 +2946,7 @@ module.exports = /*
     function peg$parsechem_lit() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 29,
+      var key    = peg$currPos * 124 + 29,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2984,7 +2986,7 @@ module.exports = /*
     function peg$parsechem_sentence() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 123 + 30,
+      var key    = peg$currPos * 124 + 30,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3060,7 +3062,7 @@ module.exports = /*
     function peg$parsechem_phrase() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 31,
+      var key    = peg$currPos * 124 + 31,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3140,9 +3142,9 @@ module.exports = /*
     }
 
     function peg$parsechem_word() {
-      var s0, s1, s2;
+      var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 32,
+      var key    = peg$currPos * 124 + 32,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3173,9 +3175,15 @@ module.exports = /*
         if (s1 !== peg$FAILED) {
           s2 = peg$parsechem_char_nl();
           if (s2 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c96(s1, s2);
-            s0 = s1;
+            s3 = peg$parsechem_word_nt();
+            if (s3 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c96(s1, s2, s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -3194,7 +3202,7 @@ module.exports = /*
     function peg$parsechem_word_nt() {
       var s0, s1;
 
-      var key    = peg$currPos * 123 + 33,
+      var key    = peg$currPos * 124 + 33,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3225,10 +3233,44 @@ module.exports = /*
       return s0;
     }
 
+    function peg$parsechem_char() {
+      var s0, s1;
+
+      var key    = peg$currPos * 124 + 34,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsechem_char_nl();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c98(s1);
+      }
+      s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseCHEM_LETTER();
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c99(s1);
+        }
+        s0 = s1;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
     function peg$parsechem_char_nl() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 34,
+      var key    = peg$currPos * 124 + 35,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3253,7 +3295,7 @@ module.exports = /*
             s3 = peg$parseCURLY_CLOSE();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c99(s2);
+              s1 = peg$c100(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3269,14 +3311,14 @@ module.exports = /*
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$parseCHEM_DOLLAR();
+          s1 = peg$parseBEGIN_MATH();
           if (s1 !== peg$FAILED) {
-            s2 = peg$parsechem_latex();
+            s2 = peg$parseexpr();
             if (s2 !== peg$FAILED) {
-              s3 = peg$parseCHEM_DOLLAR();
+              s3 = peg$parseEND_MATH();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c100(s2);
+                s1 = peg$c101(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3297,7 +3339,7 @@ module.exports = /*
               s2 = peg$parsechem_bond();
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c101(s1, s2);
+                s1 = peg$c102(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3320,7 +3362,7 @@ module.exports = /*
                 s1 = peg$parseCHEM_NONLETTER();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c102(s1);
+                  s1 = peg$c99(s1);
                 }
                 s0 = s1;
               }
@@ -3334,44 +3376,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parsechem_char() {
-      var s0, s1;
-
-      var key    = peg$currPos * 123 + 35,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      s1 = peg$parsechem_char_nl();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c98(s1);
-      }
-      s0 = s1;
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parseCHEM_LETTER();
-        if (s1 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c102(s1);
-        }
-        s0 = s1;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
     function peg$parsechem_bond() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 36,
+      var key    = peg$currPos * 124 + 36,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3411,7 +3419,7 @@ module.exports = /*
     function peg$parsechem_script() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 123 + 37,
+      var key    = peg$currPos * 124 + 37,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3457,11 +3465,11 @@ module.exports = /*
           s0 = peg$currPos;
           s1 = peg$parseCHEM_SUPERSUB();
           if (s1 !== peg$FAILED) {
-            s2 = peg$parseCHEM_DOLLAR();
+            s2 = peg$parseBEGIN_MATH();
             if (s2 !== peg$FAILED) {
-              s3 = peg$parsechem_latex();
+              s3 = peg$parseexpr();
               if (s3 !== peg$FAILED) {
-                s4 = peg$parseCHEM_DOLLAR();
+                s4 = peg$parseEND_MATH();
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
                   s1 = peg$c106(s1, s3);
@@ -3493,7 +3501,7 @@ module.exports = /*
     function peg$parsechem_macro() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 123 + 38,
+      var key    = peg$currPos * 124 + 38,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3538,9 +3546,9 @@ module.exports = /*
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parseCHEM_MACRO_2P();
+        s1 = peg$parseCHEM_MACRO_2PC();
         if (s1 !== peg$FAILED) {
-          s2 = peg$parsechem_lit();
+          s2 = peg$parseCOLOR_SPEC_NAMED();
           if (s2 !== peg$FAILED) {
             s3 = peg$parsechem_lit();
             if (s3 !== peg$FAILED) {
@@ -3561,13 +3569,19 @@ module.exports = /*
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$parseCHEM_MACRO_1P();
+          s1 = peg$parseCHEM_MACRO_2P();
           if (s1 !== peg$FAILED) {
             s2 = peg$parsechem_lit();
             if (s2 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c111(s1, s2);
-              s0 = s1;
+              s3 = peg$parsechem_lit();
+              if (s3 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c111(s1, s2, s3);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -3575,6 +3589,24 @@ module.exports = /*
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            s1 = peg$parseCHEM_MACRO_1P();
+            if (s1 !== peg$FAILED) {
+              s2 = peg$parsechem_lit();
+              if (s2 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c112(s1, s2);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
           }
         }
       }
@@ -3584,35 +3616,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parsechem_latex() {
-      var s0, s1;
-
-      var key    = peg$currPos * 123 + 39,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      s1 = peg$parseexpr();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c3(s1);
-      }
-      s0 = s1;
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
     function peg$parsechem_text() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 40,
+      var key    = peg$currPos * 124 + 39,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3634,7 +3641,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c112(s1);
+        s1 = peg$c113(s1);
       }
       s0 = s1;
 
@@ -3646,7 +3653,7 @@ module.exports = /*
     function peg$parsealpha() {
       var s0;
 
-      var key    = peg$currPos * 123 + 41,
+      var key    = peg$currPos * 124 + 40,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3655,12 +3662,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c113.test(input.charAt(peg$currPos))) {
+      if (peg$c114.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c114); }
+        if (peg$silentFails === 0) { peg$fail(peg$c115); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3671,7 +3678,7 @@ module.exports = /*
     function peg$parseliteral_id() {
       var s0;
 
-      var key    = peg$currPos * 123 + 42,
+      var key    = peg$currPos * 124 + 41,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3680,12 +3687,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c113.test(input.charAt(peg$currPos))) {
+      if (peg$c114.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c114); }
+        if (peg$silentFails === 0) { peg$fail(peg$c115); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3696,7 +3703,7 @@ module.exports = /*
     function peg$parseliteral_mn() {
       var s0;
 
-      var key    = peg$currPos * 123 + 43,
+      var key    = peg$currPos * 124 + 42,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3721,7 +3728,7 @@ module.exports = /*
     function peg$parseliteral_uf_lt() {
       var s0;
 
-      var key    = peg$currPos * 123 + 44,
+      var key    = peg$currPos * 124 + 43,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3730,12 +3737,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c115.test(input.charAt(peg$currPos))) {
+      if (peg$c116.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c116); }
+        if (peg$silentFails === 0) { peg$fail(peg$c117); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3746,7 +3753,7 @@ module.exports = /*
     function peg$parsedelimiter_uf_lt() {
       var s0;
 
-      var key    = peg$currPos * 123 + 45,
+      var key    = peg$currPos * 124 + 44,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3755,12 +3762,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c117.test(input.charAt(peg$currPos))) {
+      if (peg$c118.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c118); }
+        if (peg$silentFails === 0) { peg$fail(peg$c119); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3771,7 +3778,7 @@ module.exports = /*
     function peg$parseliteral_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 123 + 46,
+      var key    = peg$currPos * 124 + 45,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3780,12 +3787,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c119.test(input.charAt(peg$currPos))) {
+      if (peg$c120.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c120); }
+        if (peg$silentFails === 0) { peg$fail(peg$c121); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3796,7 +3803,7 @@ module.exports = /*
     function peg$parsedelimiter_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 123 + 47,
+      var key    = peg$currPos * 124 + 46,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3805,12 +3812,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c121.test(input.charAt(peg$currPos))) {
+      if (peg$c122.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c122); }
+        if (peg$silentFails === 0) { peg$fail(peg$c123); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3821,7 +3828,7 @@ module.exports = /*
     function peg$parseboxchars() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 48,
+      var key    = peg$currPos * 124 + 47,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3830,33 +3837,33 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c123.test(input.charAt(peg$currPos))) {
+      if (peg$c124.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c124); }
+        if (peg$silentFails === 0) { peg$fail(peg$c125); }
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (peg$c125.test(input.charAt(peg$currPos))) {
+        if (peg$c126.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c126); }
+          if (peg$silentFails === 0) { peg$fail(peg$c127); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c127.test(input.charAt(peg$currPos))) {
+          if (peg$c128.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c128); }
+            if (peg$silentFails === 0) { peg$fail(peg$c129); }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c129(s1, s2);
+            s1 = peg$c130(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3876,7 +3883,7 @@ module.exports = /*
     function peg$parseBOX() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
-      var key    = peg$currPos * 123 + 49,
+      var key    = peg$currPos * 124 + 48,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3889,7 +3896,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c130(s1);
+        s2 = peg$c131(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -3899,11 +3906,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c131;
+              s4 = peg$c132;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c132); }
+              if (peg$silentFails === 0) { peg$fail(peg$c133); }
             }
             if (s4 !== peg$FAILED) {
               s5 = [];
@@ -3928,7 +3935,7 @@ module.exports = /*
                   s7 = peg$parse_();
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c133(s1, s5);
+                    s1 = peg$c134(s1, s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3967,7 +3974,7 @@ module.exports = /*
     function peg$parseLITERAL() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-      var key    = peg$currPos * 123 + 50,
+      var key    = peg$currPos * 124 + 49,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3984,11 +3991,11 @@ module.exports = /*
           s1 = peg$parseliteral_uf_lt();
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 45) {
-              s1 = peg$c134;
+              s1 = peg$c135;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c135); }
+              if (peg$silentFails === 0) { peg$fail(peg$c136); }
             }
             if (s1 === peg$FAILED) {
               s1 = peg$parseliteral_uf_op();
@@ -4000,7 +4007,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c136(s1);
+          s1 = peg$c137(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4015,7 +4022,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c137(s1);
+          s2 = peg$c138(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -4025,11 +4032,11 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s4 = peg$c138;
+                s4 = peg$c139;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c139); }
+                if (peg$silentFails === 0) { peg$fail(peg$c140); }
               }
               if (s4 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 91) {
@@ -4040,19 +4047,19 @@ module.exports = /*
                   if (peg$silentFails === 0) { peg$fail(peg$c79); }
                 }
                 if (s4 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c140) {
-                    s4 = peg$c140;
+                  if (input.substr(peg$currPos, 2) === peg$c141) {
+                    s4 = peg$c141;
                     peg$currPos += 2;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c141); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c142); }
                   }
                   if (s4 === peg$FAILED) {
                     s4 = peg$currPos;
                     s5 = peg$c6;
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s4;
-                      s5 = peg$c142(s1);
+                      s5 = peg$c143(s1);
                     }
                     s4 = s5;
                   }
@@ -4062,7 +4069,7 @@ module.exports = /*
                 s5 = peg$parse_();
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c143(s1, s4);
+                  s1 = peg$c144(s1, s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4089,7 +4096,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c144(s1);
+            s2 = peg$c145(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -4099,11 +4106,11 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s4 = peg$c138;
+                  s4 = peg$c139;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c139); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c140); }
                 }
                 if (s4 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 91) {
@@ -4114,19 +4121,19 @@ module.exports = /*
                     if (peg$silentFails === 0) { peg$fail(peg$c79); }
                   }
                   if (s4 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 2) === peg$c140) {
-                      s4 = peg$c140;
+                    if (input.substr(peg$currPos, 2) === peg$c141) {
+                      s4 = peg$c141;
                       peg$currPos += 2;
                     } else {
                       s4 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c142); }
                     }
                     if (s4 === peg$FAILED) {
                       s4 = peg$currPos;
                       s5 = peg$c6;
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s4;
-                        s5 = peg$c142(s1);
+                        s5 = peg$c143(s1);
                       }
                       s4 = s5;
                     }
@@ -4136,7 +4143,7 @@ module.exports = /*
                   s5 = peg$parse_();
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c145(s1, s4);
+                    s1 = peg$c146(s1, s4);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4163,7 +4170,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c146(s1);
+              s2 = peg$c147(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -4173,7 +4180,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c147(s1);
+                  s1 = peg$c148(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4192,7 +4199,7 @@ module.exports = /*
               s1 = peg$parsegeneric_func();
               if (s1 !== peg$FAILED) {
                 peg$savedPos = peg$currPos;
-                s2 = peg$c148(s1);
+                s2 = peg$c149(s1);
                 if (s2) {
                   s2 = void 0;
                 } else {
@@ -4202,7 +4209,7 @@ module.exports = /*
                   s3 = peg$parse_();
                   if (s3 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c149(s1);
+                    s1 = peg$c150(s1);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4221,7 +4228,7 @@ module.exports = /*
                 s1 = peg$parsegeneric_func();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = peg$currPos;
-                  s2 = peg$c150(s1);
+                  s2 = peg$c151(s1);
                   if (s2) {
                     s2 = void 0;
                   } else {
@@ -4231,17 +4238,17 @@ module.exports = /*
                     s3 = peg$parse_();
                     if (s3 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 123) {
-                        s4 = peg$c131;
+                        s4 = peg$c132;
                         peg$currPos++;
                       } else {
                         s4 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c132); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c133); }
                       }
                       if (s4 !== peg$FAILED) {
                         s5 = peg$parsegeneric_func();
                         if (s5 !== peg$FAILED) {
                           peg$savedPos = peg$currPos;
-                          s6 = peg$c151(s1, s5);
+                          s6 = peg$c152(s1, s5);
                           if (s6) {
                             s6 = void 0;
                           } else {
@@ -4261,7 +4268,7 @@ module.exports = /*
                                 s9 = peg$parse_();
                                 if (s9 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c152(s1, s5);
+                                  s1 = peg$c153(s1, s5);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -4304,7 +4311,7 @@ module.exports = /*
                   s1 = peg$parsegeneric_func();
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = peg$currPos;
-                    s2 = peg$c153(s1);
+                    s2 = peg$c154(s1);
                     if (s2) {
                       s2 = void 0;
                     } else {
@@ -4314,7 +4321,7 @@ module.exports = /*
                       s3 = peg$parse_();
                       if (s3 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c154(s1);
+                        s1 = peg$c155(s1);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -4333,7 +4340,7 @@ module.exports = /*
                     s1 = peg$parsegeneric_func();
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = peg$currPos;
-                      s2 = peg$c155(s1);
+                      s2 = peg$c156(s1);
                       if (s2) {
                         s2 = void 0;
                       } else {
@@ -4343,17 +4350,17 @@ module.exports = /*
                         s3 = peg$parse_();
                         if (s3 !== peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 123) {
-                            s4 = peg$c131;
+                            s4 = peg$c132;
                             peg$currPos++;
                           } else {
                             s4 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c132); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c133); }
                           }
                           if (s4 !== peg$FAILED) {
                             s5 = peg$parsegeneric_func();
                             if (s5 !== peg$FAILED) {
                               peg$savedPos = peg$currPos;
-                              s6 = peg$c156(s1, s5);
+                              s6 = peg$c157(s1, s5);
                               if (s6) {
                                 s6 = void 0;
                               } else {
@@ -4373,7 +4380,7 @@ module.exports = /*
                                     s9 = peg$parse_();
                                     if (s9 !== peg$FAILED) {
                                       peg$savedPos = s0;
-                                      s1 = peg$c157(s1, s5);
+                                      s1 = peg$c158(s1, s5);
                                       s0 = s1;
                                     } else {
                                       peg$currPos = s0;
@@ -4419,31 +4426,31 @@ module.exports = /*
                       }
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c158(s1);
+                        s1 = peg$c159(s1);
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
                         if (input.charCodeAt(peg$currPos) === 92) {
-                          s1 = peg$c159;
+                          s1 = peg$c160;
                           peg$currPos++;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c160); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c161); }
                         }
                         if (s1 !== peg$FAILED) {
-                          if (peg$c161.test(input.charAt(peg$currPos))) {
+                          if (peg$c162.test(input.charAt(peg$currPos))) {
                             s2 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s2 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c162); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c163); }
                           }
                           if (s2 !== peg$FAILED) {
                             s3 = peg$parse_();
                             if (s3 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c163(s2);
+                              s1 = peg$c164(s2);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -4459,18 +4466,18 @@ module.exports = /*
                         }
                         if (s0 === peg$FAILED) {
                           s0 = peg$currPos;
-                          if (peg$c164.test(input.charAt(peg$currPos))) {
+                          if (peg$c165.test(input.charAt(peg$currPos))) {
                             s1 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c165); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c166); }
                           }
                           if (s1 !== peg$FAILED) {
                             s2 = peg$parse_();
                             if (s2 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c136(s1);
+                              s1 = peg$c137(s1);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -4482,18 +4489,18 @@ module.exports = /*
                           }
                           if (s0 === peg$FAILED) {
                             s0 = peg$currPos;
-                            if (peg$c166.test(input.charAt(peg$currPos))) {
+                            if (peg$c167.test(input.charAt(peg$currPos))) {
                               s1 = input.charAt(peg$currPos);
                               peg$currPos++;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c167); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c168); }
                             }
                             if (s1 !== peg$FAILED) {
                               s2 = peg$parse_();
                               if (s2 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c168(s1);
+                                s1 = peg$c169(s1);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -4523,7 +4530,7 @@ module.exports = /*
     function peg$parseDELIMITER() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 51,
+      var key    = peg$currPos * 124 + 50,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4550,7 +4557,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c136(s1);
+          s1 = peg$c137(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4563,25 +4570,25 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c159;
+          s1 = peg$c160;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c160); }
+          if (peg$silentFails === 0) { peg$fail(peg$c161); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c169.test(input.charAt(peg$currPos))) {
+          if (peg$c170.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c170); }
+            if (peg$silentFails === 0) { peg$fail(peg$c171); }
           }
           if (s2 !== peg$FAILED) {
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c163(s2);
+              s1 = peg$c164(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4600,7 +4607,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c171(s1);
+            s2 = peg$c172(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -4610,7 +4617,7 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c147(s1);
+                s1 = peg$c148(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4629,7 +4636,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c172(s1);
+              s2 = peg$c173(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -4639,7 +4646,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c173(s1);
+                  s1 = peg$c174(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4665,7 +4672,7 @@ module.exports = /*
     function peg$parseFUN_AR1nb() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 52,
+      var key    = peg$currPos * 124 + 51,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4678,7 +4685,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c174(s1);
+        s2 = peg$c175(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -4688,7 +4695,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c175(s1);
+            s1 = peg$c176(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4711,7 +4718,7 @@ module.exports = /*
     function peg$parseFUN_AR1opt() {
       var s0, s1, s2, s3, s4, s5;
 
-      var key    = peg$currPos * 123 + 53,
+      var key    = peg$currPos * 124 + 52,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4724,7 +4731,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c176(s1);
+        s2 = peg$c177(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -4744,7 +4751,7 @@ module.exports = /*
               s5 = peg$parse_();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c175(s1);
+                s1 = peg$c176(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4775,7 +4782,7 @@ module.exports = /*
     function peg$parseNEXT_CELL() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 54,
+      var key    = peg$currPos * 124 + 53,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4786,11 +4793,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 38) {
-        s1 = peg$c177;
+        s1 = peg$c178;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c178); }
+        if (peg$silentFails === 0) { peg$fail(peg$c179); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4814,7 +4821,7 @@ module.exports = /*
     function peg$parseNEXT_ROW() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 55,
+      var key    = peg$currPos * 124 + 54,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4824,12 +4831,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c179) {
-        s1 = peg$c179;
+      if (input.substr(peg$currPos, 2) === peg$c180) {
+        s1 = peg$c180;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c180); }
+        if (peg$silentFails === 0) { peg$fail(peg$c181); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4853,7 +4860,7 @@ module.exports = /*
     function peg$parseBEGIN() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 56,
+      var key    = peg$currPos * 124 + 55,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4863,12 +4870,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c181) {
-        s1 = peg$c181;
+      if (input.substr(peg$currPos, 6) === peg$c182) {
+        s1 = peg$c182;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c182); }
+        if (peg$silentFails === 0) { peg$fail(peg$c183); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4892,7 +4899,7 @@ module.exports = /*
     function peg$parseEND() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 57,
+      var key    = peg$currPos * 124 + 56,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4902,12 +4909,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c183) {
-        s1 = peg$c183;
+      if (input.substr(peg$currPos, 4) === peg$c184) {
+        s1 = peg$c184;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c184); }
+        if (peg$silentFails === 0) { peg$fail(peg$c185); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4931,7 +4938,7 @@ module.exports = /*
     function peg$parseBEGIN_MATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 58,
+      var key    = peg$currPos * 124 + 57,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4943,12 +4950,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c185) {
-          s2 = peg$c185;
+        if (input.substr(peg$currPos, 8) === peg$c186) {
+          s2 = peg$c186;
           peg$currPos += 8;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c186); }
+          if (peg$silentFails === 0) { peg$fail(peg$c187); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4976,7 +4983,7 @@ module.exports = /*
     function peg$parseEND_MATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 59,
+      var key    = peg$currPos * 124 + 58,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4988,12 +4995,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c185) {
-          s2 = peg$c185;
+        if (input.substr(peg$currPos, 8) === peg$c186) {
+          s2 = peg$c186;
           peg$currPos += 8;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c186); }
+          if (peg$silentFails === 0) { peg$fail(peg$c187); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5021,7 +5028,7 @@ module.exports = /*
     function peg$parseBEGIN_PMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 60,
+      var key    = peg$currPos * 124 + 59,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5033,12 +5040,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c187) {
-          s2 = peg$c187;
+        if (input.substr(peg$currPos, 9) === peg$c188) {
+          s2 = peg$c188;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c188); }
+          if (peg$silentFails === 0) { peg$fail(peg$c189); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5066,7 +5073,7 @@ module.exports = /*
     function peg$parseEND_PMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 61,
+      var key    = peg$currPos * 124 + 60,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5078,12 +5085,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c187) {
-          s2 = peg$c187;
+        if (input.substr(peg$currPos, 9) === peg$c188) {
+          s2 = peg$c188;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c188); }
+          if (peg$silentFails === 0) { peg$fail(peg$c189); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5111,7 +5118,7 @@ module.exports = /*
     function peg$parseBEGIN_BMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 62,
+      var key    = peg$currPos * 124 + 61,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5123,12 +5130,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c189) {
-          s2 = peg$c189;
+        if (input.substr(peg$currPos, 9) === peg$c190) {
+          s2 = peg$c190;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c190); }
+          if (peg$silentFails === 0) { peg$fail(peg$c191); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5156,7 +5163,7 @@ module.exports = /*
     function peg$parseEND_BMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 63,
+      var key    = peg$currPos * 124 + 62,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5168,12 +5175,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c189) {
-          s2 = peg$c189;
+        if (input.substr(peg$currPos, 9) === peg$c190) {
+          s2 = peg$c190;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c190); }
+          if (peg$silentFails === 0) { peg$fail(peg$c191); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5201,7 +5208,7 @@ module.exports = /*
     function peg$parseBEGIN_BBMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 64,
+      var key    = peg$currPos * 124 + 63,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5213,12 +5220,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c191) {
-          s2 = peg$c191;
+        if (input.substr(peg$currPos, 9) === peg$c192) {
+          s2 = peg$c192;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c192); }
+          if (peg$silentFails === 0) { peg$fail(peg$c193); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5246,7 +5253,7 @@ module.exports = /*
     function peg$parseEND_BBMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 65,
+      var key    = peg$currPos * 124 + 64,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5258,12 +5265,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c191) {
-          s2 = peg$c191;
+        if (input.substr(peg$currPos, 9) === peg$c192) {
+          s2 = peg$c192;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c192); }
+          if (peg$silentFails === 0) { peg$fail(peg$c193); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5291,7 +5298,7 @@ module.exports = /*
     function peg$parseBEGIN_VMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 66,
+      var key    = peg$currPos * 124 + 65,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5303,12 +5310,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c193) {
-          s2 = peg$c193;
+        if (input.substr(peg$currPos, 9) === peg$c194) {
+          s2 = peg$c194;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c194); }
+          if (peg$silentFails === 0) { peg$fail(peg$c195); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5336,7 +5343,7 @@ module.exports = /*
     function peg$parseEND_VMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 67,
+      var key    = peg$currPos * 124 + 66,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5348,12 +5355,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c193) {
-          s2 = peg$c193;
+        if (input.substr(peg$currPos, 9) === peg$c194) {
+          s2 = peg$c194;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c194); }
+          if (peg$silentFails === 0) { peg$fail(peg$c195); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5381,7 +5388,7 @@ module.exports = /*
     function peg$parseBEGIN_VVMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 68,
+      var key    = peg$currPos * 124 + 67,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5393,12 +5400,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c195) {
-          s2 = peg$c195;
+        if (input.substr(peg$currPos, 9) === peg$c196) {
+          s2 = peg$c196;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c196); }
+          if (peg$silentFails === 0) { peg$fail(peg$c197); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5426,7 +5433,7 @@ module.exports = /*
     function peg$parseEND_VVMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 69,
+      var key    = peg$currPos * 124 + 68,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5438,12 +5445,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c195) {
-          s2 = peg$c195;
+        if (input.substr(peg$currPos, 9) === peg$c196) {
+          s2 = peg$c196;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c196); }
+          if (peg$silentFails === 0) { peg$fail(peg$c197); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5471,7 +5478,7 @@ module.exports = /*
     function peg$parseBEGIN_ARRAY() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 70,
+      var key    = peg$currPos * 124 + 69,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5483,12 +5490,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c197) {
-          s2 = peg$c197;
+        if (input.substr(peg$currPos, 7) === peg$c198) {
+          s2 = peg$c198;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c198); }
+          if (peg$silentFails === 0) { peg$fail(peg$c199); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5516,7 +5523,7 @@ module.exports = /*
     function peg$parseEND_ARRAY() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 71,
+      var key    = peg$currPos * 124 + 70,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5528,12 +5535,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c197) {
-          s2 = peg$c197;
+        if (input.substr(peg$currPos, 7) === peg$c198) {
+          s2 = peg$c198;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c198); }
+          if (peg$silentFails === 0) { peg$fail(peg$c199); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5561,7 +5568,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGN() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 72,
+      var key    = peg$currPos * 124 + 71,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5573,12 +5580,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c199) {
-          s2 = peg$c199;
+        if (input.substr(peg$currPos, 7) === peg$c200) {
+          s2 = peg$c200;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c200); }
+          if (peg$silentFails === 0) { peg$fail(peg$c201); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5606,7 +5613,7 @@ module.exports = /*
     function peg$parseEND_ALIGN() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 73,
+      var key    = peg$currPos * 124 + 72,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5618,12 +5625,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c199) {
-          s2 = peg$c199;
+        if (input.substr(peg$currPos, 7) === peg$c200) {
+          s2 = peg$c200;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c200); }
+          if (peg$silentFails === 0) { peg$fail(peg$c201); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5651,7 +5658,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNED() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 74,
+      var key    = peg$currPos * 124 + 73,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5663,12 +5670,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c201) {
-          s2 = peg$c201;
+        if (input.substr(peg$currPos, 9) === peg$c202) {
+          s2 = peg$c202;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c202); }
+          if (peg$silentFails === 0) { peg$fail(peg$c203); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5696,7 +5703,7 @@ module.exports = /*
     function peg$parseEND_ALIGNED() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 75,
+      var key    = peg$currPos * 124 + 74,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5708,12 +5715,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c201) {
-          s2 = peg$c201;
+        if (input.substr(peg$currPos, 9) === peg$c202) {
+          s2 = peg$c202;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c202); }
+          if (peg$silentFails === 0) { peg$fail(peg$c203); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5741,7 +5748,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 76,
+      var key    = peg$currPos * 124 + 75,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5753,12 +5760,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c203) {
-          s2 = peg$c203;
+        if (input.substr(peg$currPos, 9) === peg$c204) {
+          s2 = peg$c204;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c204); }
+          if (peg$silentFails === 0) { peg$fail(peg$c205); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5786,7 +5793,7 @@ module.exports = /*
     function peg$parseEND_ALIGNAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 77,
+      var key    = peg$currPos * 124 + 76,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5798,12 +5805,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c203) {
-          s2 = peg$c203;
+        if (input.substr(peg$currPos, 9) === peg$c204) {
+          s2 = peg$c204;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c204); }
+          if (peg$silentFails === 0) { peg$fail(peg$c205); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5831,7 +5838,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNEDAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 78,
+      var key    = peg$currPos * 124 + 77,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5843,12 +5850,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c205) {
-          s2 = peg$c205;
+        if (input.substr(peg$currPos, 11) === peg$c206) {
+          s2 = peg$c206;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c206); }
+          if (peg$silentFails === 0) { peg$fail(peg$c207); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5876,7 +5883,7 @@ module.exports = /*
     function peg$parseEND_ALIGNEDAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 79,
+      var key    = peg$currPos * 124 + 78,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5888,12 +5895,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c205) {
-          s2 = peg$c205;
+        if (input.substr(peg$currPos, 11) === peg$c206) {
+          s2 = peg$c206;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c206); }
+          if (peg$silentFails === 0) { peg$fail(peg$c207); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5921,7 +5928,7 @@ module.exports = /*
     function peg$parseBEGIN_SMALLMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 80,
+      var key    = peg$currPos * 124 + 79,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5933,12 +5940,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c207) {
-          s2 = peg$c207;
+        if (input.substr(peg$currPos, 13) === peg$c208) {
+          s2 = peg$c208;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c208); }
+          if (peg$silentFails === 0) { peg$fail(peg$c209); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5966,7 +5973,7 @@ module.exports = /*
     function peg$parseEND_SMALLMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 81,
+      var key    = peg$currPos * 124 + 80,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5978,12 +5985,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c207) {
-          s2 = peg$c207;
+        if (input.substr(peg$currPos, 13) === peg$c208) {
+          s2 = peg$c208;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c208); }
+          if (peg$silentFails === 0) { peg$fail(peg$c209); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6011,7 +6018,7 @@ module.exports = /*
     function peg$parseBEGIN_CASES() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 82,
+      var key    = peg$currPos * 124 + 81,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6023,12 +6030,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c209) {
-          s2 = peg$c209;
+        if (input.substr(peg$currPos, 7) === peg$c210) {
+          s2 = peg$c210;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c210); }
+          if (peg$silentFails === 0) { peg$fail(peg$c211); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6056,7 +6063,7 @@ module.exports = /*
     function peg$parseEND_CASES() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 83,
+      var key    = peg$currPos * 124 + 82,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6068,12 +6075,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c209) {
-          s2 = peg$c209;
+        if (input.substr(peg$currPos, 7) === peg$c210) {
+          s2 = peg$c210;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c210); }
+          if (peg$silentFails === 0) { peg$fail(peg$c211); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6101,7 +6108,7 @@ module.exports = /*
     function peg$parseSQ_CLOSE() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 84,
+      var key    = peg$currPos * 124 + 83,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6140,7 +6147,7 @@ module.exports = /*
     function peg$parseCURLY_OPEN() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 85,
+      var key    = peg$currPos * 124 + 84,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6151,11 +6158,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c131;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c132); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6179,7 +6186,7 @@ module.exports = /*
     function peg$parseCURLY_CLOSE() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 86,
+      var key    = peg$currPos * 124 + 85,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6218,7 +6225,7 @@ module.exports = /*
     function peg$parseSUP() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 87,
+      var key    = peg$currPos * 124 + 86,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6257,7 +6264,7 @@ module.exports = /*
     function peg$parseSUB() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 88,
+      var key    = peg$currPos * 124 + 87,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6296,7 +6303,7 @@ module.exports = /*
     function peg$parsegeneric_func() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 89,
+      var key    = peg$currPos * 124 + 88,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6307,11 +6314,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c159;
+        s1 = peg$c160;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c160); }
+        if (peg$silentFails === 0) { peg$fail(peg$c161); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -6345,53 +6352,7 @@ module.exports = /*
     function peg$parseBIG() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 90,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      s1 = peg$parsegeneric_func();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = peg$currPos;
-        s2 = peg$c211(s1);
-        if (s2) {
-          s2 = void 0;
-        } else {
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c175(s1);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseFUN_AR1() {
-      var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 123 + 91,
+      var key    = peg$currPos * 124 + 89,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6414,7 +6375,53 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c175(s1);
+            s1 = peg$c176(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseFUN_AR1() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 124 + 90,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c213(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c176(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6433,7 +6440,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c213(s1);
+          s2 = peg$c214(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -6443,7 +6450,7 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c213(s1);
+              s1 = peg$c214(s1);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6467,53 +6474,7 @@ module.exports = /*
     function peg$parseFUN_MHCHEM() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 92,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      s1 = peg$parsegeneric_func();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = peg$currPos;
-        s2 = peg$c214(s1);
-        if (s2) {
-          s2 = void 0;
-        } else {
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c175(s1);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseFUN_AR2() {
-      var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 123 + 93,
+      var key    = peg$currPos * 124 + 91,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6536,7 +6497,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c175(s1);
+            s1 = peg$c176(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6556,10 +6517,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseFUN_INFIX() {
+    function peg$parseFUN_AR2() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 94,
+      var key    = peg$currPos * 124 + 92,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6582,7 +6543,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c175(s1);
+            s1 = peg$c176(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6602,10 +6563,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseDECLh() {
+    function peg$parseFUN_INFIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 95,
+      var key    = peg$currPos * 124 + 93,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6628,7 +6589,53 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c218(s1);
+            s1 = peg$c176(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseDECLh() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 124 + 94,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c218(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c219(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6651,7 +6658,7 @@ module.exports = /*
     function peg$parseFUN_AR2nb() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 96,
+      var key    = peg$currPos * 124 + 95,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6664,7 +6671,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c219(s1);
+        s2 = peg$c220(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6674,7 +6681,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c175(s1);
+            s1 = peg$c176(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6697,52 +6704,7 @@ module.exports = /*
     function peg$parseLEFT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 97,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      s1 = peg$parsegeneric_func();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = peg$currPos;
-        s2 = peg$c220(s1);
-        if (s2) {
-          s2 = void 0;
-        } else {
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            s1 = [s1, s2, s3];
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseRIGHT() {
-      var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 123 + 98,
+      var key    = peg$currPos * 124 + 96,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6784,10 +6746,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseHLINE() {
+    function peg$parseRIGHT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 99,
+      var key    = peg$currPos * 124 + 97,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6809,8 +6771,53 @@ module.exports = /*
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
+            s1 = [s1, s2, s3];
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseHLINE() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 124 + 98,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c223(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c175(s1);
+            s1 = peg$c176(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6833,7 +6840,7 @@ module.exports = /*
     function peg$parseCOLOR() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 123 + 100,
+      var key    = peg$currPos * 124 + 99,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6846,7 +6853,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c223(s1);
+        s2 = peg$c224(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6858,7 +6865,7 @@ module.exports = /*
             s4 = peg$parseCOLOR_SPEC();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c224(s1, s4);
+              s1 = peg$c225(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6885,7 +6892,7 @@ module.exports = /*
     function peg$parseDEFINECOLOR() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17;
 
-      var key    = peg$currPos * 123 + 101,
+      var key    = peg$currPos * 124 + 100,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6898,7 +6905,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c225(s1);
+        s2 = peg$c226(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6908,11 +6915,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c131;
+              s4 = peg$c132;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c132); }
+              if (peg$silentFails === 0) { peg$fail(peg$c133); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -6941,22 +6948,22 @@ module.exports = /*
                       s9 = peg$parse_();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 123) {
-                          s10 = peg$c131;
+                          s10 = peg$c132;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c132); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c133); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             s12 = peg$currPos;
-                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c226) {
+                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c227) {
                               s13 = input.substr(peg$currPos, 5);
                               peg$currPos += 5;
                             } else {
                               s13 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c227); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c228); }
                             }
                             if (s13 !== peg$FAILED) {
                               s14 = peg$parse_();
@@ -6974,7 +6981,7 @@ module.exports = /*
                                     s17 = peg$parseCOLOR_SPEC_NAMED();
                                     if (s17 !== peg$FAILED) {
                                       peg$savedPos = s12;
-                                      s13 = peg$c228(s1, s6, s17);
+                                      s13 = peg$c229(s1, s6, s17);
                                       s12 = s13;
                                     } else {
                                       peg$currPos = s12;
@@ -6998,12 +7005,12 @@ module.exports = /*
                             }
                             if (s12 === peg$FAILED) {
                               s12 = peg$currPos;
-                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c229) {
+                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c230) {
                                 s13 = input.substr(peg$currPos, 4);
                                 peg$currPos += 4;
                               } else {
                                 s13 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c230); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c231); }
                               }
                               if (s13 !== peg$FAILED) {
                                 s14 = peg$parse_();
@@ -7021,7 +7028,7 @@ module.exports = /*
                                       s17 = peg$parseCOLOR_SPEC_GRAY();
                                       if (s17 !== peg$FAILED) {
                                         peg$savedPos = s12;
-                                        s13 = peg$c231(s1, s6, s17);
+                                        s13 = peg$c232(s1, s6, s17);
                                         s12 = s13;
                                       } else {
                                         peg$currPos = s12;
@@ -7045,12 +7052,12 @@ module.exports = /*
                               }
                               if (s12 === peg$FAILED) {
                                 s12 = peg$currPos;
-                                if (input.substr(peg$currPos, 3) === peg$c232) {
-                                  s13 = peg$c232;
+                                if (input.substr(peg$currPos, 3) === peg$c233) {
+                                  s13 = peg$c233;
                                   peg$currPos += 3;
                                 } else {
                                   s13 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c233); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c234); }
                                 }
                                 if (s13 !== peg$FAILED) {
                                   s14 = peg$parse_();
@@ -7068,7 +7075,7 @@ module.exports = /*
                                         s17 = peg$parseCOLOR_SPEC_rgb();
                                         if (s17 !== peg$FAILED) {
                                           peg$savedPos = s12;
-                                          s13 = peg$c234(s1, s6, s17);
+                                          s13 = peg$c235(s1, s6, s17);
                                           s12 = s13;
                                         } else {
                                           peg$currPos = s12;
@@ -7092,12 +7099,12 @@ module.exports = /*
                                 }
                                 if (s12 === peg$FAILED) {
                                   s12 = peg$currPos;
-                                  if (input.substr(peg$currPos, 3) === peg$c235) {
-                                    s13 = peg$c235;
+                                  if (input.substr(peg$currPos, 3) === peg$c236) {
+                                    s13 = peg$c236;
                                     peg$currPos += 3;
                                   } else {
                                     s13 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c236); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c237); }
                                   }
                                   if (s13 !== peg$FAILED) {
                                     s14 = peg$parse_();
@@ -7115,7 +7122,7 @@ module.exports = /*
                                           s17 = peg$parseCOLOR_SPEC_RGB();
                                           if (s17 !== peg$FAILED) {
                                             peg$savedPos = s12;
-                                            s13 = peg$c234(s1, s6, s17);
+                                            s13 = peg$c235(s1, s6, s17);
                                             s12 = s13;
                                           } else {
                                             peg$currPos = s12;
@@ -7139,12 +7146,12 @@ module.exports = /*
                                   }
                                   if (s12 === peg$FAILED) {
                                     s12 = peg$currPos;
-                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c237) {
+                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c238) {
                                       s13 = input.substr(peg$currPos, 4);
                                       peg$currPos += 4;
                                     } else {
                                       s13 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c239); }
                                     }
                                     if (s13 !== peg$FAILED) {
                                       s14 = peg$parse_();
@@ -7162,7 +7169,7 @@ module.exports = /*
                                             s17 = peg$parseCOLOR_SPEC_CMYK();
                                             if (s17 !== peg$FAILED) {
                                               peg$savedPos = s12;
-                                              s13 = peg$c239(s1, s6, s17);
+                                              s13 = peg$c240(s1, s6, s17);
                                               s12 = s13;
                                             } else {
                                               peg$currPos = s12;
@@ -7190,7 +7197,7 @@ module.exports = /*
                             }
                             if (s12 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c240(s1, s6, s12);
+                              s1 = peg$c241(s1, s6, s12);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -7249,7 +7256,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
-      var key    = peg$currPos * 123 + 102,
+      var key    = peg$currPos * 124 + 101,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7271,12 +7278,12 @@ module.exports = /*
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c226) {
+            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c227) {
               s3 = input.substr(peg$currPos, 5);
               peg$currPos += 5;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c227); }
+              if (peg$silentFails === 0) { peg$fail(peg$c228); }
             }
             if (s3 !== peg$FAILED) {
               s4 = peg$parse_();
@@ -7294,7 +7301,7 @@ module.exports = /*
                     s7 = peg$parseCOLOR_SPEC_NAMED();
                     if (s7 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c241(s7);
+                      s1 = peg$c242(s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -7336,12 +7343,12 @@ module.exports = /*
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c229) {
+              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c230) {
                 s3 = input.substr(peg$currPos, 4);
                 peg$currPos += 4;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c230); }
+                if (peg$silentFails === 0) { peg$fail(peg$c231); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -7359,7 +7366,7 @@ module.exports = /*
                       s7 = peg$parseCOLOR_SPEC_GRAY();
                       if (s7 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c242(s7);
+                        s1 = peg$c243(s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -7401,12 +7408,12 @@ module.exports = /*
             if (s1 !== peg$FAILED) {
               s2 = peg$parse_();
               if (s2 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 3) === peg$c232) {
-                  s3 = peg$c232;
+                if (input.substr(peg$currPos, 3) === peg$c233) {
+                  s3 = peg$c233;
                   peg$currPos += 3;
                 } else {
                   s3 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c233); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c234); }
                 }
                 if (s3 !== peg$FAILED) {
                   s4 = peg$parse_();
@@ -7424,7 +7431,7 @@ module.exports = /*
                         s7 = peg$parseCOLOR_SPEC_rgb();
                         if (s7 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c243(s7);
+                          s1 = peg$c244(s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -7466,12 +7473,12 @@ module.exports = /*
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse_();
                 if (s2 !== peg$FAILED) {
-                  if (input.substr(peg$currPos, 3) === peg$c235) {
-                    s3 = peg$c235;
+                  if (input.substr(peg$currPos, 3) === peg$c236) {
+                    s3 = peg$c236;
                     peg$currPos += 3;
                   } else {
                     s3 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c236); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c237); }
                   }
                   if (s3 !== peg$FAILED) {
                     s4 = peg$parse_();
@@ -7489,7 +7496,7 @@ module.exports = /*
                           s7 = peg$parseCOLOR_SPEC_RGB();
                           if (s7 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c243(s7);
+                            s1 = peg$c244(s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7531,12 +7538,12 @@ module.exports = /*
                 if (s1 !== peg$FAILED) {
                   s2 = peg$parse_();
                   if (s2 !== peg$FAILED) {
-                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c237) {
+                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c238) {
                       s3 = input.substr(peg$currPos, 4);
                       peg$currPos += 4;
                     } else {
                       s3 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c238); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c239); }
                     }
                     if (s3 !== peg$FAILED) {
                       s4 = peg$parse_();
@@ -7554,7 +7561,7 @@ module.exports = /*
                             s7 = peg$parseCOLOR_SPEC_CMYK();
                             if (s7 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c244(s7);
+                              s1 = peg$c245(s7);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -7598,7 +7605,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_NAMED() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 123 + 103,
+      var key    = peg$currPos * 124 + 102,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7609,11 +7616,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c131;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c132); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7642,7 +7649,7 @@ module.exports = /*
                 s6 = peg$parse_();
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c245(s3);
+                  s1 = peg$c246(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7677,7 +7684,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_GRAY() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 123 + 104,
+      var key    = peg$currPos * 124 + 103,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7688,11 +7695,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c131;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c132); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7717,7 +7724,7 @@ module.exports = /*
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c246(s3);
+              s1 = peg$c247(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7744,7 +7751,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_rgb() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-      var key    = peg$currPos * 123 + 105,
+      var key    = peg$currPos * 124 + 104,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7755,11 +7762,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c131;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c132); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7767,11 +7774,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c247;
+              s4 = peg$c248;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c248); }
+              if (peg$silentFails === 0) { peg$fail(peg$c249); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7779,11 +7786,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c247;
+                    s7 = peg$c248;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c248); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c249); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -7801,7 +7808,7 @@ module.exports = /*
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c249(s3, s6, s9);
+                            s1 = peg$c250(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7856,7 +7863,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_RGB() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-      var key    = peg$currPos * 123 + 106,
+      var key    = peg$currPos * 124 + 105,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7867,11 +7874,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c131;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c132); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7879,11 +7886,11 @@ module.exports = /*
           s3 = peg$parseCNUM255();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c247;
+              s4 = peg$c248;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c248); }
+              if (peg$silentFails === 0) { peg$fail(peg$c249); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7891,11 +7898,11 @@ module.exports = /*
                 s6 = peg$parseCNUM255();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c247;
+                    s7 = peg$c248;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c248); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c249); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -7913,7 +7920,7 @@ module.exports = /*
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c249(s3, s6, s9);
+                            s1 = peg$c250(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7968,7 +7975,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_CMYK() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14;
 
-      var key    = peg$currPos * 123 + 107,
+      var key    = peg$currPos * 124 + 106,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7979,11 +7986,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c131;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c132); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7991,11 +7998,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c247;
+              s4 = peg$c248;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c248); }
+              if (peg$silentFails === 0) { peg$fail(peg$c249); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -8003,11 +8010,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c247;
+                    s7 = peg$c248;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c248); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c249); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -8015,11 +8022,11 @@ module.exports = /*
                       s9 = peg$parseCNUM();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 44) {
-                          s10 = peg$c247;
+                          s10 = peg$c248;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c248); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c249); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
@@ -8037,7 +8044,7 @@ module.exports = /*
                                 s14 = peg$parse_();
                                 if (s14 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c250(s3, s6, s9, s12);
+                                  s1 = peg$c251(s3, s6, s9, s12);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -8104,7 +8111,7 @@ module.exports = /*
     function peg$parseCNUM255() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 123 + 108,
+      var key    = peg$currPos * 124 + 107,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8116,20 +8123,20 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s2 = peg$c251;
+        s2 = peg$c252;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c252); }
+        if (peg$silentFails === 0) { peg$fail(peg$c253); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$currPos;
-        if (peg$c253.test(input.charAt(peg$currPos))) {
+        if (peg$c254.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c254); }
+          if (peg$silentFails === 0) { peg$fail(peg$c255); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -8184,7 +8191,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c255(s1);
+        s2 = peg$c256(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8194,7 +8201,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c256(s1);
+            s1 = peg$c257(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8217,7 +8224,7 @@ module.exports = /*
     function peg$parseCNUM() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 123 + 109,
+      var key    = peg$currPos * 124 + 108,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8230,22 +8237,22 @@ module.exports = /*
       s1 = peg$currPos;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s3 = peg$c251;
+        s3 = peg$c252;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c252); }
+        if (peg$silentFails === 0) { peg$fail(peg$c253); }
       }
       if (s3 === peg$FAILED) {
         s3 = null;
       }
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c257;
+          s4 = peg$c258;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c258); }
+          if (peg$silentFails === 0) { peg$fail(peg$c259); }
         }
         if (s4 !== peg$FAILED) {
           s5 = [];
@@ -8294,7 +8301,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c259(s1);
+          s1 = peg$c260(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8308,20 +8315,20 @@ module.exports = /*
         s0 = peg$currPos;
         s1 = peg$currPos;
         s2 = peg$currPos;
-        if (peg$c260.test(input.charAt(peg$currPos))) {
+        if (peg$c261.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c261); }
+          if (peg$silentFails === 0) { peg$fail(peg$c262); }
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c257;
+            s4 = peg$c258;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c258); }
+            if (peg$silentFails === 0) { peg$fail(peg$c259); }
           }
           if (s4 === peg$FAILED) {
             s4 = null;
@@ -8346,7 +8353,7 @@ module.exports = /*
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c259(s1);
+            s1 = peg$c260(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8363,85 +8370,50 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseimpossible() {
-      var s0;
-
-      var key    = peg$currPos * 123 + 110,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      peg$savedPos = peg$currPos;
-      s0 = peg$c262();
-      if (s0) {
-        s0 = void 0;
-      } else {
-        s0 = peg$FAILED;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseEOF() {
-      var s0;
-
-      var key    = peg$currPos * 123 + 111,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      peg$savedPos = peg$currPos;
-      s0 = peg$c263();
-      if (s0) {
-        s0 = void 0;
-      } else {
-        s0 = peg$FAILED;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseCHEM_LETTER() {
-      var s0;
-
-      var key    = peg$currPos * 123 + 112,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      if (peg$c113.test(input.charAt(peg$currPos))) {
-        s0 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c114); }
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
     function peg$parseCHEM_SINGLE_MACRO() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 123 + 113,
+      var key    = peg$currPos * 124 + 109,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c263(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c176(s1);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_BOND() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 124 + 110,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8461,9 +8433,199 @@ module.exports = /*
           s2 = peg$FAILED;
         }
         if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c175(s1);
-          s0 = s1;
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c176(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_MACRO_1P() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 124 + 111,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c265(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c176(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_MACRO_2P() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 124 + 112,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c266(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c176(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_MACRO_2PU() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 124 + 113,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c267(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c176(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_MACRO_2PC() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 124 + 114,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c268(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c176(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -8481,7 +8643,7 @@ module.exports = /*
     function peg$parseCHEM_SCRIPT_FOLLOW() {
       var s0;
 
-      var key    = peg$currPos * 123 + 114,
+      var key    = peg$currPos * 124 + 115,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8494,12 +8656,12 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$parseliteral_id();
         if (s0 === peg$FAILED) {
-          if (peg$c265.test(input.charAt(peg$currPos))) {
+          if (peg$c269.test(input.charAt(peg$currPos))) {
             s0 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c266); }
+            if (peg$silentFails === 0) { peg$fail(peg$c270); }
           }
         }
       }
@@ -8512,7 +8674,7 @@ module.exports = /*
     function peg$parseCHEM_SUPERSUB() {
       var s0;
 
-      var key    = peg$currPos * 123 + 115,
+      var key    = peg$currPos * 124 + 116,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8546,7 +8708,7 @@ module.exports = /*
     function peg$parseCHEM_BOND_TYPE() {
       var s0;
 
-      var key    = peg$currPos * 123 + 116,
+      var key    = peg$currPos * 124 + 117,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8556,123 +8718,123 @@ module.exports = /*
       }
 
       if (input.charCodeAt(peg$currPos) === 61) {
-        s0 = peg$c267;
+        s0 = peg$c271;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c268); }
+        if (peg$silentFails === 0) { peg$fail(peg$c272); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 35) {
-          s0 = peg$c269;
+          s0 = peg$c273;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c270); }
+          if (peg$silentFails === 0) { peg$fail(peg$c274); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c271) {
-            s0 = peg$c271;
+          if (input.substr(peg$currPos, 3) === peg$c275) {
+            s0 = peg$c275;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c272); }
+            if (peg$silentFails === 0) { peg$fail(peg$c276); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c273) {
-              s0 = peg$c273;
+            if (input.substr(peg$currPos, 2) === peg$c277) {
+              s0 = peg$c277;
               peg$currPos += 2;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c274); }
+              if (peg$silentFails === 0) { peg$fail(peg$c278); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c275) {
-                s0 = peg$c275;
+              if (input.substr(peg$currPos, 2) === peg$c279) {
+                s0 = peg$c279;
                 peg$currPos += 2;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c276); }
+                if (peg$silentFails === 0) { peg$fail(peg$c280); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 126) {
-                  s0 = peg$c277;
+                  s0 = peg$c281;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c278); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c282); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 3) === peg$c279) {
-                    s0 = peg$c279;
+                  if (input.substr(peg$currPos, 3) === peg$c283) {
+                    s0 = peg$c283;
                     peg$currPos += 3;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c280); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c284); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 4) === peg$c281) {
-                      s0 = peg$c281;
+                    if (input.substr(peg$currPos, 4) === peg$c285) {
+                      s0 = peg$c285;
                       peg$currPos += 4;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c282); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c286); }
                     }
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 3) === peg$c283) {
-                        s0 = peg$c283;
+                      if (input.substr(peg$currPos, 3) === peg$c287) {
+                        s0 = peg$c287;
                         peg$currPos += 3;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c288); }
                       }
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 2) === peg$c285) {
-                          s0 = peg$c285;
+                        if (input.substr(peg$currPos, 2) === peg$c289) {
+                          s0 = peg$c289;
                           peg$currPos += 2;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c286); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c290); }
                         }
                         if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c287) {
-                            s0 = peg$c287;
+                          if (input.substr(peg$currPos, 2) === peg$c291) {
+                            s0 = peg$c291;
                             peg$currPos += 2;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c288); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c292); }
                           }
                           if (s0 === peg$FAILED) {
                             if (input.charCodeAt(peg$currPos) === 45) {
-                              s0 = peg$c134;
+                              s0 = peg$c135;
                               peg$currPos++;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c135); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c136); }
                             }
                             if (s0 === peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 49) {
-                                s0 = peg$c289;
+                                s0 = peg$c293;
                                 peg$currPos++;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c290); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c294); }
                               }
                               if (s0 === peg$FAILED) {
                                 if (input.charCodeAt(peg$currPos) === 50) {
-                                  s0 = peg$c291;
+                                  s0 = peg$c295;
                                   peg$currPos++;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c292); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c296); }
                                 }
                                 if (s0 === peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 51) {
-                                    s0 = peg$c293;
+                                    s0 = peg$c297;
                                     peg$currPos++;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c298); }
                                   }
                                 }
                               }
@@ -8694,35 +8856,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseCHEM_DOLLAR() {
-      var s0;
-
-      var key    = peg$currPos * 123 + 117,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      if (input.charCodeAt(peg$currPos) === 167) {
-        s0 = peg$c295;
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c296); }
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseCHEM_BOND() {
+    function peg$parseBEGIN_MATH() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 118,
+      var key    = peg$currPos * 124 + 118,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8732,20 +8869,19 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      s1 = peg$parsegeneric_func();
+      s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        peg$savedPos = peg$currPos;
-        s2 = peg$c297(s1);
-        if (s2) {
-          s2 = void 0;
+        if (input.substr(peg$currPos, 6) === peg$c299) {
+          s2 = peg$c299;
+          peg$currPos += 6;
         } else {
           s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c300); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c175(s1);
+            s1 = [s1, s2, s3];
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8765,10 +8901,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseCHEM_NONLETTER() {
-      var s0, s1, s2;
+    function peg$parseEND_MATH() {
+      var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 123 + 119,
+      var key    = peg$currPos * 124 + 119,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8778,70 +8914,155 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c140) {
-        s1 = peg$c140;
+      s1 = peg$parseEND();
+      if (s1 !== peg$FAILED) {
+        if (input.substr(peg$currPos, 6) === peg$c299) {
+          s2 = peg$c299;
+          peg$currPos += 6;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c300); }
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            s1 = [s1, s2, s3];
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_LETTER() {
+      var s0;
+
+      var key    = peg$currPos * 124 + 120,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (peg$c114.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_NONLETTER() {
+      var s0, s1, s2;
+
+      var key    = peg$currPos * 124 + 121,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 2) === peg$c141) {
+        s1 = peg$c141;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c141); }
+        if (peg$silentFails === 0) { peg$fail(peg$c142); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c298(s1);
+        s1 = peg$c301(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c299) {
-          s1 = peg$c299;
+        if (input.substr(peg$currPos, 2) === peg$c302) {
+          s1 = peg$c302;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c300); }
+          if (peg$silentFails === 0) { peg$fail(peg$c303); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c298(s1);
+          s1 = peg$c301(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (peg$c301.test(input.charAt(peg$currPos))) {
-            s1 = input.charAt(peg$currPos);
-            peg$currPos++;
+          if (input.substr(peg$currPos, 2) === peg$c180) {
+            s1 = peg$c180;
+            peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c302); }
+            if (peg$silentFails === 0) { peg$fail(peg$c181); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c298(s1);
+            s1 = peg$c301(s1);
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            s1 = peg$parseliteral_mn();
+            if (peg$c304.test(input.charAt(peg$currPos))) {
+              s1 = input.charAt(peg$currPos);
+              peg$currPos++;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+            }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c298(s1);
+              s1 = peg$c301(s1);
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              s1 = peg$parseCURLY_OPEN();
+              s1 = peg$parseliteral_mn();
               if (s1 !== peg$FAILED) {
-                s2 = peg$parseCURLY_CLOSE();
-                if (s2 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c303();
-                  s0 = s1;
+                peg$savedPos = s0;
+                s1 = peg$c301(s1);
+              }
+              s0 = s1;
+              if (s0 === peg$FAILED) {
+                s0 = peg$currPos;
+                s1 = peg$parseCURLY_OPEN();
+                if (s1 !== peg$FAILED) {
+                  s2 = peg$parseCURLY_CLOSE();
+                  if (s2 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c306();
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
                 } else {
                   peg$currPos = s0;
                   s0 = peg$FAILED;
                 }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
               }
             }
           }
@@ -8853,10 +9074,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseCHEM_MACRO_1P() {
-      var s0, s1, s2, s3;
+    function peg$parseimpossible() {
+      var s0;
 
-      var key    = peg$currPos * 123 + 120,
+      var key    = peg$currPos * 124 + 122,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8865,32 +9086,11 @@ module.exports = /*
         return cached.result;
       }
 
-      s0 = peg$currPos;
-      s1 = peg$parsegeneric_func();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = peg$currPos;
-        s2 = peg$c304(s1);
-        if (s2) {
-          s2 = void 0;
-        } else {
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c175(s1);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+      peg$savedPos = peg$currPos;
+      s0 = peg$c307();
+      if (s0) {
+        s0 = void 0;
       } else {
-        peg$currPos = s0;
         s0 = peg$FAILED;
       }
 
@@ -8899,10 +9099,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseCHEM_MACRO_2P() {
-      var s0, s1, s2, s3;
+    function peg$parseEOF() {
+      var s0;
 
-      var key    = peg$currPos * 123 + 121,
+      var key    = peg$currPos * 124 + 123,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8911,78 +9111,11 @@ module.exports = /*
         return cached.result;
       }
 
-      s0 = peg$currPos;
-      s1 = peg$parsegeneric_func();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = peg$currPos;
-        s2 = peg$c305(s1);
-        if (s2) {
-          s2 = void 0;
-        } else {
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c175(s1);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
+      peg$savedPos = peg$currPos;
+      s0 = peg$c308();
+      if (s0) {
+        s0 = void 0;
       } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseCHEM_MACRO_2PU() {
-      var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 123 + 122,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      s1 = peg$parsegeneric_func();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = peg$currPos;
-        s2 = peg$c306(s1);
-        if (s2) {
-          s2 = void 0;
-        } else {
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c175(s1);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
         s0 = peg$FAILED;
       }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -229,239 +229,238 @@ module.exports = /*
         peg$c81 = peg$classExpectation(["t", "c", "b"], false, false),
         peg$c82 = "]",
         peg$c83 = peg$literalExpectation("]", false),
-        peg$c84 = function(p) { return ast.LList(p,ast.LList.EMPTY); },
-        peg$c85 = function(m) { return m; },
-        peg$c86 = function(m, n) { return ast.LList(m, n); },
-        peg$c87 = function(name, l) { return ast.Tex.CHEM_BOND(name, l);},
-        peg$c88 = function(e) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(e))]); },
-        peg$c89 = function(a, b) { return a + b; },
-        peg$c90 = function(a, b) { return a + "$" + b + "$"; },
-        peg$c91 = "\\alpha",
-        peg$c92 = peg$literalExpectation("\\alpha", false),
-        peg$c93 = "\\delta",
-        peg$c94 = peg$literalExpectation("\\delta", false),
-        peg$c95 = "\\mu",
-        peg$c96 = peg$literalExpectation("\\mu", false),
-        peg$c97 = "\\eta",
-        peg$c98 = peg$literalExpectation("\\eta", false),
-        peg$c99 = "\\gamma",
-        peg$c100 = peg$literalExpectation("\\gamma", false),
-        peg$c101 = "\\pm",
-        peg$c102 = peg$literalExpectation("\\pm", false),
-        peg$c103 = "\\approx",
-        peg$c104 = peg$literalExpectation("\\approx", false),
-        peg$c105 = "\\ca",
-        peg$c106 = peg$literalExpectation("\\ca", false),
-        peg$c107 = "_",
-        peg$c108 = peg$literalExpectation("_", false),
-        peg$c109 = "\\red",
-        peg$c110 = peg$literalExpectation("\\red", false),
-        peg$c111 = "red",
-        peg$c112 = peg$literalExpectation("red", false),
-        peg$c113 = function(m) {
+        peg$c84 = " ",
+        peg$c85 = peg$literalExpectation(" ", false),
+        peg$c86 = function(p, s) { return ast.LList(p,ast.LList(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(" ")),s)); },
+        peg$c87 = function(p) { return ast.LList(p,ast.LList.EMPTY); },
+        peg$c88 = "(^)",
+        peg$c89 = peg$literalExpectation("(^)", false),
+        peg$c90 = function(m) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); },
+        peg$c91 = function(m, n) { return ast.Tex.CHEM_WORD(m, ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(n))); },
+        peg$c92 = function(m) { return m; },
+        peg$c93 = "^",
+        peg$c94 = peg$literalExpectation("^", false),
+        peg$c95 = function(m, n) { return ast.Tex.CHEM_WORD(m, n); },
+        peg$c96 = function() { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("")); },
+        peg$c97 = function(m) { return m;},
+        peg$c98 = function(c) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("{" + b + "}"));; },
+        peg$c99 = function(c) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("$" + c + "$")); },
+        peg$c100 = function(name, l) { return ast.Tex.CHEM_BOND(name, l);},
+        peg$c101 = function(c) {return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c))},
+        peg$c102 = function(e) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(e))]); },
+        peg$c103 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(b))); },
+        peg$c104 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), b); },
+        peg$c105 = function(a, b) { return a + "$" + b + "$"; },
+        peg$c106 = "_",
+        peg$c107 = peg$literalExpectation("_", false),
+        peg$c108 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2u(name, l1, l2); },
+        peg$c109 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2(name, l1, l2); },
+        peg$c110 = function(name, l) { return ast.Tex.CHEM_FUN1(name, l); },
+        peg$c111 = function(m) {
                 var s = "";
                 for (var c in m)
                     s += m[c];
                 return s;//ast.RenderT.TEX_ONLY(s);
             },
-        peg$c114 = /^[a-zA-Z]/,
-        peg$c115 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
-        peg$c116 = /^[,:;?!']/,
-        peg$c117 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
-        peg$c118 = /^[().]/,
-        peg$c119 = peg$classExpectation(["(", ")", "."], false, false),
-        peg$c120 = /^[\-+*=]/,
-        peg$c121 = peg$classExpectation(["-", "+", "*", "="], false, false),
-        peg$c122 = /^[\/|]/,
-        peg$c123 = peg$classExpectation(["/", "|"], false, false),
-        peg$c124 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
-        peg$c125 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
-        peg$c126 = /^[\uD800-\uDBFF]/,
-        peg$c127 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
-        peg$c128 = /^[\uDC00-\uDFFF]/,
-        peg$c129 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
-        peg$c130 = function(l, h) { return text(); },
-        peg$c131 = function(b) { return tu.box_functions[b]; },
-        peg$c132 = "{",
-        peg$c133 = peg$literalExpectation("{", false),
-        peg$c134 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
-        peg$c135 = "-",
-        peg$c136 = peg$literalExpectation("-", false),
-        peg$c137 = function(c) { return ast.RenderT.TEX_ONLY(c); },
-        peg$c138 = function(f) { return tu.latex_function_names[f]; },
-        peg$c139 = "(",
-        peg$c140 = peg$literalExpectation("(", false),
-        peg$c141 = "\\{",
-        peg$c142 = peg$literalExpectation("\\{", false),
-        peg$c143 = function(f) { return " ";},
-        peg$c144 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
-        peg$c145 = function(f) { return tu.mediawiki_function_names[f]; },
-        peg$c146 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
-        peg$c147 = function(f) { return tu.other_literals1[f]; },
-        peg$c148 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
-        peg$c149 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c150 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c151 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
-        peg$c152 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c153 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c154 = function(f) { return tu.other_literals2[f]; },
-        peg$c155 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c156 = function(mbox) { return mbox === "\\mbox"; },
-        peg$c157 = function(mbox, f) { return tu.other_literals2[f]; },
-        peg$c158 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c159 = function(f) { return ast.RenderT.TEX_ONLY(f); },
-        peg$c160 = "\\",
-        peg$c161 = peg$literalExpectation("\\", false),
-        peg$c162 = /^[, ;!_#%$&]/,
-        peg$c163 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
-        peg$c164 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
-        peg$c165 = /^[><~]/,
-        peg$c166 = peg$classExpectation([">", "<", "~"], false, false),
-        peg$c167 = /^[%$]/,
-        peg$c168 = peg$classExpectation(["%", "$"], false, false),
-        peg$c169 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */},
-        peg$c170 = /^[{}|]/,
-        peg$c171 = peg$classExpectation(["{", "}", "|"], false, false),
-        peg$c172 = function(f) { return tu.other_delimiters1[f]; },
-        peg$c173 = function(f) { return tu.other_delimiters2[f]; },
-        peg$c174 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
+        peg$c112 = /^[a-zA-Z]/,
+        peg$c113 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
+        peg$c114 = /^[,:;?!']/,
+        peg$c115 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
+        peg$c116 = /^[().]/,
+        peg$c117 = peg$classExpectation(["(", ")", "."], false, false),
+        peg$c118 = /^[\-+*=]/,
+        peg$c119 = peg$classExpectation(["-", "+", "*", "="], false, false),
+        peg$c120 = /^[\/|]/,
+        peg$c121 = peg$classExpectation(["/", "|"], false, false),
+        peg$c122 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
+        peg$c123 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
+        peg$c124 = /^[\uD800-\uDBFF]/,
+        peg$c125 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
+        peg$c126 = /^[\uDC00-\uDFFF]/,
+        peg$c127 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
+        peg$c128 = function(l, h) { return text(); },
+        peg$c129 = function(b) { return tu.box_functions[b]; },
+        peg$c130 = "{",
+        peg$c131 = peg$literalExpectation("{", false),
+        peg$c132 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
+        peg$c133 = "-",
+        peg$c134 = peg$literalExpectation("-", false),
+        peg$c135 = function(c) { return ast.RenderT.TEX_ONLY(c); },
+        peg$c136 = function(f) { return tu.latex_function_names[f]; },
+        peg$c137 = "(",
+        peg$c138 = peg$literalExpectation("(", false),
+        peg$c139 = "\\{",
+        peg$c140 = peg$literalExpectation("\\{", false),
+        peg$c141 = function(f) { return " ";},
+        peg$c142 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
+        peg$c143 = function(f) { return tu.mediawiki_function_names[f]; },
+        peg$c144 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
+        peg$c145 = function(f) { return tu.other_literals1[f]; },
+        peg$c146 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
+        peg$c147 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c148 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c149 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
+        peg$c150 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c151 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c152 = function(f) { return tu.other_literals2[f]; },
+        peg$c153 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c154 = function(mbox) { return mbox === "\\mbox"; },
+        peg$c155 = function(mbox, f) { return tu.other_literals2[f]; },
+        peg$c156 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c157 = function(f) { return ast.RenderT.TEX_ONLY(f); },
+        peg$c158 = "\\",
+        peg$c159 = peg$literalExpectation("\\", false),
+        peg$c160 = /^[, ;!_#%$&]/,
+        peg$c161 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
+        peg$c162 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
+        peg$c163 = /^[><~]/,
+        peg$c164 = peg$classExpectation([">", "<", "~"], false, false),
+        peg$c165 = /^[%$]/,
+        peg$c166 = peg$classExpectation(["%", "$"], false, false),
+        peg$c167 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */},
+        peg$c168 = /^[{}|]/,
+        peg$c169 = peg$classExpectation(["{", "}", "|"], false, false),
+        peg$c170 = function(f) { return tu.other_delimiters1[f]; },
+        peg$c171 = function(f) { return tu.other_delimiters2[f]; },
+        peg$c172 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
              console.assert(Array.isArray(p) && p.length === 1);
              console.assert(p[0].constructor === ast.Tex.LITERAL);
              console.assert(p[0][0].constructor === ast.RenderT.TEX_ONLY);
              return p[0][0];
            },
-        peg$c175 = function(f) { return tu.fun_ar1nb[f]; },
-        peg$c176 = function(f) { return f; },
-        peg$c177 = function(f) { return tu.fun_ar1opt[f]; },
-        peg$c178 = "&",
-        peg$c179 = peg$literalExpectation("&", false),
-        peg$c180 = "\\\\",
-        peg$c181 = peg$literalExpectation("\\\\", false),
-        peg$c182 = "\\begin",
-        peg$c183 = peg$literalExpectation("\\begin", false),
-        peg$c184 = "\\end",
-        peg$c185 = peg$literalExpectation("\\end", false),
-        peg$c186 = "{matrix}",
-        peg$c187 = peg$literalExpectation("{matrix}", false),
-        peg$c188 = "{pmatrix}",
-        peg$c189 = peg$literalExpectation("{pmatrix}", false),
-        peg$c190 = "{bmatrix}",
-        peg$c191 = peg$literalExpectation("{bmatrix}", false),
-        peg$c192 = "{Bmatrix}",
-        peg$c193 = peg$literalExpectation("{Bmatrix}", false),
-        peg$c194 = "{vmatrix}",
-        peg$c195 = peg$literalExpectation("{vmatrix}", false),
-        peg$c196 = "{Vmatrix}",
-        peg$c197 = peg$literalExpectation("{Vmatrix}", false),
-        peg$c198 = "{array}",
-        peg$c199 = peg$literalExpectation("{array}", false),
-        peg$c200 = "{align}",
-        peg$c201 = peg$literalExpectation("{align}", false),
-        peg$c202 = "{aligned}",
-        peg$c203 = peg$literalExpectation("{aligned}", false),
-        peg$c204 = "{alignat}",
-        peg$c205 = peg$literalExpectation("{alignat}", false),
-        peg$c206 = "{alignedat}",
-        peg$c207 = peg$literalExpectation("{alignedat}", false),
-        peg$c208 = "{smallmatrix}",
-        peg$c209 = peg$literalExpectation("{smallmatrix}", false),
-        peg$c210 = "{cases}",
-        peg$c211 = peg$literalExpectation("{cases}", false),
-        peg$c212 = "^",
-        peg$c213 = peg$literalExpectation("^", false),
-        peg$c214 = function(f) { return tu.big_literals[f]; },
-        peg$c215 = function(f) { return tu.fun_ar1[f]; },
-        peg$c216 = function(f) { return tu.other_fun_ar1[f]; },
-        peg$c217 = function(f) { return tu.fun_mhchem[f]; },
-        peg$c218 = function(f) { return tu.fun_ar2[f]; },
-        peg$c219 = function(f) { return tu.fun_infix[f]; },
-        peg$c220 = function(f) { return tu.declh_function[f]; },
-        peg$c221 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
-        peg$c222 = function(f) { return tu.fun_ar2nb[f]; },
-        peg$c223 = function(f) { return tu.left_function[f]; },
-        peg$c224 = function(f) { return tu.right_function[f]; },
-        peg$c225 = function(f) { return tu.hline_function[f]; },
-        peg$c226 = function(f) { return tu.color_function[f]; },
-        peg$c227 = function(f, cs) { return f + " " + cs; },
-        peg$c228 = function(f) { return tu.definecolor_function[f]; },
-        peg$c229 = "named",
-        peg$c230 = peg$literalExpectation("named", true),
-        peg$c231 = function(f, name, cs) { return "{named}" + cs; },
-        peg$c232 = "gray",
-        peg$c233 = peg$literalExpectation("gray", true),
-        peg$c234 = function(f, name, cs) { return "{gray}" + cs; },
-        peg$c235 = "rgb",
-        peg$c236 = peg$literalExpectation("rgb", false),
-        peg$c237 = function(f, name, cs) { return "{rgb}" + cs; },
-        peg$c238 = "RGB",
-        peg$c239 = peg$literalExpectation("RGB", false),
-        peg$c240 = "cmyk",
-        peg$c241 = peg$literalExpectation("cmyk", true),
-        peg$c242 = function(f, name, cs) { return "{cmyk}" + cs; },
-        peg$c243 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
-        peg$c244 = function(cs) { return "[named]" + cs; },
-        peg$c245 = function(cs) { return "[gray]" + cs; },
-        peg$c246 = function(cs) { return "[rgb]" + cs; },
-        peg$c247 = function(cs) { return "[cmyk]" + cs; },
-        peg$c248 = function(name) { return "{" + name.join('') + "}"; },
-        peg$c249 = function(k) { return "{"+k+"}"; },
-        peg$c250 = ",",
-        peg$c251 = peg$literalExpectation(",", false),
-        peg$c252 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
-        peg$c253 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
-        peg$c254 = "0",
-        peg$c255 = peg$literalExpectation("0", false),
-        peg$c256 = /^[1-9]/,
-        peg$c257 = peg$classExpectation([["1", "9"]], false, false),
-        peg$c258 = function(n) { return parseInt(n, 10) <= 255; },
-        peg$c259 = function(n) { return n / 255; },
-        peg$c260 = ".",
-        peg$c261 = peg$literalExpectation(".", false),
-        peg$c262 = function(n) { return n; },
-        peg$c263 = /^[01]/,
-        peg$c264 = peg$classExpectation(["0", "1"], false, false),
-        peg$c265 = function() { return false; },
-        peg$c266 = function() { return peg$currPos === input.length; },
-        peg$c267 = /^[+-.*']/,
-        peg$c268 = peg$classExpectation([["+", "."], "*", "'"], false, false),
-        peg$c269 = "=",
-        peg$c270 = peg$literalExpectation("=", false),
-        peg$c271 = "#",
-        peg$c272 = peg$literalExpectation("#", false),
-        peg$c273 = "~--",
-        peg$c274 = peg$literalExpectation("~--", false),
-        peg$c275 = "~-",
-        peg$c276 = peg$literalExpectation("~-", false),
-        peg$c277 = "~=",
-        peg$c278 = peg$literalExpectation("~=", false),
-        peg$c279 = "~",
-        peg$c280 = peg$literalExpectation("~", false),
-        peg$c281 = "-~-",
-        peg$c282 = peg$literalExpectation("-~-", false),
-        peg$c283 = "....",
-        peg$c284 = peg$literalExpectation("....", false),
-        peg$c285 = "...",
-        peg$c286 = peg$literalExpectation("...", false),
-        peg$c287 = "<-",
-        peg$c288 = peg$literalExpectation("<-", false),
-        peg$c289 = "->",
-        peg$c290 = peg$literalExpectation("->", false),
-        peg$c291 = "1",
-        peg$c292 = peg$literalExpectation("1", false),
-        peg$c293 = "2",
-        peg$c294 = peg$literalExpectation("2", false),
-        peg$c295 = "3",
-        peg$c296 = peg$literalExpectation("3", false),
-        peg$c297 = "$",
-        peg$c298 = peg$literalExpectation("$", false),
-        peg$c299 = function(f) { return tu.mhchem_bond[f]; },
-        peg$c300 = "\\}",
-        peg$c301 = peg$literalExpectation("\\}", false),
-        peg$c302 = /^[+-=#().,;\/*<>|@&'\\[\]]/,
-        peg$c303 = peg$classExpectation([["+", "="], "#", "(", ")", ".", ",", ";", "/", "*", "<", ">", "|", "@", "&", "'", "\\", "[", "]"], false, false),
-        peg$c304 = function(f) { return tu.mhchem_macro_1p[f]; },
-        peg$c305 = function(f) { return tu.mhchem_macro_2p[f]; },
-        peg$c306 = function(f) { return tu.mhchem_macro_2pu[f]; },
+        peg$c173 = function(f) { return tu.fun_ar1nb[f]; },
+        peg$c174 = function(f) { return f; },
+        peg$c175 = function(f) { return tu.fun_ar1opt[f]; },
+        peg$c176 = "&",
+        peg$c177 = peg$literalExpectation("&", false),
+        peg$c178 = "\\\\",
+        peg$c179 = peg$literalExpectation("\\\\", false),
+        peg$c180 = "\\begin",
+        peg$c181 = peg$literalExpectation("\\begin", false),
+        peg$c182 = "\\end",
+        peg$c183 = peg$literalExpectation("\\end", false),
+        peg$c184 = "{matrix}",
+        peg$c185 = peg$literalExpectation("{matrix}", false),
+        peg$c186 = "{pmatrix}",
+        peg$c187 = peg$literalExpectation("{pmatrix}", false),
+        peg$c188 = "{bmatrix}",
+        peg$c189 = peg$literalExpectation("{bmatrix}", false),
+        peg$c190 = "{Bmatrix}",
+        peg$c191 = peg$literalExpectation("{Bmatrix}", false),
+        peg$c192 = "{vmatrix}",
+        peg$c193 = peg$literalExpectation("{vmatrix}", false),
+        peg$c194 = "{Vmatrix}",
+        peg$c195 = peg$literalExpectation("{Vmatrix}", false),
+        peg$c196 = "{array}",
+        peg$c197 = peg$literalExpectation("{array}", false),
+        peg$c198 = "{align}",
+        peg$c199 = peg$literalExpectation("{align}", false),
+        peg$c200 = "{aligned}",
+        peg$c201 = peg$literalExpectation("{aligned}", false),
+        peg$c202 = "{alignat}",
+        peg$c203 = peg$literalExpectation("{alignat}", false),
+        peg$c204 = "{alignedat}",
+        peg$c205 = peg$literalExpectation("{alignedat}", false),
+        peg$c206 = "{smallmatrix}",
+        peg$c207 = peg$literalExpectation("{smallmatrix}", false),
+        peg$c208 = "{cases}",
+        peg$c209 = peg$literalExpectation("{cases}", false),
+        peg$c210 = function(f) { return tu.big_literals[f]; },
+        peg$c211 = function(f) { return tu.fun_ar1[f]; },
+        peg$c212 = function(f) { return tu.other_fun_ar1[f]; },
+        peg$c213 = function(f) { return tu.fun_mhchem[f]; },
+        peg$c214 = function(f) { return tu.fun_ar2[f]; },
+        peg$c215 = function(f) { return tu.fun_infix[f]; },
+        peg$c216 = function(f) { return tu.declh_function[f]; },
+        peg$c217 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
+        peg$c218 = function(f) { return tu.fun_ar2nb[f]; },
+        peg$c219 = function(f) { return tu.left_function[f]; },
+        peg$c220 = function(f) { return tu.right_function[f]; },
+        peg$c221 = function(f) { return tu.hline_function[f]; },
+        peg$c222 = function(f) { return tu.color_function[f]; },
+        peg$c223 = function(f, cs) { return f + " " + cs; },
+        peg$c224 = function(f) { return tu.definecolor_function[f]; },
+        peg$c225 = "named",
+        peg$c226 = peg$literalExpectation("named", true),
+        peg$c227 = function(f, name, cs) { return "{named}" + cs; },
+        peg$c228 = "gray",
+        peg$c229 = peg$literalExpectation("gray", true),
+        peg$c230 = function(f, name, cs) { return "{gray}" + cs; },
+        peg$c231 = "rgb",
+        peg$c232 = peg$literalExpectation("rgb", false),
+        peg$c233 = function(f, name, cs) { return "{rgb}" + cs; },
+        peg$c234 = "RGB",
+        peg$c235 = peg$literalExpectation("RGB", false),
+        peg$c236 = "cmyk",
+        peg$c237 = peg$literalExpectation("cmyk", true),
+        peg$c238 = function(f, name, cs) { return "{cmyk}" + cs; },
+        peg$c239 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
+        peg$c240 = function(cs) { return "[named]" + cs; },
+        peg$c241 = function(cs) { return "[gray]" + cs; },
+        peg$c242 = function(cs) { return "[rgb]" + cs; },
+        peg$c243 = function(cs) { return "[cmyk]" + cs; },
+        peg$c244 = function(name) { return "{" + name.join('') + "}"; },
+        peg$c245 = function(k) { return "{"+k+"}"; },
+        peg$c246 = ",",
+        peg$c247 = peg$literalExpectation(",", false),
+        peg$c248 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
+        peg$c249 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
+        peg$c250 = "0",
+        peg$c251 = peg$literalExpectation("0", false),
+        peg$c252 = /^[1-9]/,
+        peg$c253 = peg$classExpectation([["1", "9"]], false, false),
+        peg$c254 = function(n) { return parseInt(n, 10) <= 255; },
+        peg$c255 = function(n) { return n / 255; },
+        peg$c256 = ".",
+        peg$c257 = peg$literalExpectation(".", false),
+        peg$c258 = function(n) { return n; },
+        peg$c259 = /^[01]/,
+        peg$c260 = peg$classExpectation(["0", "1"], false, false),
+        peg$c261 = function() { return false; },
+        peg$c262 = function() { return peg$currPos === input.length; },
+        peg$c263 = function(f) { return tu.mhchem_single_macro[f]; },
+        peg$c264 = /^[+-.*']/,
+        peg$c265 = peg$classExpectation([["+", "."], "*", "'"], false, false),
+        peg$c266 = "=",
+        peg$c267 = peg$literalExpectation("=", false),
+        peg$c268 = "#",
+        peg$c269 = peg$literalExpectation("#", false),
+        peg$c270 = "~--",
+        peg$c271 = peg$literalExpectation("~--", false),
+        peg$c272 = "~-",
+        peg$c273 = peg$literalExpectation("~-", false),
+        peg$c274 = "~=",
+        peg$c275 = peg$literalExpectation("~=", false),
+        peg$c276 = "~",
+        peg$c277 = peg$literalExpectation("~", false),
+        peg$c278 = "-~-",
+        peg$c279 = peg$literalExpectation("-~-", false),
+        peg$c280 = "....",
+        peg$c281 = peg$literalExpectation("....", false),
+        peg$c282 = "...",
+        peg$c283 = peg$literalExpectation("...", false),
+        peg$c284 = "<-",
+        peg$c285 = peg$literalExpectation("<-", false),
+        peg$c286 = "->",
+        peg$c287 = peg$literalExpectation("->", false),
+        peg$c288 = "1",
+        peg$c289 = peg$literalExpectation("1", false),
+        peg$c290 = "2",
+        peg$c291 = peg$literalExpectation("2", false),
+        peg$c292 = "3",
+        peg$c293 = peg$literalExpectation("3", false),
+        peg$c294 = "$",
+        peg$c295 = peg$literalExpectation("$", false),
+        peg$c296 = function(f) { return tu.mhchem_bond[f]; },
+        peg$c297 = function(c) { return c; },
+        peg$c298 = "\\}",
+        peg$c299 = peg$literalExpectation("\\}", false),
+        peg$c300 = /^[+-=#().,;\/*<>|@&'[\]]/,
+        peg$c301 = peg$classExpectation([["+", "="], "#", "(", ")", ".", ",", ";", "/", "*", "<", ">", "|", "@", "&", "'", "[", "]"], false, false),
+        peg$c302 = function() { return "{}"; },
+        peg$c303 = function(f) { return tu.mhchem_macro_1p[f]; },
+        peg$c304 = function(f) { return tu.mhchem_macro_2p[f]; },
+        peg$c305 = function(f) { return tu.mhchem_macro_2pu[f]; },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -2987,7 +2986,7 @@ module.exports = /*
     }
 
     function peg$parsechem_sentence() {
-      var s0, s1, s2, s3;
+      var s0, s1, s2, s3, s4;
 
       var key    = peg$currPos * 122 + 30,
           cached = peg$resultsCache[key];
@@ -3003,11 +3002,23 @@ module.exports = /*
       if (s1 !== peg$FAILED) {
         s2 = peg$parsechem_phrase();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
+          if (input.charCodeAt(peg$currPos) === 32) {
+            s3 = peg$c84;
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c85); }
+          }
           if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c84(s2);
-            s0 = s1;
+            s4 = peg$parsechem_sentence();
+            if (s4 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c86(s2, s4);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -3020,6 +3031,30 @@ module.exports = /*
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parse_();
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parsechem_phrase();
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parse_();
+            if (s3 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c87(s2);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
@@ -3027,7 +3062,7 @@ module.exports = /*
     }
 
     function peg$parsechem_phrase() {
-      var s0, s1;
+      var s0, s1, s2;
 
       var key    = peg$currPos * 122 + 31,
           cached = peg$resultsCache[key];
@@ -3039,12 +3074,69 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      s1 = peg$parsechem_word();
+      if (input.substr(peg$currPos, 3) === peg$c88) {
+        s1 = peg$c88;
+        peg$currPos += 3;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c89); }
+      }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c85(s1);
+        s1 = peg$c90(s1);
       }
       s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parsechem_word();
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parseCHEM_SINGLE_MACRO();
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c91(s1, s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parsechem_word();
+          if (s1 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c92(s1);
+          }
+          s0 = s1;
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            s1 = peg$parseCHEM_SINGLE_MACRO();
+            if (s1 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c90(s1);
+            }
+            s0 = s1;
+            if (s0 === peg$FAILED) {
+              s0 = peg$currPos;
+              if (input.charCodeAt(peg$currPos) === 94) {
+                s1 = peg$c93;
+                peg$currPos++;
+              } else {
+                s1 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c94); }
+              }
+              if (s1 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c90(s1);
+              }
+              s0 = s1;
+            }
+          }
+        }
+      }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
@@ -3064,12 +3156,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      s1 = peg$parsechem_nonletter();
+      s1 = peg$parsechem_char();
       if (s1 !== peg$FAILED) {
         s2 = peg$parsechem_word_nt();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c86(s1, s2);
+          s1 = peg$c95(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3101,7 +3193,7 @@ module.exports = /*
       s1 = peg$parsechem_word();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c85(s1);
+        s1 = peg$c92(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -3109,7 +3201,7 @@ module.exports = /*
         s1 = peg$c6;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c7();
+          s1 = peg$c96();
         }
         s0 = s1;
       }
@@ -3119,8 +3211,8 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parsechem_nonletter() {
-      var s0, s1, s2;
+    function peg$parsechem_char() {
+      var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 34,
           cached = peg$resultsCache[key];
@@ -3132,20 +3224,104 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      s1 = peg$parseCHEM_BOND();
+      s1 = peg$parsechem_script();
       if (s1 !== peg$FAILED) {
-        s2 = peg$parsechem_bond();
-        if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c87(s1, s2);
-          s0 = s1;
+        peg$savedPos = s0;
+        s1 = peg$c97(s1);
+      }
+      s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseCURLY_OPEN();
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parsechem_text();
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parseCURLY_CLOSE();
+            if (s3 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c98(s2);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parseCHEM_DOLLAR();
+          if (s1 !== peg$FAILED) {
+            s2 = peg$parsechem_latex();
+            if (s2 !== peg$FAILED) {
+              s3 = peg$parseCHEM_DOLLAR();
+              if (s3 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c99(s2);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            s1 = peg$parseCHEM_BOND();
+            if (s1 !== peg$FAILED) {
+              s2 = peg$parsechem_bond();
+              if (s2 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c100(s1, s2);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+            if (s0 === peg$FAILED) {
+              s0 = peg$currPos;
+              s1 = peg$parsechem_macro();
+              if (s1 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c92(s1);
+              }
+              s0 = s1;
+              if (s0 === peg$FAILED) {
+                s0 = peg$currPos;
+                s1 = peg$parseCHEM_NONLETTER();
+                if (s1 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c101(s1);
+                }
+                s0 = s1;
+                if (s0 === peg$FAILED) {
+                  s0 = peg$currPos;
+                  s1 = peg$parseCHEM_LETTER();
+                  if (s1 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c101(s1);
+                  }
+                  s0 = s1;
+                }
+              }
+            }
+          }
+        }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3173,7 +3349,7 @@ module.exports = /*
           s3 = peg$parseCURLY_CLOSE();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c88(s2);
+            s1 = peg$c102(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3211,7 +3387,7 @@ module.exports = /*
         s2 = peg$parseCHEM_SCRIPT_FOLLOW();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c89(s1, s2);
+          s1 = peg$c103(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3228,7 +3404,7 @@ module.exports = /*
           s2 = peg$parsechem_lit();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c89(s1, s2);
+            s1 = peg$c104(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3249,7 +3425,7 @@ module.exports = /*
                 s4 = peg$parseCHEM_DOLLAR();
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c90(s1, s3);
+                  s1 = peg$c105(s1, s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3275,104 +3451,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parsechem_single_macro() {
-      var s0, s1;
-
-      var key    = peg$currPos * 122 + 37,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      if (input.substr(peg$currPos, 6) === peg$c91) {
-        s0 = peg$c91;
-        peg$currPos += 6;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c92); }
-      }
-      if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c93) {
-          s0 = peg$c93;
-          peg$currPos += 6;
-        } else {
-          s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c94); }
-        }
-        if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c95) {
-            s0 = peg$c95;
-            peg$currPos += 3;
-          } else {
-            s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c96); }
-          }
-          if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c97) {
-              s0 = peg$c97;
-              peg$currPos += 4;
-            } else {
-              s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c98); }
-            }
-            if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 6) === peg$c99) {
-                s0 = peg$c99;
-                peg$currPos += 6;
-              } else {
-                s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c100); }
-              }
-              if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 3) === peg$c101) {
-                  s0 = peg$c101;
-                  peg$currPos += 3;
-                } else {
-                  s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c102); }
-                }
-                if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 7) === peg$c103) {
-                    s0 = peg$c103;
-                    peg$currPos += 7;
-                  } else {
-                    s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c104); }
-                  }
-                  if (s0 === peg$FAILED) {
-                    s0 = peg$currPos;
-                    if (input.substr(peg$currPos, 3) === peg$c105) {
-                      s1 = peg$c105;
-                      peg$currPos += 3;
-                    } else {
-                      s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c106); }
-                    }
-                    if (s1 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c85(s1);
-                    }
-                    s0 = s1;
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
     function peg$parsechem_macro() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 122 + 38,
+      var key    = peg$currPos * 122 + 37,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3387,16 +3469,17 @@ module.exports = /*
         s2 = peg$parsechem_lit();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 95) {
-            s3 = peg$c107;
+            s3 = peg$c106;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c108); }
+            if (peg$silentFails === 0) { peg$fail(peg$c107); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parsechem_lit();
             if (s4 !== peg$FAILED) {
-              s1 = [s1, s2, s3, s4];
+              peg$savedPos = s0;
+              s1 = peg$c108(s1, s2, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3422,7 +3505,8 @@ module.exports = /*
           if (s2 !== peg$FAILED) {
             s3 = peg$parsechem_lit();
             if (s3 !== peg$FAILED) {
-              s1 = [s1, s2, s3];
+              peg$savedPos = s0;
+              s1 = peg$c109(s1, s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3442,7 +3526,8 @@ module.exports = /*
           if (s1 !== peg$FAILED) {
             s2 = peg$parsechem_lit();
             if (s2 !== peg$FAILED) {
-              s1 = [s1, s2];
+              peg$savedPos = s0;
+              s1 = peg$c110(s1, s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3460,50 +3545,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parsechem_color() {
-      var s0, s1;
-
-      var key    = peg$currPos * 122 + 39,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      if (input.substr(peg$currPos, 4) === peg$c109) {
-        s0 = peg$c109;
-        peg$currPos += 4;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c110); }
-      }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        if (input.substr(peg$currPos, 3) === peg$c111) {
-          s1 = peg$c111;
-          peg$currPos += 3;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c112); }
-        }
-        if (s1 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c85(s1);
-        }
-        s0 = s1;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
     function peg$parsechem_latex() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 40,
+      var key    = peg$currPos * 122 + 38,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3525,7 +3570,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c113(s1);
+        s1 = peg$c111(s1);
       }
       s0 = s1;
 
@@ -3537,7 +3582,7 @@ module.exports = /*
     function peg$parsechem_text() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 41,
+      var key    = peg$currPos * 122 + 39,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3559,7 +3604,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c113(s1);
+        s1 = peg$c111(s1);
       }
       s0 = s1;
 
@@ -3571,7 +3616,7 @@ module.exports = /*
     function peg$parsealpha() {
       var s0;
 
-      var key    = peg$currPos * 122 + 42,
+      var key    = peg$currPos * 122 + 40,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3580,12 +3625,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c114.test(input.charAt(peg$currPos))) {
+      if (peg$c112.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c113); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3596,7 +3641,7 @@ module.exports = /*
     function peg$parseliteral_id() {
       var s0;
 
-      var key    = peg$currPos * 122 + 43,
+      var key    = peg$currPos * 122 + 41,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3605,12 +3650,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c114.test(input.charAt(peg$currPos))) {
+      if (peg$c112.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c113); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3621,7 +3666,7 @@ module.exports = /*
     function peg$parseliteral_mn() {
       var s0;
 
-      var key    = peg$currPos * 122 + 44,
+      var key    = peg$currPos * 122 + 42,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3646,7 +3691,32 @@ module.exports = /*
     function peg$parseliteral_uf_lt() {
       var s0;
 
-      var key    = peg$currPos * 122 + 45,
+      var key    = peg$currPos * 122 + 43,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (peg$c114.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsedelimiter_uf_lt() {
+      var s0;
+
+      var key    = peg$currPos * 122 + 44,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3668,10 +3738,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parsedelimiter_uf_lt() {
+    function peg$parseliteral_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 122 + 46,
+      var key    = peg$currPos * 122 + 45,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3693,10 +3763,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseliteral_uf_op() {
+    function peg$parsedelimiter_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 122 + 47,
+      var key    = peg$currPos * 122 + 46,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3718,10 +3788,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parsedelimiter_uf_op() {
-      var s0;
+    function peg$parseboxchars() {
+      var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 48,
+      var key    = peg$currPos * 122 + 47,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3737,51 +3807,26 @@ module.exports = /*
         s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c123); }
       }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseboxchars() {
-      var s0, s1, s2;
-
-      var key    = peg$currPos * 122 + 49,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      if (peg$c124.test(input.charAt(peg$currPos))) {
-        s0 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c125); }
-      }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (peg$c126.test(input.charAt(peg$currPos))) {
+        if (peg$c124.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c127); }
+          if (peg$silentFails === 0) { peg$fail(peg$c125); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c128.test(input.charAt(peg$currPos))) {
+          if (peg$c126.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c129); }
+            if (peg$silentFails === 0) { peg$fail(peg$c127); }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c130(s1, s2);
+            s1 = peg$c128(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3801,7 +3846,7 @@ module.exports = /*
     function peg$parseBOX() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
-      var key    = peg$currPos * 122 + 50,
+      var key    = peg$currPos * 122 + 48,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3814,7 +3859,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c131(s1);
+        s2 = peg$c129(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -3824,11 +3869,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c132;
+              s4 = peg$c130;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c133); }
+              if (peg$silentFails === 0) { peg$fail(peg$c131); }
             }
             if (s4 !== peg$FAILED) {
               s5 = [];
@@ -3853,7 +3898,7 @@ module.exports = /*
                   s7 = peg$parse_();
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c134(s1, s5);
+                    s1 = peg$c132(s1, s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3892,7 +3937,7 @@ module.exports = /*
     function peg$parseLITERAL() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-      var key    = peg$currPos * 122 + 51,
+      var key    = peg$currPos * 122 + 49,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3909,11 +3954,11 @@ module.exports = /*
           s1 = peg$parseliteral_uf_lt();
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 45) {
-              s1 = peg$c135;
+              s1 = peg$c133;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c136); }
+              if (peg$silentFails === 0) { peg$fail(peg$c134); }
             }
             if (s1 === peg$FAILED) {
               s1 = peg$parseliteral_uf_op();
@@ -3925,7 +3970,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c137(s1);
+          s1 = peg$c135(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3940,7 +3985,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c138(s1);
+          s2 = peg$c136(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -3950,11 +3995,11 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s4 = peg$c139;
+                s4 = peg$c137;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c140); }
+                if (peg$silentFails === 0) { peg$fail(peg$c138); }
               }
               if (s4 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 91) {
@@ -3965,19 +4010,19 @@ module.exports = /*
                   if (peg$silentFails === 0) { peg$fail(peg$c79); }
                 }
                 if (s4 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c141) {
-                    s4 = peg$c141;
+                  if (input.substr(peg$currPos, 2) === peg$c139) {
+                    s4 = peg$c139;
                     peg$currPos += 2;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c142); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c140); }
                   }
                   if (s4 === peg$FAILED) {
                     s4 = peg$currPos;
                     s5 = peg$c6;
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s4;
-                      s5 = peg$c143(s1);
+                      s5 = peg$c141(s1);
                     }
                     s4 = s5;
                   }
@@ -3987,7 +4032,7 @@ module.exports = /*
                 s5 = peg$parse_();
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c144(s1, s4);
+                  s1 = peg$c142(s1, s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4014,7 +4059,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c145(s1);
+            s2 = peg$c143(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -4024,11 +4069,11 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s4 = peg$c139;
+                  s4 = peg$c137;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c140); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c138); }
                 }
                 if (s4 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 91) {
@@ -4039,19 +4084,19 @@ module.exports = /*
                     if (peg$silentFails === 0) { peg$fail(peg$c79); }
                   }
                   if (s4 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 2) === peg$c141) {
-                      s4 = peg$c141;
+                    if (input.substr(peg$currPos, 2) === peg$c139) {
+                      s4 = peg$c139;
                       peg$currPos += 2;
                     } else {
                       s4 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c142); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c140); }
                     }
                     if (s4 === peg$FAILED) {
                       s4 = peg$currPos;
                       s5 = peg$c6;
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s4;
-                        s5 = peg$c143(s1);
+                        s5 = peg$c141(s1);
                       }
                       s4 = s5;
                     }
@@ -4061,7 +4106,7 @@ module.exports = /*
                   s5 = peg$parse_();
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c146(s1, s4);
+                    s1 = peg$c144(s1, s4);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4088,7 +4133,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c147(s1);
+              s2 = peg$c145(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -4098,7 +4143,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c148(s1);
+                  s1 = peg$c146(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4117,7 +4162,7 @@ module.exports = /*
               s1 = peg$parsegeneric_func();
               if (s1 !== peg$FAILED) {
                 peg$savedPos = peg$currPos;
-                s2 = peg$c149(s1);
+                s2 = peg$c147(s1);
                 if (s2) {
                   s2 = void 0;
                 } else {
@@ -4127,7 +4172,7 @@ module.exports = /*
                   s3 = peg$parse_();
                   if (s3 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c150(s1);
+                    s1 = peg$c148(s1);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4146,7 +4191,7 @@ module.exports = /*
                 s1 = peg$parsegeneric_func();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = peg$currPos;
-                  s2 = peg$c151(s1);
+                  s2 = peg$c149(s1);
                   if (s2) {
                     s2 = void 0;
                   } else {
@@ -4156,17 +4201,17 @@ module.exports = /*
                     s3 = peg$parse_();
                     if (s3 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 123) {
-                        s4 = peg$c132;
+                        s4 = peg$c130;
                         peg$currPos++;
                       } else {
                         s4 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c131); }
                       }
                       if (s4 !== peg$FAILED) {
                         s5 = peg$parsegeneric_func();
                         if (s5 !== peg$FAILED) {
                           peg$savedPos = peg$currPos;
-                          s6 = peg$c152(s1, s5);
+                          s6 = peg$c150(s1, s5);
                           if (s6) {
                             s6 = void 0;
                           } else {
@@ -4186,7 +4231,7 @@ module.exports = /*
                                 s9 = peg$parse_();
                                 if (s9 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c153(s1, s5);
+                                  s1 = peg$c151(s1, s5);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -4229,7 +4274,7 @@ module.exports = /*
                   s1 = peg$parsegeneric_func();
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = peg$currPos;
-                    s2 = peg$c154(s1);
+                    s2 = peg$c152(s1);
                     if (s2) {
                       s2 = void 0;
                     } else {
@@ -4239,7 +4284,7 @@ module.exports = /*
                       s3 = peg$parse_();
                       if (s3 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c155(s1);
+                        s1 = peg$c153(s1);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -4258,7 +4303,7 @@ module.exports = /*
                     s1 = peg$parsegeneric_func();
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = peg$currPos;
-                      s2 = peg$c156(s1);
+                      s2 = peg$c154(s1);
                       if (s2) {
                         s2 = void 0;
                       } else {
@@ -4268,17 +4313,17 @@ module.exports = /*
                         s3 = peg$parse_();
                         if (s3 !== peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 123) {
-                            s4 = peg$c132;
+                            s4 = peg$c130;
                             peg$currPos++;
                           } else {
                             s4 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c133); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c131); }
                           }
                           if (s4 !== peg$FAILED) {
                             s5 = peg$parsegeneric_func();
                             if (s5 !== peg$FAILED) {
                               peg$savedPos = peg$currPos;
-                              s6 = peg$c157(s1, s5);
+                              s6 = peg$c155(s1, s5);
                               if (s6) {
                                 s6 = void 0;
                               } else {
@@ -4298,7 +4343,7 @@ module.exports = /*
                                     s9 = peg$parse_();
                                     if (s9 !== peg$FAILED) {
                                       peg$savedPos = s0;
-                                      s1 = peg$c158(s1, s5);
+                                      s1 = peg$c156(s1, s5);
                                       s0 = s1;
                                     } else {
                                       peg$currPos = s0;
@@ -4344,31 +4389,31 @@ module.exports = /*
                       }
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c159(s1);
+                        s1 = peg$c157(s1);
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
                         if (input.charCodeAt(peg$currPos) === 92) {
-                          s1 = peg$c160;
+                          s1 = peg$c158;
                           peg$currPos++;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c161); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c159); }
                         }
                         if (s1 !== peg$FAILED) {
-                          if (peg$c162.test(input.charAt(peg$currPos))) {
+                          if (peg$c160.test(input.charAt(peg$currPos))) {
                             s2 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s2 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c163); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c161); }
                           }
                           if (s2 !== peg$FAILED) {
                             s3 = peg$parse_();
                             if (s3 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c164(s2);
+                              s1 = peg$c162(s2);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -4384,18 +4429,18 @@ module.exports = /*
                         }
                         if (s0 === peg$FAILED) {
                           s0 = peg$currPos;
-                          if (peg$c165.test(input.charAt(peg$currPos))) {
+                          if (peg$c163.test(input.charAt(peg$currPos))) {
                             s1 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c166); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c164); }
                           }
                           if (s1 !== peg$FAILED) {
                             s2 = peg$parse_();
                             if (s2 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c137(s1);
+                              s1 = peg$c135(s1);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -4407,18 +4452,18 @@ module.exports = /*
                           }
                           if (s0 === peg$FAILED) {
                             s0 = peg$currPos;
-                            if (peg$c167.test(input.charAt(peg$currPos))) {
+                            if (peg$c165.test(input.charAt(peg$currPos))) {
                               s1 = input.charAt(peg$currPos);
                               peg$currPos++;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c168); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c166); }
                             }
                             if (s1 !== peg$FAILED) {
                               s2 = peg$parse_();
                               if (s2 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c169(s1);
+                                s1 = peg$c167(s1);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -4448,7 +4493,7 @@ module.exports = /*
     function peg$parseDELIMITER() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 52,
+      var key    = peg$currPos * 122 + 50,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4475,7 +4520,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c137(s1);
+          s1 = peg$c135(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4488,25 +4533,25 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c160;
+          s1 = peg$c158;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c161); }
+          if (peg$silentFails === 0) { peg$fail(peg$c159); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c170.test(input.charAt(peg$currPos))) {
+          if (peg$c168.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c171); }
+            if (peg$silentFails === 0) { peg$fail(peg$c169); }
           }
           if (s2 !== peg$FAILED) {
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c164(s2);
+              s1 = peg$c162(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4525,7 +4570,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c172(s1);
+            s2 = peg$c170(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -4535,7 +4580,7 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c148(s1);
+                s1 = peg$c146(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4554,7 +4599,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c173(s1);
+              s2 = peg$c171(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -4564,7 +4609,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c174(s1);
+                  s1 = peg$c172(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4590,7 +4635,7 @@ module.exports = /*
     function peg$parseFUN_AR1nb() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 53,
+      var key    = peg$currPos * 122 + 51,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4603,7 +4648,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c175(s1);
+        s2 = peg$c173(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -4613,7 +4658,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c174(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4636,7 +4681,7 @@ module.exports = /*
     function peg$parseFUN_AR1opt() {
       var s0, s1, s2, s3, s4, s5;
 
-      var key    = peg$currPos * 122 + 54,
+      var key    = peg$currPos * 122 + 52,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4649,7 +4694,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c177(s1);
+        s2 = peg$c175(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -4669,7 +4714,7 @@ module.exports = /*
               s5 = peg$parse_();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c176(s1);
+                s1 = peg$c174(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4700,7 +4745,7 @@ module.exports = /*
     function peg$parseNEXT_CELL() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 55,
+      var key    = peg$currPos * 122 + 53,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4711,11 +4756,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 38) {
-        s1 = peg$c178;
+        s1 = peg$c176;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c177); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4739,7 +4784,7 @@ module.exports = /*
     function peg$parseNEXT_ROW() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 56,
+      var key    = peg$currPos * 122 + 54,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4749,12 +4794,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c180) {
-        s1 = peg$c180;
+      if (input.substr(peg$currPos, 2) === peg$c178) {
+        s1 = peg$c178;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c181); }
+        if (peg$silentFails === 0) { peg$fail(peg$c179); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4778,7 +4823,7 @@ module.exports = /*
     function peg$parseBEGIN() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 57,
+      var key    = peg$currPos * 122 + 55,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4788,12 +4833,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c182) {
-        s1 = peg$c182;
+      if (input.substr(peg$currPos, 6) === peg$c180) {
+        s1 = peg$c180;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c181); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4817,7 +4862,7 @@ module.exports = /*
     function peg$parseEND() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 58,
+      var key    = peg$currPos * 122 + 56,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4827,12 +4872,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c184) {
-        s1 = peg$c184;
+      if (input.substr(peg$currPos, 4) === peg$c182) {
+        s1 = peg$c182;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c185); }
+        if (peg$silentFails === 0) { peg$fail(peg$c183); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4856,7 +4901,7 @@ module.exports = /*
     function peg$parseBEGIN_MATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 59,
+      var key    = peg$currPos * 122 + 57,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4868,12 +4913,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c186) {
-          s2 = peg$c186;
+        if (input.substr(peg$currPos, 8) === peg$c184) {
+          s2 = peg$c184;
           peg$currPos += 8;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c187); }
+          if (peg$silentFails === 0) { peg$fail(peg$c185); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4901,7 +4946,7 @@ module.exports = /*
     function peg$parseEND_MATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 60,
+      var key    = peg$currPos * 122 + 58,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4913,9 +4958,54 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c186) {
-          s2 = peg$c186;
+        if (input.substr(peg$currPos, 8) === peg$c184) {
+          s2 = peg$c184;
           peg$currPos += 8;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c185); }
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            s1 = [s1, s2, s3];
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseBEGIN_PMATRIX() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 122 + 59,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parseBEGIN();
+      if (s1 !== peg$FAILED) {
+        if (input.substr(peg$currPos, 9) === peg$c186) {
+          s2 = peg$c186;
+          peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$c187); }
@@ -4943,7 +5033,52 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseBEGIN_PMATRIX() {
+    function peg$parseEND_PMATRIX() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 122 + 60,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parseEND();
+      if (s1 !== peg$FAILED) {
+        if (input.substr(peg$currPos, 9) === peg$c186) {
+          s2 = peg$c186;
+          peg$currPos += 9;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c187); }
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            s1 = [s1, s2, s3];
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseBEGIN_BMATRIX() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 61,
@@ -4988,7 +5123,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseEND_PMATRIX() {
+    function peg$parseEND_BMATRIX() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 62,
@@ -5033,7 +5168,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseBEGIN_BMATRIX() {
+    function peg$parseBEGIN_BBMATRIX() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 63,
@@ -5078,7 +5213,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseEND_BMATRIX() {
+    function peg$parseEND_BBMATRIX() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 64,
@@ -5123,7 +5258,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseBEGIN_BBMATRIX() {
+    function peg$parseBEGIN_VMATRIX() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 65,
@@ -5168,7 +5303,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseEND_BBMATRIX() {
+    function peg$parseEND_VMATRIX() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 66,
@@ -5213,7 +5348,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseBEGIN_VMATRIX() {
+    function peg$parseBEGIN_VVMATRIX() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 67,
@@ -5258,7 +5393,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseEND_VMATRIX() {
+    function peg$parseEND_VVMATRIX() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 68,
@@ -5303,7 +5438,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseBEGIN_VVMATRIX() {
+    function peg$parseBEGIN_ARRAY() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 69,
@@ -5318,9 +5453,9 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c196) {
+        if (input.substr(peg$currPos, 7) === peg$c196) {
           s2 = peg$c196;
-          peg$currPos += 9;
+          peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$c197); }
@@ -5348,7 +5483,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseEND_VVMATRIX() {
+    function peg$parseEND_ARRAY() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 70,
@@ -5363,9 +5498,9 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c196) {
+        if (input.substr(peg$currPos, 7) === peg$c196) {
           s2 = peg$c196;
-          peg$currPos += 9;
+          peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$c197); }
@@ -5393,7 +5528,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseBEGIN_ARRAY() {
+    function peg$parseBEGIN_ALIGN() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 71,
@@ -5438,7 +5573,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseEND_ARRAY() {
+    function peg$parseEND_ALIGN() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 72,
@@ -5483,7 +5618,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseBEGIN_ALIGN() {
+    function peg$parseBEGIN_ALIGNED() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 73,
@@ -5498,9 +5633,9 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c200) {
+        if (input.substr(peg$currPos, 9) === peg$c200) {
           s2 = peg$c200;
-          peg$currPos += 7;
+          peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$c201); }
@@ -5528,7 +5663,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseEND_ALIGN() {
+    function peg$parseEND_ALIGNED() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 74,
@@ -5543,9 +5678,9 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c200) {
+        if (input.substr(peg$currPos, 9) === peg$c200) {
           s2 = peg$c200;
-          peg$currPos += 7;
+          peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$c201); }
@@ -5573,7 +5708,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseBEGIN_ALIGNED() {
+    function peg$parseBEGIN_ALIGNAT() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 75,
@@ -5618,7 +5753,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseEND_ALIGNED() {
+    function peg$parseEND_ALIGNAT() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 76,
@@ -5663,7 +5798,7 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseBEGIN_ALIGNAT() {
+    function peg$parseBEGIN_ALIGNEDAT() {
       var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 77,
@@ -5678,102 +5813,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c204) {
+        if (input.substr(peg$currPos, 11) === peg$c204) {
           s2 = peg$c204;
-          peg$currPos += 9;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c205); }
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            s1 = [s1, s2, s3];
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseEND_ALIGNAT() {
-      var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 122 + 78,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      s1 = peg$parseEND();
-      if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c204) {
-          s2 = peg$c204;
-          peg$currPos += 9;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c205); }
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            s1 = [s1, s2, s3];
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseBEGIN_ALIGNEDAT() {
-      var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 122 + 79,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      s1 = peg$parseBEGIN();
-      if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c206) {
-          s2 = peg$c206;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c207); }
+          if (peg$silentFails === 0) { peg$fail(peg$c205); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5801,7 +5846,7 @@ module.exports = /*
     function peg$parseEND_ALIGNEDAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 80,
+      var key    = peg$currPos * 122 + 78,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5813,12 +5858,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c206) {
-          s2 = peg$c206;
+        if (input.substr(peg$currPos, 11) === peg$c204) {
+          s2 = peg$c204;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c207); }
+          if (peg$silentFails === 0) { peg$fail(peg$c205); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5846,7 +5891,7 @@ module.exports = /*
     function peg$parseBEGIN_SMALLMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 81,
+      var key    = peg$currPos * 122 + 79,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5858,12 +5903,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c208) {
-          s2 = peg$c208;
+        if (input.substr(peg$currPos, 13) === peg$c206) {
+          s2 = peg$c206;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c209); }
+          if (peg$silentFails === 0) { peg$fail(peg$c207); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5891,7 +5936,7 @@ module.exports = /*
     function peg$parseEND_SMALLMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 82,
+      var key    = peg$currPos * 122 + 80,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5903,12 +5948,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c208) {
-          s2 = peg$c208;
+        if (input.substr(peg$currPos, 13) === peg$c206) {
+          s2 = peg$c206;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c209); }
+          if (peg$silentFails === 0) { peg$fail(peg$c207); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5936,7 +5981,7 @@ module.exports = /*
     function peg$parseBEGIN_CASES() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 83,
+      var key    = peg$currPos * 122 + 81,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5948,12 +5993,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c210) {
-          s2 = peg$c210;
+        if (input.substr(peg$currPos, 7) === peg$c208) {
+          s2 = peg$c208;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c211); }
+          if (peg$silentFails === 0) { peg$fail(peg$c209); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5981,7 +6026,7 @@ module.exports = /*
     function peg$parseEND_CASES() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 84,
+      var key    = peg$currPos * 122 + 82,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5993,12 +6038,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c210) {
-          s2 = peg$c210;
+        if (input.substr(peg$currPos, 7) === peg$c208) {
+          s2 = peg$c208;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c211); }
+          if (peg$silentFails === 0) { peg$fail(peg$c209); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6026,7 +6071,7 @@ module.exports = /*
     function peg$parseSQ_CLOSE() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 85,
+      var key    = peg$currPos * 122 + 83,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6065,7 +6110,7 @@ module.exports = /*
     function peg$parseCURLY_OPEN() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 86,
+      var key    = peg$currPos * 122 + 84,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6076,11 +6121,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c130;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c131); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6104,7 +6149,7 @@ module.exports = /*
     function peg$parseCURLY_CLOSE() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 87,
+      var key    = peg$currPos * 122 + 85,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6143,7 +6188,7 @@ module.exports = /*
     function peg$parseSUP() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 88,
+      var key    = peg$currPos * 122 + 86,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6154,11 +6199,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 94) {
-        s1 = peg$c212;
+        s1 = peg$c93;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c213); }
+        if (peg$silentFails === 0) { peg$fail(peg$c94); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6182,7 +6227,7 @@ module.exports = /*
     function peg$parseSUB() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 89,
+      var key    = peg$currPos * 122 + 87,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6193,11 +6238,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 95) {
-        s1 = peg$c107;
+        s1 = peg$c106;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c108); }
+        if (peg$silentFails === 0) { peg$fail(peg$c107); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6221,7 +6266,7 @@ module.exports = /*
     function peg$parsegeneric_func() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 90,
+      var key    = peg$currPos * 122 + 88,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6232,11 +6277,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c160;
+        s1 = peg$c158;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c161); }
+        if (peg$silentFails === 0) { peg$fail(peg$c159); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -6270,7 +6315,7 @@ module.exports = /*
     function peg$parseBIG() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 91,
+      var key    = peg$currPos * 122 + 89,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6283,7 +6328,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c214(s1);
+        s2 = peg$c210(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6293,7 +6338,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c174(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6316,7 +6361,7 @@ module.exports = /*
     function peg$parseFUN_AR1() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 92,
+      var key    = peg$currPos * 122 + 90,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6329,7 +6374,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c215(s1);
+        s2 = peg$c211(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6339,7 +6384,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c174(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6358,7 +6403,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c216(s1);
+          s2 = peg$c212(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -6368,7 +6413,7 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c216(s1);
+              s1 = peg$c212(s1);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6392,7 +6437,7 @@ module.exports = /*
     function peg$parseFUN_MHCHEM() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 93,
+      var key    = peg$currPos * 122 + 91,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6405,7 +6450,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c217(s1);
+        s2 = peg$c213(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6413,7 +6458,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c176(s1);
+          s1 = peg$c174(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6432,7 +6477,7 @@ module.exports = /*
     function peg$parseFUN_AR2() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 94,
+      var key    = peg$currPos * 122 + 92,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6445,7 +6490,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c218(s1);
+        s2 = peg$c214(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6455,7 +6500,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c174(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6478,7 +6523,7 @@ module.exports = /*
     function peg$parseFUN_INFIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 95,
+      var key    = peg$currPos * 122 + 93,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6491,7 +6536,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c219(s1);
+        s2 = peg$c215(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6501,7 +6546,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c174(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6524,7 +6569,7 @@ module.exports = /*
     function peg$parseDECLh() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 96,
+      var key    = peg$currPos * 122 + 94,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6537,7 +6582,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c220(s1);
+        s2 = peg$c216(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6547,7 +6592,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c221(s1);
+            s1 = peg$c217(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6570,7 +6615,7 @@ module.exports = /*
     function peg$parseFUN_AR2nb() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 97,
+      var key    = peg$currPos * 122 + 95,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6583,7 +6628,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c222(s1);
+        s2 = peg$c218(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6593,7 +6638,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c174(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6616,7 +6661,7 @@ module.exports = /*
     function peg$parseLEFT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 98,
+      var key    = peg$currPos * 122 + 96,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6629,7 +6674,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c223(s1);
+        s2 = peg$c219(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6661,7 +6706,7 @@ module.exports = /*
     function peg$parseRIGHT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 99,
+      var key    = peg$currPos * 122 + 97,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6674,7 +6719,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c224(s1);
+        s2 = peg$c220(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6706,7 +6751,7 @@ module.exports = /*
     function peg$parseHLINE() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 100,
+      var key    = peg$currPos * 122 + 98,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6719,7 +6764,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c225(s1);
+        s2 = peg$c221(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6729,7 +6774,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c174(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6752,7 +6797,7 @@ module.exports = /*
     function peg$parseCOLOR() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 122 + 101,
+      var key    = peg$currPos * 122 + 99,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6765,7 +6810,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c226(s1);
+        s2 = peg$c222(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6777,7 +6822,7 @@ module.exports = /*
             s4 = peg$parseCOLOR_SPEC();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c227(s1, s4);
+              s1 = peg$c223(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6804,7 +6849,7 @@ module.exports = /*
     function peg$parseDEFINECOLOR() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17;
 
-      var key    = peg$currPos * 122 + 102,
+      var key    = peg$currPos * 122 + 100,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6817,7 +6862,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c228(s1);
+        s2 = peg$c224(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6827,11 +6872,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c132;
+              s4 = peg$c130;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c133); }
+              if (peg$silentFails === 0) { peg$fail(peg$c131); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -6860,22 +6905,22 @@ module.exports = /*
                       s9 = peg$parse_();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 123) {
-                          s10 = peg$c132;
+                          s10 = peg$c130;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c133); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c131); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             s12 = peg$currPos;
-                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c229) {
+                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c225) {
                               s13 = input.substr(peg$currPos, 5);
                               peg$currPos += 5;
                             } else {
                               s13 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c230); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c226); }
                             }
                             if (s13 !== peg$FAILED) {
                               s14 = peg$parse_();
@@ -6893,7 +6938,7 @@ module.exports = /*
                                     s17 = peg$parseCOLOR_SPEC_NAMED();
                                     if (s17 !== peg$FAILED) {
                                       peg$savedPos = s12;
-                                      s13 = peg$c231(s1, s6, s17);
+                                      s13 = peg$c227(s1, s6, s17);
                                       s12 = s13;
                                     } else {
                                       peg$currPos = s12;
@@ -6917,12 +6962,12 @@ module.exports = /*
                             }
                             if (s12 === peg$FAILED) {
                               s12 = peg$currPos;
-                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c232) {
+                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c228) {
                                 s13 = input.substr(peg$currPos, 4);
                                 peg$currPos += 4;
                               } else {
                                 s13 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c233); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c229); }
                               }
                               if (s13 !== peg$FAILED) {
                                 s14 = peg$parse_();
@@ -6940,7 +6985,7 @@ module.exports = /*
                                       s17 = peg$parseCOLOR_SPEC_GRAY();
                                       if (s17 !== peg$FAILED) {
                                         peg$savedPos = s12;
-                                        s13 = peg$c234(s1, s6, s17);
+                                        s13 = peg$c230(s1, s6, s17);
                                         s12 = s13;
                                       } else {
                                         peg$currPos = s12;
@@ -6964,12 +7009,12 @@ module.exports = /*
                               }
                               if (s12 === peg$FAILED) {
                                 s12 = peg$currPos;
-                                if (input.substr(peg$currPos, 3) === peg$c235) {
-                                  s13 = peg$c235;
+                                if (input.substr(peg$currPos, 3) === peg$c231) {
+                                  s13 = peg$c231;
                                   peg$currPos += 3;
                                 } else {
                                   s13 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c236); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c232); }
                                 }
                                 if (s13 !== peg$FAILED) {
                                   s14 = peg$parse_();
@@ -6987,7 +7032,7 @@ module.exports = /*
                                         s17 = peg$parseCOLOR_SPEC_rgb();
                                         if (s17 !== peg$FAILED) {
                                           peg$savedPos = s12;
-                                          s13 = peg$c237(s1, s6, s17);
+                                          s13 = peg$c233(s1, s6, s17);
                                           s12 = s13;
                                         } else {
                                           peg$currPos = s12;
@@ -7011,12 +7056,12 @@ module.exports = /*
                                 }
                                 if (s12 === peg$FAILED) {
                                   s12 = peg$currPos;
-                                  if (input.substr(peg$currPos, 3) === peg$c238) {
-                                    s13 = peg$c238;
+                                  if (input.substr(peg$currPos, 3) === peg$c234) {
+                                    s13 = peg$c234;
                                     peg$currPos += 3;
                                   } else {
                                     s13 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c239); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c235); }
                                   }
                                   if (s13 !== peg$FAILED) {
                                     s14 = peg$parse_();
@@ -7034,7 +7079,7 @@ module.exports = /*
                                           s17 = peg$parseCOLOR_SPEC_RGB();
                                           if (s17 !== peg$FAILED) {
                                             peg$savedPos = s12;
-                                            s13 = peg$c237(s1, s6, s17);
+                                            s13 = peg$c233(s1, s6, s17);
                                             s12 = s13;
                                           } else {
                                             peg$currPos = s12;
@@ -7058,12 +7103,12 @@ module.exports = /*
                                   }
                                   if (s12 === peg$FAILED) {
                                     s12 = peg$currPos;
-                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c240) {
+                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c236) {
                                       s13 = input.substr(peg$currPos, 4);
                                       peg$currPos += 4;
                                     } else {
                                       s13 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c241); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c237); }
                                     }
                                     if (s13 !== peg$FAILED) {
                                       s14 = peg$parse_();
@@ -7081,7 +7126,7 @@ module.exports = /*
                                             s17 = peg$parseCOLOR_SPEC_CMYK();
                                             if (s17 !== peg$FAILED) {
                                               peg$savedPos = s12;
-                                              s13 = peg$c242(s1, s6, s17);
+                                              s13 = peg$c238(s1, s6, s17);
                                               s12 = s13;
                                             } else {
                                               peg$currPos = s12;
@@ -7109,7 +7154,7 @@ module.exports = /*
                             }
                             if (s12 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c243(s1, s6, s12);
+                              s1 = peg$c239(s1, s6, s12);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -7168,7 +7213,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
-      var key    = peg$currPos * 122 + 103,
+      var key    = peg$currPos * 122 + 101,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7190,12 +7235,12 @@ module.exports = /*
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c229) {
+            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c225) {
               s3 = input.substr(peg$currPos, 5);
               peg$currPos += 5;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c230); }
+              if (peg$silentFails === 0) { peg$fail(peg$c226); }
             }
             if (s3 !== peg$FAILED) {
               s4 = peg$parse_();
@@ -7213,7 +7258,7 @@ module.exports = /*
                     s7 = peg$parseCOLOR_SPEC_NAMED();
                     if (s7 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c244(s7);
+                      s1 = peg$c240(s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -7255,12 +7300,12 @@ module.exports = /*
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c232) {
+              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c228) {
                 s3 = input.substr(peg$currPos, 4);
                 peg$currPos += 4;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c233); }
+                if (peg$silentFails === 0) { peg$fail(peg$c229); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -7278,7 +7323,7 @@ module.exports = /*
                       s7 = peg$parseCOLOR_SPEC_GRAY();
                       if (s7 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c245(s7);
+                        s1 = peg$c241(s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -7320,12 +7365,12 @@ module.exports = /*
             if (s1 !== peg$FAILED) {
               s2 = peg$parse_();
               if (s2 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 3) === peg$c235) {
-                  s3 = peg$c235;
+                if (input.substr(peg$currPos, 3) === peg$c231) {
+                  s3 = peg$c231;
                   peg$currPos += 3;
                 } else {
                   s3 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c236); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c232); }
                 }
                 if (s3 !== peg$FAILED) {
                   s4 = peg$parse_();
@@ -7343,7 +7388,7 @@ module.exports = /*
                         s7 = peg$parseCOLOR_SPEC_rgb();
                         if (s7 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c246(s7);
+                          s1 = peg$c242(s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -7385,12 +7430,12 @@ module.exports = /*
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse_();
                 if (s2 !== peg$FAILED) {
-                  if (input.substr(peg$currPos, 3) === peg$c238) {
-                    s3 = peg$c238;
+                  if (input.substr(peg$currPos, 3) === peg$c234) {
+                    s3 = peg$c234;
                     peg$currPos += 3;
                   } else {
                     s3 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c239); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c235); }
                   }
                   if (s3 !== peg$FAILED) {
                     s4 = peg$parse_();
@@ -7408,7 +7453,7 @@ module.exports = /*
                           s7 = peg$parseCOLOR_SPEC_RGB();
                           if (s7 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c246(s7);
+                            s1 = peg$c242(s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7450,12 +7495,12 @@ module.exports = /*
                 if (s1 !== peg$FAILED) {
                   s2 = peg$parse_();
                   if (s2 !== peg$FAILED) {
-                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c240) {
+                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c236) {
                       s3 = input.substr(peg$currPos, 4);
                       peg$currPos += 4;
                     } else {
                       s3 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c241); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c237); }
                     }
                     if (s3 !== peg$FAILED) {
                       s4 = peg$parse_();
@@ -7473,7 +7518,7 @@ module.exports = /*
                             s7 = peg$parseCOLOR_SPEC_CMYK();
                             if (s7 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c247(s7);
+                              s1 = peg$c243(s7);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -7517,7 +7562,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_NAMED() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 122 + 104,
+      var key    = peg$currPos * 122 + 102,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7528,11 +7573,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c130;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c131); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7561,7 +7606,7 @@ module.exports = /*
                 s6 = peg$parse_();
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c248(s3);
+                  s1 = peg$c244(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7596,7 +7641,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_GRAY() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 122 + 105,
+      var key    = peg$currPos * 122 + 103,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7607,11 +7652,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c130;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c131); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7636,7 +7681,7 @@ module.exports = /*
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c249(s3);
+              s1 = peg$c245(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7663,7 +7708,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_rgb() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-      var key    = peg$currPos * 122 + 106,
+      var key    = peg$currPos * 122 + 104,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7674,11 +7719,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c130;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c131); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7686,11 +7731,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c250;
+              s4 = peg$c246;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c251); }
+              if (peg$silentFails === 0) { peg$fail(peg$c247); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7698,11 +7743,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c250;
+                    s7 = peg$c246;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c251); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c247); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -7720,7 +7765,7 @@ module.exports = /*
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c252(s3, s6, s9);
+                            s1 = peg$c248(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7775,7 +7820,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_RGB() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-      var key    = peg$currPos * 122 + 107,
+      var key    = peg$currPos * 122 + 105,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7786,11 +7831,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c130;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c131); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7798,11 +7843,11 @@ module.exports = /*
           s3 = peg$parseCNUM255();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c250;
+              s4 = peg$c246;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c251); }
+              if (peg$silentFails === 0) { peg$fail(peg$c247); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7810,11 +7855,11 @@ module.exports = /*
                 s6 = peg$parseCNUM255();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c250;
+                    s7 = peg$c246;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c251); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c247); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -7832,7 +7877,7 @@ module.exports = /*
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c252(s3, s6, s9);
+                            s1 = peg$c248(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7887,7 +7932,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_CMYK() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14;
 
-      var key    = peg$currPos * 122 + 108,
+      var key    = peg$currPos * 122 + 106,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7898,11 +7943,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c130;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c131); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7910,11 +7955,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c250;
+              s4 = peg$c246;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c251); }
+              if (peg$silentFails === 0) { peg$fail(peg$c247); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7922,11 +7967,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c250;
+                    s7 = peg$c246;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c251); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c247); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -7934,11 +7979,11 @@ module.exports = /*
                       s9 = peg$parseCNUM();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 44) {
-                          s10 = peg$c250;
+                          s10 = peg$c246;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c251); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c247); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
@@ -7956,7 +8001,7 @@ module.exports = /*
                                 s14 = peg$parse_();
                                 if (s14 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c253(s3, s6, s9, s12);
+                                  s1 = peg$c249(s3, s6, s9, s12);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -8023,7 +8068,7 @@ module.exports = /*
     function peg$parseCNUM255() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 122 + 109,
+      var key    = peg$currPos * 122 + 107,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8035,20 +8080,20 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s2 = peg$c254;
+        s2 = peg$c250;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c255); }
+        if (peg$silentFails === 0) { peg$fail(peg$c251); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$currPos;
-        if (peg$c256.test(input.charAt(peg$currPos))) {
+        if (peg$c252.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c257); }
+          if (peg$silentFails === 0) { peg$fail(peg$c253); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -8103,7 +8148,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c258(s1);
+        s2 = peg$c254(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8113,7 +8158,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c259(s1);
+            s1 = peg$c255(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8136,7 +8181,7 @@ module.exports = /*
     function peg$parseCNUM() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 122 + 110,
+      var key    = peg$currPos * 122 + 108,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8149,22 +8194,22 @@ module.exports = /*
       s1 = peg$currPos;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s3 = peg$c254;
+        s3 = peg$c250;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c255); }
+        if (peg$silentFails === 0) { peg$fail(peg$c251); }
       }
       if (s3 === peg$FAILED) {
         s3 = null;
       }
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c260;
+          s4 = peg$c256;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c261); }
+          if (peg$silentFails === 0) { peg$fail(peg$c257); }
         }
         if (s4 !== peg$FAILED) {
           s5 = [];
@@ -8213,7 +8258,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c262(s1);
+          s1 = peg$c258(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8227,20 +8272,20 @@ module.exports = /*
         s0 = peg$currPos;
         s1 = peg$currPos;
         s2 = peg$currPos;
-        if (peg$c263.test(input.charAt(peg$currPos))) {
+        if (peg$c259.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c264); }
+          if (peg$silentFails === 0) { peg$fail(peg$c260); }
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c260;
+            s4 = peg$c256;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c261); }
+            if (peg$silentFails === 0) { peg$fail(peg$c257); }
           }
           if (s4 === peg$FAILED) {
             s4 = null;
@@ -8265,7 +8310,7 @@ module.exports = /*
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c262(s1);
+            s1 = peg$c258(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8285,7 +8330,7 @@ module.exports = /*
     function peg$parseimpossible() {
       var s0;
 
-      var key    = peg$currPos * 122 + 111,
+      var key    = peg$currPos * 122 + 109,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8295,7 +8340,7 @@ module.exports = /*
       }
 
       peg$savedPos = peg$currPos;
-      s0 = peg$c265();
+      s0 = peg$c261();
       if (s0) {
         s0 = void 0;
       } else {
@@ -8310,7 +8355,7 @@ module.exports = /*
     function peg$parseEOF() {
       var s0;
 
-      var key    = peg$currPos * 122 + 112,
+      var key    = peg$currPos * 122 + 110,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8320,10 +8365,75 @@ module.exports = /*
       }
 
       peg$savedPos = peg$currPos;
-      s0 = peg$c266();
+      s0 = peg$c262();
       if (s0) {
         s0 = void 0;
       } else {
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_LETTER() {
+      var s0;
+
+      var key    = peg$currPos * 122 + 111,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (peg$c112.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c113); }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_SINGLE_MACRO() {
+      var s0, s1, s2;
+
+      var key    = peg$currPos * 122 + 112,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c263(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c174(s1);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
         s0 = peg$FAILED;
       }
 
@@ -8348,12 +8458,12 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$parseliteral_id();
         if (s0 === peg$FAILED) {
-          if (peg$c267.test(input.charAt(peg$currPos))) {
+          if (peg$c264.test(input.charAt(peg$currPos))) {
             s0 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c268); }
+            if (peg$silentFails === 0) { peg$fail(peg$c265); }
           }
         }
       }
@@ -8376,19 +8486,19 @@ module.exports = /*
       }
 
       if (input.charCodeAt(peg$currPos) === 95) {
-        s0 = peg$c107;
+        s0 = peg$c106;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c108); }
+        if (peg$silentFails === 0) { peg$fail(peg$c107); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 94) {
-          s0 = peg$c212;
+          s0 = peg$c93;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c213); }
+          if (peg$silentFails === 0) { peg$fail(peg$c94); }
         }
       }
 
@@ -8410,123 +8520,123 @@ module.exports = /*
       }
 
       if (input.charCodeAt(peg$currPos) === 61) {
-        s0 = peg$c269;
+        s0 = peg$c266;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c270); }
+        if (peg$silentFails === 0) { peg$fail(peg$c267); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 35) {
-          s0 = peg$c271;
+          s0 = peg$c268;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c272); }
+          if (peg$silentFails === 0) { peg$fail(peg$c269); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c273) {
-            s0 = peg$c273;
+          if (input.substr(peg$currPos, 3) === peg$c270) {
+            s0 = peg$c270;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c274); }
+            if (peg$silentFails === 0) { peg$fail(peg$c271); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c275) {
-              s0 = peg$c275;
+            if (input.substr(peg$currPos, 2) === peg$c272) {
+              s0 = peg$c272;
               peg$currPos += 2;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c276); }
+              if (peg$silentFails === 0) { peg$fail(peg$c273); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c277) {
-                s0 = peg$c277;
+              if (input.substr(peg$currPos, 2) === peg$c274) {
+                s0 = peg$c274;
                 peg$currPos += 2;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c278); }
+                if (peg$silentFails === 0) { peg$fail(peg$c275); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 126) {
-                  s0 = peg$c279;
+                  s0 = peg$c276;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c280); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c277); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 3) === peg$c281) {
-                    s0 = peg$c281;
+                  if (input.substr(peg$currPos, 3) === peg$c278) {
+                    s0 = peg$c278;
                     peg$currPos += 3;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c282); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c279); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 45) {
-                      s0 = peg$c135;
+                      s0 = peg$c133;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c136); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c134); }
                     }
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 4) === peg$c283) {
-                        s0 = peg$c283;
+                      if (input.substr(peg$currPos, 4) === peg$c280) {
+                        s0 = peg$c280;
                         peg$currPos += 4;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c281); }
                       }
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 3) === peg$c285) {
-                          s0 = peg$c285;
+                        if (input.substr(peg$currPos, 3) === peg$c282) {
+                          s0 = peg$c282;
                           peg$currPos += 3;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c286); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c283); }
                         }
                         if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c287) {
-                            s0 = peg$c287;
+                          if (input.substr(peg$currPos, 2) === peg$c284) {
+                            s0 = peg$c284;
                             peg$currPos += 2;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c288); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c285); }
                           }
                           if (s0 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 2) === peg$c289) {
-                              s0 = peg$c289;
+                            if (input.substr(peg$currPos, 2) === peg$c286) {
+                              s0 = peg$c286;
                               peg$currPos += 2;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c290); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c287); }
                             }
                             if (s0 === peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 49) {
-                                s0 = peg$c291;
+                                s0 = peg$c288;
                                 peg$currPos++;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c292); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c289); }
                               }
                               if (s0 === peg$FAILED) {
                                 if (input.charCodeAt(peg$currPos) === 50) {
-                                  s0 = peg$c293;
+                                  s0 = peg$c290;
                                   peg$currPos++;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c291); }
                                 }
                                 if (s0 === peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 51) {
-                                    s0 = peg$c295;
+                                    s0 = peg$c292;
                                     peg$currPos++;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c296); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c293); }
                                   }
                                 }
                               }
@@ -8561,11 +8671,11 @@ module.exports = /*
       }
 
       if (input.charCodeAt(peg$currPos) === 36) {
-        s0 = peg$c297;
+        s0 = peg$c294;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c298); }
+        if (peg$silentFails === 0) { peg$fail(peg$c295); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -8589,7 +8699,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c299(s1);
+        s2 = peg$c296(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8597,7 +8707,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c176(s1);
+          s1 = peg$c174(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8625,38 +8735,63 @@ module.exports = /*
         return cached.result;
       }
 
-      if (input.substr(peg$currPos, 2) === peg$c141) {
-        s0 = peg$c141;
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 2) === peg$c139) {
+        s1 = peg$c139;
         peg$currPos += 2;
       } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c142); }
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c140); }
       }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c297(s1);
+      }
+      s0 = s1;
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c300) {
-          s0 = peg$c300;
+        s0 = peg$currPos;
+        if (input.substr(peg$currPos, 2) === peg$c298) {
+          s1 = peg$c298;
           peg$currPos += 2;
         } else {
-          s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c301); }
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c299); }
         }
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c297(s1);
+        }
+        s0 = s1;
         if (s0 === peg$FAILED) {
-          if (peg$c302.test(input.charAt(peg$currPos))) {
-            s0 = input.charAt(peg$currPos);
+          s0 = peg$currPos;
+          if (peg$c300.test(input.charAt(peg$currPos))) {
+            s1 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
-            s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c303); }
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c301); }
           }
+          if (s1 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c297(s1);
+          }
+          s0 = s1;
           if (s0 === peg$FAILED) {
-            s0 = peg$parseliteral_mn();
+            s0 = peg$currPos;
+            s1 = peg$parseliteral_mn();
+            if (s1 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c297(s1);
+            }
+            s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               s1 = peg$parseCURLY_OPEN();
               if (s1 !== peg$FAILED) {
                 s2 = peg$parseCURLY_CLOSE();
                 if (s2 !== peg$FAILED) {
-                  s1 = [s1, s2];
+                  peg$savedPos = s0;
+                  s1 = peg$c302();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8692,7 +8827,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c304(s1);
+        s2 = peg$c303(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8700,7 +8835,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c176(s1);
+          s1 = peg$c174(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8732,7 +8867,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c305(s1);
+        s2 = peg$c304(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8740,7 +8875,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c176(s1);
+          s1 = peg$c174(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8772,7 +8907,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c306(s1);
+        s2 = peg$c305(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8780,7 +8915,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c176(s1);
+          s1 = peg$c174(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -243,10 +243,10 @@ module.exports = /*
         peg$c95 = function(m, n) { return ast.Tex.CHEM_WORD(m, n); },
         peg$c96 = function() { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("")); },
         peg$c97 = function(m) { return m;},
-        peg$c98 = function(c) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("{" + b + "}"));; },
-        peg$c99 = function(c) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("$" + c + "$")); },
-        peg$c100 = function(name, l) { return ast.Tex.CHEM_BOND(name, l);},
-        peg$c101 = function(c) {return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c))},
+        peg$c98 = function(c) { return ast.Tex.CURLY([c]); },
+        peg$c99 = function(c) { return ast.Tex.DOLLAR([c]); },
+        peg$c100 = function(name, l) { return ast.Tex.CHEM_BOND(name, l); },
+        peg$c101 = function(c) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) },
         peg$c102 = function(e) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(e))]); },
         peg$c103 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(b))); },
         peg$c104 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), b); },
@@ -256,60 +256,55 @@ module.exports = /*
         peg$c108 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2u(name, l1, l2); },
         peg$c109 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2(name, l1, l2); },
         peg$c110 = function(name, l) { return ast.Tex.CHEM_FUN1(name, l); },
-        peg$c111 = function(m) {
-                var s = "";
-                for (var c in m)
-                    s += m[c];
-                return s;//ast.RenderT.TEX_ONLY(s);
-            },
-        peg$c112 = /^[a-zA-Z]/,
-        peg$c113 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
-        peg$c114 = /^[,:;?!']/,
-        peg$c115 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
-        peg$c116 = /^[().]/,
-        peg$c117 = peg$classExpectation(["(", ")", "."], false, false),
-        peg$c118 = /^[\-+*=]/,
-        peg$c119 = peg$classExpectation(["-", "+", "*", "="], false, false),
-        peg$c120 = /^[\/|]/,
-        peg$c121 = peg$classExpectation(["/", "|"], false, false),
-        peg$c122 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
-        peg$c123 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
-        peg$c124 = /^[\uD800-\uDBFF]/,
-        peg$c125 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
-        peg$c126 = /^[\uDC00-\uDFFF]/,
-        peg$c127 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
-        peg$c128 = function(l, h) { return text(); },
-        peg$c129 = function(b) { return tu.box_functions[b]; },
-        peg$c130 = "{",
-        peg$c131 = peg$literalExpectation("{", false),
-        peg$c132 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
-        peg$c133 = "-",
-        peg$c134 = peg$literalExpectation("-", false),
-        peg$c135 = function(c) { return ast.RenderT.TEX_ONLY(c); },
-        peg$c136 = function(f) { return tu.latex_function_names[f]; },
-        peg$c137 = "(",
-        peg$c138 = peg$literalExpectation("(", false),
-        peg$c139 = "\\{",
-        peg$c140 = peg$literalExpectation("\\{", false),
-        peg$c141 = function(f) { return " ";},
-        peg$c142 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
-        peg$c143 = function(f) { return tu.mediawiki_function_names[f]; },
-        peg$c144 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
-        peg$c145 = function(f) { return tu.other_literals1[f]; },
-        peg$c146 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
-        peg$c147 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c148 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c149 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
-        peg$c150 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c151 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c152 = function(f) { return tu.other_literals2[f]; },
-        peg$c153 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c154 = function(mbox) { return mbox === "\\mbox"; },
-        peg$c155 = function(mbox, f) { return tu.other_literals2[f]; },
-        peg$c156 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c157 = function(f) { return ast.RenderT.TEX_ONLY(f); },
-        peg$c158 = "\\",
-        peg$c159 = peg$literalExpectation("\\", false),
+        peg$c111 = "\\",
+        peg$c112 = peg$literalExpectation("\\", false),
+        peg$c113 = function(cs) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); },
+        peg$c114 = /^[a-zA-Z]/,
+        peg$c115 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
+        peg$c116 = /^[,:;?!']/,
+        peg$c117 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
+        peg$c118 = /^[().]/,
+        peg$c119 = peg$classExpectation(["(", ")", "."], false, false),
+        peg$c120 = /^[\-+*=]/,
+        peg$c121 = peg$classExpectation(["-", "+", "*", "="], false, false),
+        peg$c122 = /^[\/|]/,
+        peg$c123 = peg$classExpectation(["/", "|"], false, false),
+        peg$c124 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
+        peg$c125 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
+        peg$c126 = /^[\uD800-\uDBFF]/,
+        peg$c127 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
+        peg$c128 = /^[\uDC00-\uDFFF]/,
+        peg$c129 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
+        peg$c130 = function(l, h) { return text(); },
+        peg$c131 = function(b) { return tu.box_functions[b]; },
+        peg$c132 = "{",
+        peg$c133 = peg$literalExpectation("{", false),
+        peg$c134 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
+        peg$c135 = "-",
+        peg$c136 = peg$literalExpectation("-", false),
+        peg$c137 = function(c) { return ast.RenderT.TEX_ONLY(c); },
+        peg$c138 = function(f) { return tu.latex_function_names[f]; },
+        peg$c139 = "(",
+        peg$c140 = peg$literalExpectation("(", false),
+        peg$c141 = "\\{",
+        peg$c142 = peg$literalExpectation("\\{", false),
+        peg$c143 = function(f) { return " ";},
+        peg$c144 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
+        peg$c145 = function(f) { return tu.mediawiki_function_names[f]; },
+        peg$c146 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
+        peg$c147 = function(f) { return tu.other_literals1[f]; },
+        peg$c148 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
+        peg$c149 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c150 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c151 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
+        peg$c152 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c153 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c154 = function(f) { return tu.other_literals2[f]; },
+        peg$c155 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c156 = function(mbox) { return mbox === "\\mbox"; },
+        peg$c157 = function(mbox, f) { return tu.other_literals2[f]; },
+        peg$c158 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c159 = function(f) { return ast.RenderT.TEX_ONLY(f); },
         peg$c160 = /^[, ;!_#%$&]/,
         peg$c161 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
         peg$c162 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
@@ -3560,17 +3555,65 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = [];
       s2 = peg$parseboxchars();
+      if (s2 === peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 95) {
+          s2 = peg$c106;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c107); }
+        }
+        if (s2 === peg$FAILED) {
+          s2 = peg$parseCURLY_OPEN();
+          if (s2 === peg$FAILED) {
+            s2 = peg$parseCURLY_CLOSE();
+            if (s2 === peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 92) {
+                s2 = peg$c111;
+                peg$currPos++;
+              } else {
+                s2 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c112); }
+              }
+            }
+          }
+        }
+      }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
           s2 = peg$parseboxchars();
+          if (s2 === peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 95) {
+              s2 = peg$c106;
+              peg$currPos++;
+            } else {
+              s2 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c107); }
+            }
+            if (s2 === peg$FAILED) {
+              s2 = peg$parseCURLY_OPEN();
+              if (s2 === peg$FAILED) {
+                s2 = peg$parseCURLY_CLOSE();
+                if (s2 === peg$FAILED) {
+                  if (input.charCodeAt(peg$currPos) === 92) {
+                    s2 = peg$c111;
+                    peg$currPos++;
+                  } else {
+                    s2 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c112); }
+                  }
+                }
+              }
+            }
+          }
         }
       } else {
         s1 = peg$FAILED;
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c111(s1);
+        s1 = peg$c113(s1);
       }
       s0 = s1;
 
@@ -3604,7 +3647,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c111(s1);
+        s1 = peg$c113(s1);
       }
       s0 = s1;
 
@@ -3625,12 +3668,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c112.test(input.charAt(peg$currPos))) {
+      if (peg$c114.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c113); }
+        if (peg$silentFails === 0) { peg$fail(peg$c115); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3650,12 +3693,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c112.test(input.charAt(peg$currPos))) {
+      if (peg$c114.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c113); }
+        if (peg$silentFails === 0) { peg$fail(peg$c115); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3700,31 +3743,6 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c114.test(input.charAt(peg$currPos))) {
-        s0 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parsedelimiter_uf_lt() {
-      var s0;
-
-      var key    = peg$currPos * 122 + 44,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
       if (peg$c116.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
@@ -3738,10 +3756,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseliteral_uf_op() {
+    function peg$parsedelimiter_uf_lt() {
       var s0;
 
-      var key    = peg$currPos * 122 + 45,
+      var key    = peg$currPos * 122 + 44,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3763,10 +3781,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parsedelimiter_uf_op() {
+    function peg$parseliteral_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 122 + 46,
+      var key    = peg$currPos * 122 + 45,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3788,10 +3806,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseboxchars() {
-      var s0, s1, s2;
+    function peg$parsedelimiter_uf_op() {
+      var s0;
 
-      var key    = peg$currPos * 122 + 47,
+      var key    = peg$currPos * 122 + 46,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3807,26 +3825,51 @@ module.exports = /*
         s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c123); }
       }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseboxchars() {
+      var s0, s1, s2;
+
+      var key    = peg$currPos * 122 + 47,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (peg$c124.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c125); }
+      }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (peg$c124.test(input.charAt(peg$currPos))) {
+        if (peg$c126.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c125); }
+          if (peg$silentFails === 0) { peg$fail(peg$c127); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c126.test(input.charAt(peg$currPos))) {
+          if (peg$c128.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c127); }
+            if (peg$silentFails === 0) { peg$fail(peg$c129); }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c128(s1, s2);
+            s1 = peg$c130(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3859,7 +3902,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c129(s1);
+        s2 = peg$c131(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -3869,11 +3912,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c130;
+              s4 = peg$c132;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c131); }
+              if (peg$silentFails === 0) { peg$fail(peg$c133); }
             }
             if (s4 !== peg$FAILED) {
               s5 = [];
@@ -3898,7 +3941,7 @@ module.exports = /*
                   s7 = peg$parse_();
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c132(s1, s5);
+                    s1 = peg$c134(s1, s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3954,11 +3997,11 @@ module.exports = /*
           s1 = peg$parseliteral_uf_lt();
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 45) {
-              s1 = peg$c133;
+              s1 = peg$c135;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c134); }
+              if (peg$silentFails === 0) { peg$fail(peg$c136); }
             }
             if (s1 === peg$FAILED) {
               s1 = peg$parseliteral_uf_op();
@@ -3970,7 +4013,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c135(s1);
+          s1 = peg$c137(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3985,7 +4028,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c136(s1);
+          s2 = peg$c138(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -3995,11 +4038,11 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s4 = peg$c137;
+                s4 = peg$c139;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c138); }
+                if (peg$silentFails === 0) { peg$fail(peg$c140); }
               }
               if (s4 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 91) {
@@ -4010,19 +4053,19 @@ module.exports = /*
                   if (peg$silentFails === 0) { peg$fail(peg$c79); }
                 }
                 if (s4 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c139) {
-                    s4 = peg$c139;
+                  if (input.substr(peg$currPos, 2) === peg$c141) {
+                    s4 = peg$c141;
                     peg$currPos += 2;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c140); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c142); }
                   }
                   if (s4 === peg$FAILED) {
                     s4 = peg$currPos;
                     s5 = peg$c6;
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s4;
-                      s5 = peg$c141(s1);
+                      s5 = peg$c143(s1);
                     }
                     s4 = s5;
                   }
@@ -4032,7 +4075,7 @@ module.exports = /*
                 s5 = peg$parse_();
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c142(s1, s4);
+                  s1 = peg$c144(s1, s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4059,7 +4102,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c143(s1);
+            s2 = peg$c145(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -4069,11 +4112,11 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s4 = peg$c137;
+                  s4 = peg$c139;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c138); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c140); }
                 }
                 if (s4 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 91) {
@@ -4084,19 +4127,19 @@ module.exports = /*
                     if (peg$silentFails === 0) { peg$fail(peg$c79); }
                   }
                   if (s4 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 2) === peg$c139) {
-                      s4 = peg$c139;
+                    if (input.substr(peg$currPos, 2) === peg$c141) {
+                      s4 = peg$c141;
                       peg$currPos += 2;
                     } else {
                       s4 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c142); }
                     }
                     if (s4 === peg$FAILED) {
                       s4 = peg$currPos;
                       s5 = peg$c6;
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s4;
-                        s5 = peg$c141(s1);
+                        s5 = peg$c143(s1);
                       }
                       s4 = s5;
                     }
@@ -4106,7 +4149,7 @@ module.exports = /*
                   s5 = peg$parse_();
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c144(s1, s4);
+                    s1 = peg$c146(s1, s4);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4133,7 +4176,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c145(s1);
+              s2 = peg$c147(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -4143,7 +4186,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c146(s1);
+                  s1 = peg$c148(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4162,7 +4205,7 @@ module.exports = /*
               s1 = peg$parsegeneric_func();
               if (s1 !== peg$FAILED) {
                 peg$savedPos = peg$currPos;
-                s2 = peg$c147(s1);
+                s2 = peg$c149(s1);
                 if (s2) {
                   s2 = void 0;
                 } else {
@@ -4172,7 +4215,7 @@ module.exports = /*
                   s3 = peg$parse_();
                   if (s3 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c148(s1);
+                    s1 = peg$c150(s1);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4191,7 +4234,7 @@ module.exports = /*
                 s1 = peg$parsegeneric_func();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = peg$currPos;
-                  s2 = peg$c149(s1);
+                  s2 = peg$c151(s1);
                   if (s2) {
                     s2 = void 0;
                   } else {
@@ -4201,17 +4244,17 @@ module.exports = /*
                     s3 = peg$parse_();
                     if (s3 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 123) {
-                        s4 = peg$c130;
+                        s4 = peg$c132;
                         peg$currPos++;
                       } else {
                         s4 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c131); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c133); }
                       }
                       if (s4 !== peg$FAILED) {
                         s5 = peg$parsegeneric_func();
                         if (s5 !== peg$FAILED) {
                           peg$savedPos = peg$currPos;
-                          s6 = peg$c150(s1, s5);
+                          s6 = peg$c152(s1, s5);
                           if (s6) {
                             s6 = void 0;
                           } else {
@@ -4231,7 +4274,7 @@ module.exports = /*
                                 s9 = peg$parse_();
                                 if (s9 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c151(s1, s5);
+                                  s1 = peg$c153(s1, s5);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -4274,7 +4317,7 @@ module.exports = /*
                   s1 = peg$parsegeneric_func();
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = peg$currPos;
-                    s2 = peg$c152(s1);
+                    s2 = peg$c154(s1);
                     if (s2) {
                       s2 = void 0;
                     } else {
@@ -4284,7 +4327,7 @@ module.exports = /*
                       s3 = peg$parse_();
                       if (s3 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c153(s1);
+                        s1 = peg$c155(s1);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -4303,7 +4346,7 @@ module.exports = /*
                     s1 = peg$parsegeneric_func();
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = peg$currPos;
-                      s2 = peg$c154(s1);
+                      s2 = peg$c156(s1);
                       if (s2) {
                         s2 = void 0;
                       } else {
@@ -4313,17 +4356,17 @@ module.exports = /*
                         s3 = peg$parse_();
                         if (s3 !== peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 123) {
-                            s4 = peg$c130;
+                            s4 = peg$c132;
                             peg$currPos++;
                           } else {
                             s4 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c131); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c133); }
                           }
                           if (s4 !== peg$FAILED) {
                             s5 = peg$parsegeneric_func();
                             if (s5 !== peg$FAILED) {
                               peg$savedPos = peg$currPos;
-                              s6 = peg$c155(s1, s5);
+                              s6 = peg$c157(s1, s5);
                               if (s6) {
                                 s6 = void 0;
                               } else {
@@ -4343,7 +4386,7 @@ module.exports = /*
                                     s9 = peg$parse_();
                                     if (s9 !== peg$FAILED) {
                                       peg$savedPos = s0;
-                                      s1 = peg$c156(s1, s5);
+                                      s1 = peg$c158(s1, s5);
                                       s0 = s1;
                                     } else {
                                       peg$currPos = s0;
@@ -4389,17 +4432,17 @@ module.exports = /*
                       }
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c157(s1);
+                        s1 = peg$c159(s1);
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
                         if (input.charCodeAt(peg$currPos) === 92) {
-                          s1 = peg$c158;
+                          s1 = peg$c111;
                           peg$currPos++;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c159); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c112); }
                         }
                         if (s1 !== peg$FAILED) {
                           if (peg$c160.test(input.charAt(peg$currPos))) {
@@ -4440,7 +4483,7 @@ module.exports = /*
                             s2 = peg$parse_();
                             if (s2 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c135(s1);
+                              s1 = peg$c137(s1);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -4520,7 +4563,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c135(s1);
+          s1 = peg$c137(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4533,11 +4576,11 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c158;
+          s1 = peg$c111;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c159); }
+          if (peg$silentFails === 0) { peg$fail(peg$c112); }
         }
         if (s1 !== peg$FAILED) {
           if (peg$c168.test(input.charAt(peg$currPos))) {
@@ -4580,7 +4623,7 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c146(s1);
+                s1 = peg$c148(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6121,11 +6164,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c130;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c131); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6277,11 +6320,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c158;
+        s1 = peg$c111;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c159); }
+        if (peg$silentFails === 0) { peg$fail(peg$c112); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -6435,7 +6478,7 @@ module.exports = /*
     }
 
     function peg$parseFUN_MHCHEM() {
-      var s0, s1, s2;
+      var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 91,
           cached = peg$resultsCache[key];
@@ -6457,9 +6500,15 @@ module.exports = /*
           s2 = peg$FAILED;
         }
         if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c174(s1);
-          s0 = s1;
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c174(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -6872,11 +6921,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c130;
+              s4 = peg$c132;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c131); }
+              if (peg$silentFails === 0) { peg$fail(peg$c133); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -6905,11 +6954,11 @@ module.exports = /*
                       s9 = peg$parse_();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 123) {
-                          s10 = peg$c130;
+                          s10 = peg$c132;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c131); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c133); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
@@ -7573,11 +7622,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c130;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c131); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7652,11 +7701,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c130;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c131); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7719,11 +7768,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c130;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c131); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7831,11 +7880,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c130;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c131); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7943,11 +7992,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c130;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c131); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -8389,12 +8438,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c112.test(input.charAt(peg$currPos))) {
+      if (peg$c114.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c113); }
+        if (peg$silentFails === 0) { peg$fail(peg$c115); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -8575,44 +8624,44 @@ module.exports = /*
                     if (peg$silentFails === 0) { peg$fail(peg$c279); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 45) {
-                      s0 = peg$c133;
-                      peg$currPos++;
+                    if (input.substr(peg$currPos, 4) === peg$c280) {
+                      s0 = peg$c280;
+                      peg$currPos += 4;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c134); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c281); }
                     }
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 4) === peg$c280) {
-                        s0 = peg$c280;
-                        peg$currPos += 4;
+                      if (input.substr(peg$currPos, 3) === peg$c282) {
+                        s0 = peg$c282;
+                        peg$currPos += 3;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c281); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c283); }
                       }
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 3) === peg$c282) {
-                          s0 = peg$c282;
-                          peg$currPos += 3;
+                        if (input.substr(peg$currPos, 2) === peg$c284) {
+                          s0 = peg$c284;
+                          peg$currPos += 2;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c283); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c285); }
                         }
                         if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c284) {
-                            s0 = peg$c284;
+                          if (input.substr(peg$currPos, 2) === peg$c286) {
+                            s0 = peg$c286;
                             peg$currPos += 2;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c285); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c287); }
                           }
                           if (s0 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 2) === peg$c286) {
-                              s0 = peg$c286;
-                              peg$currPos += 2;
+                            if (input.charCodeAt(peg$currPos) === 45) {
+                              s0 = peg$c135;
+                              peg$currPos++;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c287); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c136); }
                             }
                             if (s0 === peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 49) {
@@ -8684,7 +8733,7 @@ module.exports = /*
     }
 
     function peg$parseCHEM_BOND() {
-      var s0, s1, s2;
+      var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 117,
           cached = peg$resultsCache[key];
@@ -8706,9 +8755,15 @@ module.exports = /*
           s2 = peg$FAILED;
         }
         if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c174(s1);
-          s0 = s1;
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c174(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -8736,12 +8791,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c139) {
-        s1 = peg$c139;
+      if (input.substr(peg$currPos, 2) === peg$c141) {
+        s1 = peg$c141;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c140); }
+        if (peg$silentFails === 0) { peg$fail(peg$c142); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
@@ -8812,7 +8867,7 @@ module.exports = /*
     }
 
     function peg$parseCHEM_MACRO_1P() {
-      var s0, s1, s2;
+      var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 119,
           cached = peg$resultsCache[key];
@@ -8834,9 +8889,15 @@ module.exports = /*
           s2 = peg$FAILED;
         }
         if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c174(s1);
-          s0 = s1;
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c174(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -8852,7 +8913,7 @@ module.exports = /*
     }
 
     function peg$parseCHEM_MACRO_2P() {
-      var s0, s1, s2;
+      var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 120,
           cached = peg$resultsCache[key];
@@ -8874,9 +8935,15 @@ module.exports = /*
           s2 = peg$FAILED;
         }
         if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c174(s1);
-          s0 = s1;
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c174(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -8892,7 +8959,7 @@ module.exports = /*
     }
 
     function peg$parseCHEM_MACRO_2PU() {
-      var s0, s1, s2;
+      var s0, s1, s2, s3;
 
       var key    = peg$currPos * 122 + 121,
           cached = peg$resultsCache[key];
@@ -8914,9 +8981,15 @@ module.exports = /*
           s2 = peg$FAILED;
         }
         if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c174(s1);
-          s0 = s1;
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c174(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -241,221 +241,222 @@ module.exports = /*
         peg$c93 = "^",
         peg$c94 = peg$literalExpectation("^", false),
         peg$c95 = function(m, n) { return ast.Tex.CHEM_WORD(m, n); },
-        peg$c96 = function() { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("")); },
-        peg$c97 = function(m) { return m;},
-        peg$c98 = function(c) { return ast.Tex.CURLY([c]); },
-        peg$c99 = function(c) { return ast.Tex.DOLLAR([c]); },
-        peg$c100 = function(name, l) { return ast.Tex.CHEM_BOND(name, l); },
-        peg$c101 = function(c) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) },
-        peg$c102 = function(e) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(e))]); },
-        peg$c103 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(b))); },
-        peg$c104 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), b); },
-        peg$c105 = function(a, b) { return a + "$" + b + "$"; },
-        peg$c106 = "_",
-        peg$c107 = peg$literalExpectation("_", false),
-        peg$c108 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2u(name, l1, l2); },
-        peg$c109 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2(name, l1, l2); },
-        peg$c110 = function(name, l) { return ast.Tex.CHEM_FUN1(name, l); },
-        peg$c111 = "\\",
-        peg$c112 = peg$literalExpectation("\\", false),
-        peg$c113 = function(cs) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); },
-        peg$c114 = /^[a-zA-Z]/,
-        peg$c115 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
-        peg$c116 = /^[,:;?!']/,
-        peg$c117 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
-        peg$c118 = /^[().]/,
-        peg$c119 = peg$classExpectation(["(", ")", "."], false, false),
-        peg$c120 = /^[\-+*=]/,
-        peg$c121 = peg$classExpectation(["-", "+", "*", "="], false, false),
-        peg$c122 = /^[\/|]/,
-        peg$c123 = peg$classExpectation(["/", "|"], false, false),
-        peg$c124 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
-        peg$c125 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
-        peg$c126 = /^[\uD800-\uDBFF]/,
-        peg$c127 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
-        peg$c128 = /^[\uDC00-\uDFFF]/,
-        peg$c129 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
-        peg$c130 = function(l, h) { return text(); },
-        peg$c131 = function(b) { return tu.box_functions[b]; },
-        peg$c132 = "{",
-        peg$c133 = peg$literalExpectation("{", false),
-        peg$c134 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
-        peg$c135 = "-",
-        peg$c136 = peg$literalExpectation("-", false),
-        peg$c137 = function(c) { return ast.RenderT.TEX_ONLY(c); },
-        peg$c138 = function(f) { return tu.latex_function_names[f]; },
-        peg$c139 = "(",
-        peg$c140 = peg$literalExpectation("(", false),
-        peg$c141 = "\\{",
-        peg$c142 = peg$literalExpectation("\\{", false),
-        peg$c143 = function(f) { return " ";},
-        peg$c144 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
-        peg$c145 = function(f) { return tu.mediawiki_function_names[f]; },
-        peg$c146 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
-        peg$c147 = function(f) { return tu.other_literals1[f]; },
-        peg$c148 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
-        peg$c149 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c150 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c151 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
-        peg$c152 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c153 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c154 = function(f) { return tu.other_literals2[f]; },
-        peg$c155 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c156 = function(mbox) { return mbox === "\\mbox"; },
-        peg$c157 = function(mbox, f) { return tu.other_literals2[f]; },
-        peg$c158 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c159 = function(f) { return ast.RenderT.TEX_ONLY(f); },
-        peg$c160 = /^[, ;!_#%$&]/,
-        peg$c161 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
-        peg$c162 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
-        peg$c163 = /^[><~]/,
-        peg$c164 = peg$classExpectation([">", "<", "~"], false, false),
-        peg$c165 = /^[%$]/,
-        peg$c166 = peg$classExpectation(["%", "$"], false, false),
-        peg$c167 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */},
-        peg$c168 = /^[{}|]/,
-        peg$c169 = peg$classExpectation(["{", "}", "|"], false, false),
-        peg$c170 = function(f) { return tu.other_delimiters1[f]; },
-        peg$c171 = function(f) { return tu.other_delimiters2[f]; },
-        peg$c172 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
+        peg$c96 = function(m, n) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)), n); },
+        peg$c97 = function() { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("")); },
+        peg$c98 = function(m) { return m;},
+        peg$c99 = function(c) { return ast.Tex.CURLY([c]); },
+        peg$c100 = function(c) { return ast.Tex.DOLLAR(c.toArray()); },
+        peg$c101 = function(name, l) { return ast.Tex.CHEM_BOND(name, l); },
+        peg$c102 = function(c) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) },
+        peg$c103 = function(e) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(e))]); },
+        peg$c104 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(b))); },
+        peg$c105 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), b); },
+        peg$c106 = function(a, b) { return a + "$" + b + "$"; },
+        peg$c107 = "_",
+        peg$c108 = peg$literalExpectation("_", false),
+        peg$c109 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2u(name, l1, l2); },
+        peg$c110 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2(name, l1, l2); },
+        peg$c111 = function(name, l) { return ast.Tex.CHEM_FUN1(name, l); },
+        peg$c112 = function(cs) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); },
+        peg$c113 = /^[a-zA-Z]/,
+        peg$c114 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
+        peg$c115 = /^[,:;?!']/,
+        peg$c116 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
+        peg$c117 = /^[().]/,
+        peg$c118 = peg$classExpectation(["(", ")", "."], false, false),
+        peg$c119 = /^[\-+*=]/,
+        peg$c120 = peg$classExpectation(["-", "+", "*", "="], false, false),
+        peg$c121 = /^[\/|]/,
+        peg$c122 = peg$classExpectation(["/", "|"], false, false),
+        peg$c123 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
+        peg$c124 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
+        peg$c125 = /^[\uD800-\uDBFF]/,
+        peg$c126 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
+        peg$c127 = /^[\uDC00-\uDFFF]/,
+        peg$c128 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
+        peg$c129 = function(l, h) { return text(); },
+        peg$c130 = function(b) { return tu.box_functions[b]; },
+        peg$c131 = "{",
+        peg$c132 = peg$literalExpectation("{", false),
+        peg$c133 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
+        peg$c134 = "-",
+        peg$c135 = peg$literalExpectation("-", false),
+        peg$c136 = function(c) { return ast.RenderT.TEX_ONLY(c); },
+        peg$c137 = function(f) { return tu.latex_function_names[f]; },
+        peg$c138 = "(",
+        peg$c139 = peg$literalExpectation("(", false),
+        peg$c140 = "\\{",
+        peg$c141 = peg$literalExpectation("\\{", false),
+        peg$c142 = function(f) { return " ";},
+        peg$c143 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
+        peg$c144 = function(f) { return tu.mediawiki_function_names[f]; },
+        peg$c145 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
+        peg$c146 = function(f) { return tu.other_literals1[f]; },
+        peg$c147 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
+        peg$c148 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c149 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c150 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
+        peg$c151 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c152 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c153 = function(f) { return tu.other_literals2[f]; },
+        peg$c154 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c155 = function(mbox) { return mbox === "\\mbox"; },
+        peg$c156 = function(mbox, f) { return tu.other_literals2[f]; },
+        peg$c157 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c158 = function(f) { return ast.RenderT.TEX_ONLY(f); },
+        peg$c159 = "\\",
+        peg$c160 = peg$literalExpectation("\\", false),
+        peg$c161 = /^[, ;!_#%$&]/,
+        peg$c162 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
+        peg$c163 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
+        peg$c164 = /^[><~]/,
+        peg$c165 = peg$classExpectation([">", "<", "~"], false, false),
+        peg$c166 = /^[%$]/,
+        peg$c167 = peg$classExpectation(["%", "$"], false, false),
+        peg$c168 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */},
+        peg$c169 = /^[{}|]/,
+        peg$c170 = peg$classExpectation(["{", "}", "|"], false, false),
+        peg$c171 = function(f) { return tu.other_delimiters1[f]; },
+        peg$c172 = function(f) { return tu.other_delimiters2[f]; },
+        peg$c173 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
              console.assert(Array.isArray(p) && p.length === 1);
              console.assert(p[0].constructor === ast.Tex.LITERAL);
              console.assert(p[0][0].constructor === ast.RenderT.TEX_ONLY);
              return p[0][0];
            },
-        peg$c173 = function(f) { return tu.fun_ar1nb[f]; },
-        peg$c174 = function(f) { return f; },
-        peg$c175 = function(f) { return tu.fun_ar1opt[f]; },
-        peg$c176 = "&",
-        peg$c177 = peg$literalExpectation("&", false),
-        peg$c178 = "\\\\",
-        peg$c179 = peg$literalExpectation("\\\\", false),
-        peg$c180 = "\\begin",
-        peg$c181 = peg$literalExpectation("\\begin", false),
-        peg$c182 = "\\end",
-        peg$c183 = peg$literalExpectation("\\end", false),
-        peg$c184 = "{matrix}",
-        peg$c185 = peg$literalExpectation("{matrix}", false),
-        peg$c186 = "{pmatrix}",
-        peg$c187 = peg$literalExpectation("{pmatrix}", false),
-        peg$c188 = "{bmatrix}",
-        peg$c189 = peg$literalExpectation("{bmatrix}", false),
-        peg$c190 = "{Bmatrix}",
-        peg$c191 = peg$literalExpectation("{Bmatrix}", false),
-        peg$c192 = "{vmatrix}",
-        peg$c193 = peg$literalExpectation("{vmatrix}", false),
-        peg$c194 = "{Vmatrix}",
-        peg$c195 = peg$literalExpectation("{Vmatrix}", false),
-        peg$c196 = "{array}",
-        peg$c197 = peg$literalExpectation("{array}", false),
-        peg$c198 = "{align}",
-        peg$c199 = peg$literalExpectation("{align}", false),
-        peg$c200 = "{aligned}",
-        peg$c201 = peg$literalExpectation("{aligned}", false),
-        peg$c202 = "{alignat}",
-        peg$c203 = peg$literalExpectation("{alignat}", false),
-        peg$c204 = "{alignedat}",
-        peg$c205 = peg$literalExpectation("{alignedat}", false),
-        peg$c206 = "{smallmatrix}",
-        peg$c207 = peg$literalExpectation("{smallmatrix}", false),
-        peg$c208 = "{cases}",
-        peg$c209 = peg$literalExpectation("{cases}", false),
-        peg$c210 = function(f) { return tu.big_literals[f]; },
-        peg$c211 = function(f) { return tu.fun_ar1[f]; },
-        peg$c212 = function(f) { return tu.other_fun_ar1[f]; },
-        peg$c213 = function(f) { return tu.fun_mhchem[f]; },
-        peg$c214 = function(f) { return tu.fun_ar2[f]; },
-        peg$c215 = function(f) { return tu.fun_infix[f]; },
-        peg$c216 = function(f) { return tu.declh_function[f]; },
-        peg$c217 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
-        peg$c218 = function(f) { return tu.fun_ar2nb[f]; },
-        peg$c219 = function(f) { return tu.left_function[f]; },
-        peg$c220 = function(f) { return tu.right_function[f]; },
-        peg$c221 = function(f) { return tu.hline_function[f]; },
-        peg$c222 = function(f) { return tu.color_function[f]; },
-        peg$c223 = function(f, cs) { return f + " " + cs; },
-        peg$c224 = function(f) { return tu.definecolor_function[f]; },
-        peg$c225 = "named",
-        peg$c226 = peg$literalExpectation("named", true),
-        peg$c227 = function(f, name, cs) { return "{named}" + cs; },
-        peg$c228 = "gray",
-        peg$c229 = peg$literalExpectation("gray", true),
-        peg$c230 = function(f, name, cs) { return "{gray}" + cs; },
-        peg$c231 = "rgb",
-        peg$c232 = peg$literalExpectation("rgb", false),
-        peg$c233 = function(f, name, cs) { return "{rgb}" + cs; },
-        peg$c234 = "RGB",
-        peg$c235 = peg$literalExpectation("RGB", false),
-        peg$c236 = "cmyk",
-        peg$c237 = peg$literalExpectation("cmyk", true),
-        peg$c238 = function(f, name, cs) { return "{cmyk}" + cs; },
-        peg$c239 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
-        peg$c240 = function(cs) { return "[named]" + cs; },
-        peg$c241 = function(cs) { return "[gray]" + cs; },
-        peg$c242 = function(cs) { return "[rgb]" + cs; },
-        peg$c243 = function(cs) { return "[cmyk]" + cs; },
-        peg$c244 = function(name) { return "{" + name.join('') + "}"; },
-        peg$c245 = function(k) { return "{"+k+"}"; },
-        peg$c246 = ",",
-        peg$c247 = peg$literalExpectation(",", false),
-        peg$c248 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
-        peg$c249 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
-        peg$c250 = "0",
-        peg$c251 = peg$literalExpectation("0", false),
-        peg$c252 = /^[1-9]/,
-        peg$c253 = peg$classExpectation([["1", "9"]], false, false),
-        peg$c254 = function(n) { return parseInt(n, 10) <= 255; },
-        peg$c255 = function(n) { return n / 255; },
-        peg$c256 = ".",
-        peg$c257 = peg$literalExpectation(".", false),
-        peg$c258 = function(n) { return n; },
-        peg$c259 = /^[01]/,
-        peg$c260 = peg$classExpectation(["0", "1"], false, false),
-        peg$c261 = function() { return false; },
-        peg$c262 = function() { return peg$currPos === input.length; },
-        peg$c263 = function(f) { return tu.mhchem_single_macro[f]; },
-        peg$c264 = /^[+-.*']/,
-        peg$c265 = peg$classExpectation([["+", "."], "*", "'"], false, false),
-        peg$c266 = "=",
-        peg$c267 = peg$literalExpectation("=", false),
-        peg$c268 = "#",
-        peg$c269 = peg$literalExpectation("#", false),
-        peg$c270 = "~--",
-        peg$c271 = peg$literalExpectation("~--", false),
-        peg$c272 = "~-",
-        peg$c273 = peg$literalExpectation("~-", false),
-        peg$c274 = "~=",
-        peg$c275 = peg$literalExpectation("~=", false),
-        peg$c276 = "~",
-        peg$c277 = peg$literalExpectation("~", false),
-        peg$c278 = "-~-",
-        peg$c279 = peg$literalExpectation("-~-", false),
-        peg$c280 = "....",
-        peg$c281 = peg$literalExpectation("....", false),
-        peg$c282 = "...",
-        peg$c283 = peg$literalExpectation("...", false),
-        peg$c284 = "<-",
-        peg$c285 = peg$literalExpectation("<-", false),
-        peg$c286 = "->",
-        peg$c287 = peg$literalExpectation("->", false),
-        peg$c288 = "1",
-        peg$c289 = peg$literalExpectation("1", false),
-        peg$c290 = "2",
-        peg$c291 = peg$literalExpectation("2", false),
-        peg$c292 = "3",
-        peg$c293 = peg$literalExpectation("3", false),
-        peg$c294 = "$",
-        peg$c295 = peg$literalExpectation("$", false),
-        peg$c296 = function(f) { return tu.mhchem_bond[f]; },
-        peg$c297 = function(c) { return c; },
-        peg$c298 = "\\}",
-        peg$c299 = peg$literalExpectation("\\}", false),
-        peg$c300 = /^[+-=#().,;\/*<>|@&'[\]]/,
-        peg$c301 = peg$classExpectation([["+", "="], "#", "(", ")", ".", ",", ";", "/", "*", "<", ">", "|", "@", "&", "'", "[", "]"], false, false),
-        peg$c302 = function() { return "{}"; },
-        peg$c303 = function(f) { return tu.mhchem_macro_1p[f]; },
-        peg$c304 = function(f) { return tu.mhchem_macro_2p[f]; },
-        peg$c305 = function(f) { return tu.mhchem_macro_2pu[f]; },
+        peg$c174 = function(f) { return tu.fun_ar1nb[f]; },
+        peg$c175 = function(f) { return f; },
+        peg$c176 = function(f) { return tu.fun_ar1opt[f]; },
+        peg$c177 = "&",
+        peg$c178 = peg$literalExpectation("&", false),
+        peg$c179 = "\\\\",
+        peg$c180 = peg$literalExpectation("\\\\", false),
+        peg$c181 = "\\begin",
+        peg$c182 = peg$literalExpectation("\\begin", false),
+        peg$c183 = "\\end",
+        peg$c184 = peg$literalExpectation("\\end", false),
+        peg$c185 = "{matrix}",
+        peg$c186 = peg$literalExpectation("{matrix}", false),
+        peg$c187 = "{pmatrix}",
+        peg$c188 = peg$literalExpectation("{pmatrix}", false),
+        peg$c189 = "{bmatrix}",
+        peg$c190 = peg$literalExpectation("{bmatrix}", false),
+        peg$c191 = "{Bmatrix}",
+        peg$c192 = peg$literalExpectation("{Bmatrix}", false),
+        peg$c193 = "{vmatrix}",
+        peg$c194 = peg$literalExpectation("{vmatrix}", false),
+        peg$c195 = "{Vmatrix}",
+        peg$c196 = peg$literalExpectation("{Vmatrix}", false),
+        peg$c197 = "{array}",
+        peg$c198 = peg$literalExpectation("{array}", false),
+        peg$c199 = "{align}",
+        peg$c200 = peg$literalExpectation("{align}", false),
+        peg$c201 = "{aligned}",
+        peg$c202 = peg$literalExpectation("{aligned}", false),
+        peg$c203 = "{alignat}",
+        peg$c204 = peg$literalExpectation("{alignat}", false),
+        peg$c205 = "{alignedat}",
+        peg$c206 = peg$literalExpectation("{alignedat}", false),
+        peg$c207 = "{smallmatrix}",
+        peg$c208 = peg$literalExpectation("{smallmatrix}", false),
+        peg$c209 = "{cases}",
+        peg$c210 = peg$literalExpectation("{cases}", false),
+        peg$c211 = function(f) { return tu.big_literals[f]; },
+        peg$c212 = function(f) { return tu.fun_ar1[f]; },
+        peg$c213 = function(f) { return tu.other_fun_ar1[f]; },
+        peg$c214 = function(f) { return tu.fun_mhchem[f]; },
+        peg$c215 = function(f) { return tu.fun_ar2[f]; },
+        peg$c216 = function(f) { return tu.fun_infix[f]; },
+        peg$c217 = function(f) { return tu.declh_function[f]; },
+        peg$c218 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
+        peg$c219 = function(f) { return tu.fun_ar2nb[f]; },
+        peg$c220 = function(f) { return tu.left_function[f]; },
+        peg$c221 = function(f) { return tu.right_function[f]; },
+        peg$c222 = function(f) { return tu.hline_function[f]; },
+        peg$c223 = function(f) { return tu.color_function[f]; },
+        peg$c224 = function(f, cs) { return f + " " + cs; },
+        peg$c225 = function(f) { return tu.definecolor_function[f]; },
+        peg$c226 = "named",
+        peg$c227 = peg$literalExpectation("named", true),
+        peg$c228 = function(f, name, cs) { return "{named}" + cs; },
+        peg$c229 = "gray",
+        peg$c230 = peg$literalExpectation("gray", true),
+        peg$c231 = function(f, name, cs) { return "{gray}" + cs; },
+        peg$c232 = "rgb",
+        peg$c233 = peg$literalExpectation("rgb", false),
+        peg$c234 = function(f, name, cs) { return "{rgb}" + cs; },
+        peg$c235 = "RGB",
+        peg$c236 = peg$literalExpectation("RGB", false),
+        peg$c237 = "cmyk",
+        peg$c238 = peg$literalExpectation("cmyk", true),
+        peg$c239 = function(f, name, cs) { return "{cmyk}" + cs; },
+        peg$c240 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
+        peg$c241 = function(cs) { return "[named]" + cs; },
+        peg$c242 = function(cs) { return "[gray]" + cs; },
+        peg$c243 = function(cs) { return "[rgb]" + cs; },
+        peg$c244 = function(cs) { return "[cmyk]" + cs; },
+        peg$c245 = function(name) { return "{" + name.join('') + "}"; },
+        peg$c246 = function(k) { return "{"+k+"}"; },
+        peg$c247 = ",",
+        peg$c248 = peg$literalExpectation(",", false),
+        peg$c249 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
+        peg$c250 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
+        peg$c251 = "0",
+        peg$c252 = peg$literalExpectation("0", false),
+        peg$c253 = /^[1-9]/,
+        peg$c254 = peg$classExpectation([["1", "9"]], false, false),
+        peg$c255 = function(n) { return parseInt(n, 10) <= 255; },
+        peg$c256 = function(n) { return n / 255; },
+        peg$c257 = ".",
+        peg$c258 = peg$literalExpectation(".", false),
+        peg$c259 = function(n) { return n; },
+        peg$c260 = /^[01]/,
+        peg$c261 = peg$classExpectation(["0", "1"], false, false),
+        peg$c262 = function() { return false; },
+        peg$c263 = function() { return peg$currPos === input.length; },
+        peg$c264 = function(f) { return tu.mhchem_single_macro[f]; },
+        peg$c265 = /^[+-.*']/,
+        peg$c266 = peg$classExpectation([["+", "."], "*", "'"], false, false),
+        peg$c267 = "=",
+        peg$c268 = peg$literalExpectation("=", false),
+        peg$c269 = "#",
+        peg$c270 = peg$literalExpectation("#", false),
+        peg$c271 = "~--",
+        peg$c272 = peg$literalExpectation("~--", false),
+        peg$c273 = "~-",
+        peg$c274 = peg$literalExpectation("~-", false),
+        peg$c275 = "~=",
+        peg$c276 = peg$literalExpectation("~=", false),
+        peg$c277 = "~",
+        peg$c278 = peg$literalExpectation("~", false),
+        peg$c279 = "-~-",
+        peg$c280 = peg$literalExpectation("-~-", false),
+        peg$c281 = "....",
+        peg$c282 = peg$literalExpectation("....", false),
+        peg$c283 = "...",
+        peg$c284 = peg$literalExpectation("...", false),
+        peg$c285 = "<-",
+        peg$c286 = peg$literalExpectation("<-", false),
+        peg$c287 = "->",
+        peg$c288 = peg$literalExpectation("->", false),
+        peg$c289 = "1",
+        peg$c290 = peg$literalExpectation("1", false),
+        peg$c291 = "2",
+        peg$c292 = peg$literalExpectation("2", false),
+        peg$c293 = "3",
+        peg$c294 = peg$literalExpectation("3", false),
+        peg$c295 = "\xA7",
+        peg$c296 = peg$literalExpectation("\xA7", false),
+        peg$c297 = function(f) { return tu.mhchem_bond[f]; },
+        peg$c298 = function(c) { return c; },
+        peg$c299 = "\\}",
+        peg$c300 = peg$literalExpectation("\\}", false),
+        peg$c301 = /^[+-=#().,;\/*<>|@&'[\]]/,
+        peg$c302 = peg$classExpectation([["+", "="], "#", "(", ")", ".", ",", ";", "/", "*", "<", ">", "|", "@", "&", "'", "[", "]"], false, false),
+        peg$c303 = function() { return "{}"; },
+        peg$c304 = function(f) { return tu.mhchem_macro_1p[f]; },
+        peg$c305 = function(f) { return tu.mhchem_macro_2p[f]; },
+        peg$c306 = function(f) { return tu.mhchem_macro_2pu[f]; },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -598,7 +599,7 @@ module.exports = /*
     function peg$parsestart() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 0,
+      var key    = peg$currPos * 123 + 0,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -632,7 +633,7 @@ module.exports = /*
     function peg$parse_() {
       var s0, s1;
 
-      var key    = peg$currPos * 122 + 1,
+      var key    = peg$currPos * 123 + 1,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -668,7 +669,7 @@ module.exports = /*
     function peg$parsetex_expr() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 122 + 2,
+      var key    = peg$currPos * 123 + 2,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -762,7 +763,7 @@ module.exports = /*
     function peg$parseexpr() {
       var s0, s1;
 
-      var key    = peg$currPos * 122 + 3,
+      var key    = peg$currPos * 123 + 3,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -790,7 +791,7 @@ module.exports = /*
     function peg$parsene_expr() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 4,
+      var key    = peg$currPos * 123 + 4,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -860,7 +861,7 @@ module.exports = /*
     function peg$parselitsq_aq() {
       var s0;
 
-      var key    = peg$currPos * 122 + 5,
+      var key    = peg$currPos * 123 + 5,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -888,7 +889,7 @@ module.exports = /*
     function peg$parselitsq_fq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 6,
+      var key    = peg$currPos * 123 + 6,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -952,7 +953,7 @@ module.exports = /*
     function peg$parselitsq_uq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 7,
+      var key    = peg$currPos * 123 + 7,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -992,7 +993,7 @@ module.exports = /*
     function peg$parselitsq_dq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 8,
+      var key    = peg$currPos * 123 + 8,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1032,7 +1033,7 @@ module.exports = /*
     function peg$parselitsq_zq() {
       var s0, s1;
 
-      var key    = peg$currPos * 122 + 9,
+      var key    = peg$currPos * 123 + 9,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1057,7 +1058,7 @@ module.exports = /*
     function peg$parseexpr_nosqc() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 10,
+      var key    = peg$currPos * 123 + 10,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1100,7 +1101,7 @@ module.exports = /*
     function peg$parselit_aq() {
       var s0;
 
-      var key    = peg$currPos * 122 + 11,
+      var key    = peg$currPos * 123 + 11,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1134,7 +1135,7 @@ module.exports = /*
     function peg$parselit_fq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 12,
+      var key    = peg$currPos * 123 + 12,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1222,7 +1223,7 @@ module.exports = /*
     function peg$parselit_uq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 13,
+      var key    = peg$currPos * 123 + 13,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1262,7 +1263,7 @@ module.exports = /*
     function peg$parselit_dq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 14,
+      var key    = peg$currPos * 123 + 14,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1302,7 +1303,7 @@ module.exports = /*
     function peg$parselit_uqn() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 15,
+      var key    = peg$currPos * 123 + 15,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1336,7 +1337,7 @@ module.exports = /*
     function peg$parselit_dqn() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 16,
+      var key    = peg$currPos * 123 + 16,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1370,7 +1371,7 @@ module.exports = /*
     function peg$parseleft() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 17,
+      var key    = peg$currPos * 123 + 17,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1422,7 +1423,7 @@ module.exports = /*
     function peg$parseright() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 18,
+      var key    = peg$currPos * 123 + 18,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1474,7 +1475,7 @@ module.exports = /*
     function peg$parselit() {
       var s0, s1, s2, s3, s4, s5;
 
-      var key    = peg$currPos * 122 + 19,
+      var key    = peg$currPos * 123 + 19,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2249,7 +2250,7 @@ module.exports = /*
     function peg$parsearray() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 20,
+      var key    = peg$currPos * 123 + 20,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2283,7 +2284,7 @@ module.exports = /*
     function peg$parsealignat() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 21,
+      var key    = peg$currPos * 123 + 21,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2317,7 +2318,7 @@ module.exports = /*
     function peg$parsematrix() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 122 + 22,
+      var key    = peg$currPos * 123 + 22,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2369,7 +2370,7 @@ module.exports = /*
     function peg$parseline_start() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 23,
+      var key    = peg$currPos * 123 + 23,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2406,7 +2407,7 @@ module.exports = /*
     function peg$parseline() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 122 + 24,
+      var key    = peg$currPos * 123 + 24,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2458,7 +2459,7 @@ module.exports = /*
     function peg$parsecolumn_spec() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 122 + 25,
+      var key    = peg$currPos * 123 + 25,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2513,7 +2514,7 @@ module.exports = /*
     function peg$parseone_col() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-      var key    = peg$currPos * 122 + 26,
+      var key    = peg$currPos * 123 + 26,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2792,7 +2793,7 @@ module.exports = /*
     function peg$parsealignat_spec() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 122 + 27,
+      var key    = peg$currPos * 123 + 27,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2865,7 +2866,7 @@ module.exports = /*
     function peg$parseopt_pos() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 122 + 28,
+      var key    = peg$currPos * 123 + 28,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2943,7 +2944,7 @@ module.exports = /*
     function peg$parsechem_lit() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 29,
+      var key    = peg$currPos * 123 + 29,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2983,7 +2984,7 @@ module.exports = /*
     function peg$parsechem_sentence() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 122 + 30,
+      var key    = peg$currPos * 123 + 30,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3059,7 +3060,7 @@ module.exports = /*
     function peg$parsechem_phrase() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 31,
+      var key    = peg$currPos * 123 + 31,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3141,7 +3142,7 @@ module.exports = /*
     function peg$parsechem_word() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 32,
+      var key    = peg$currPos * 123 + 32,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3166,6 +3167,24 @@ module.exports = /*
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseCHEM_SINGLE_MACRO();
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parsechem_char_nl();
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c96(s1, s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
@@ -3175,7 +3194,7 @@ module.exports = /*
     function peg$parsechem_word_nt() {
       var s0, s1;
 
-      var key    = peg$currPos * 122 + 33,
+      var key    = peg$currPos * 123 + 33,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3196,7 +3215,7 @@ module.exports = /*
         s1 = peg$c6;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c96();
+          s1 = peg$c97();
         }
         s0 = s1;
       }
@@ -3206,10 +3225,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parsechem_char() {
+    function peg$parsechem_char_nl() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 34,
+      var key    = peg$currPos * 123 + 34,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3222,7 +3241,7 @@ module.exports = /*
       s1 = peg$parsechem_script();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c97(s1);
+        s1 = peg$c98(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -3234,7 +3253,7 @@ module.exports = /*
             s3 = peg$parseCURLY_CLOSE();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c98(s2);
+              s1 = peg$c99(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3257,7 +3276,7 @@ module.exports = /*
               s3 = peg$parseCHEM_DOLLAR();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c99(s2);
+                s1 = peg$c100(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3278,7 +3297,7 @@ module.exports = /*
               s2 = peg$parsechem_bond();
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c100(s1, s2);
+                s1 = peg$c101(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3301,18 +3320,9 @@ module.exports = /*
                 s1 = peg$parseCHEM_NONLETTER();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c101(s1);
+                  s1 = peg$c102(s1);
                 }
                 s0 = s1;
-                if (s0 === peg$FAILED) {
-                  s0 = peg$currPos;
-                  s1 = peg$parseCHEM_LETTER();
-                  if (s1 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c101(s1);
-                  }
-                  s0 = s1;
-                }
               }
             }
           }
@@ -3324,10 +3334,44 @@ module.exports = /*
       return s0;
     }
 
+    function peg$parsechem_char() {
+      var s0, s1;
+
+      var key    = peg$currPos * 123 + 35,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsechem_char_nl();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c98(s1);
+      }
+      s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseCHEM_LETTER();
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c102(s1);
+        }
+        s0 = s1;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
     function peg$parsechem_bond() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 35,
+      var key    = peg$currPos * 123 + 36,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3344,7 +3388,7 @@ module.exports = /*
           s3 = peg$parseCURLY_CLOSE();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c102(s2);
+            s1 = peg$c103(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3367,7 +3411,7 @@ module.exports = /*
     function peg$parsechem_script() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 122 + 36,
+      var key    = peg$currPos * 123 + 37,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3382,7 +3426,7 @@ module.exports = /*
         s2 = peg$parseCHEM_SCRIPT_FOLLOW();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c103(s1, s2);
+          s1 = peg$c104(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3399,7 +3443,7 @@ module.exports = /*
           s2 = peg$parsechem_lit();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c104(s1, s2);
+            s1 = peg$c105(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3420,7 +3464,7 @@ module.exports = /*
                 s4 = peg$parseCHEM_DOLLAR();
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c105(s1, s3);
+                  s1 = peg$c106(s1, s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3449,7 +3493,7 @@ module.exports = /*
     function peg$parsechem_macro() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 122 + 37,
+      var key    = peg$currPos * 123 + 38,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3464,17 +3508,17 @@ module.exports = /*
         s2 = peg$parsechem_lit();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 95) {
-            s3 = peg$c106;
+            s3 = peg$c107;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c107); }
+            if (peg$silentFails === 0) { peg$fail(peg$c108); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parsechem_lit();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c108(s1, s2, s4);
+              s1 = peg$c109(s1, s2, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3501,7 +3545,7 @@ module.exports = /*
             s3 = peg$parsechem_lit();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c109(s1, s2, s3);
+              s1 = peg$c110(s1, s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3522,7 +3566,7 @@ module.exports = /*
             s2 = peg$parsechem_lit();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c110(s1, s2);
+              s1 = peg$c111(s1, s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3541,9 +3585,9 @@ module.exports = /*
     }
 
     function peg$parsechem_latex() {
-      var s0, s1, s2;
+      var s0, s1;
 
-      var key    = peg$currPos * 122 + 38,
+      var key    = peg$currPos * 123 + 39,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3553,67 +3597,10 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      s1 = [];
-      s2 = peg$parseboxchars();
-      if (s2 === peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 95) {
-          s2 = peg$c106;
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c107); }
-        }
-        if (s2 === peg$FAILED) {
-          s2 = peg$parseCURLY_OPEN();
-          if (s2 === peg$FAILED) {
-            s2 = peg$parseCURLY_CLOSE();
-            if (s2 === peg$FAILED) {
-              if (input.charCodeAt(peg$currPos) === 92) {
-                s2 = peg$c111;
-                peg$currPos++;
-              } else {
-                s2 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c112); }
-              }
-            }
-          }
-        }
-      }
-      if (s2 !== peg$FAILED) {
-        while (s2 !== peg$FAILED) {
-          s1.push(s2);
-          s2 = peg$parseboxchars();
-          if (s2 === peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 95) {
-              s2 = peg$c106;
-              peg$currPos++;
-            } else {
-              s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c107); }
-            }
-            if (s2 === peg$FAILED) {
-              s2 = peg$parseCURLY_OPEN();
-              if (s2 === peg$FAILED) {
-                s2 = peg$parseCURLY_CLOSE();
-                if (s2 === peg$FAILED) {
-                  if (input.charCodeAt(peg$currPos) === 92) {
-                    s2 = peg$c111;
-                    peg$currPos++;
-                  } else {
-                    s2 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c112); }
-                  }
-                }
-              }
-            }
-          }
-        }
-      } else {
-        s1 = peg$FAILED;
-      }
+      s1 = peg$parseexpr();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c113(s1);
+        s1 = peg$c3(s1);
       }
       s0 = s1;
 
@@ -3625,7 +3612,7 @@ module.exports = /*
     function peg$parsechem_text() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 39,
+      var key    = peg$currPos * 123 + 40,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3647,7 +3634,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c113(s1);
+        s1 = peg$c112(s1);
       }
       s0 = s1;
 
@@ -3659,7 +3646,7 @@ module.exports = /*
     function peg$parsealpha() {
       var s0;
 
-      var key    = peg$currPos * 122 + 40,
+      var key    = peg$currPos * 123 + 41,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3668,12 +3655,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c114.test(input.charAt(peg$currPos))) {
+      if (peg$c113.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c114); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3684,7 +3671,7 @@ module.exports = /*
     function peg$parseliteral_id() {
       var s0;
 
-      var key    = peg$currPos * 122 + 41,
+      var key    = peg$currPos * 123 + 42,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3693,12 +3680,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c114.test(input.charAt(peg$currPos))) {
+      if (peg$c113.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c114); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3709,7 +3696,7 @@ module.exports = /*
     function peg$parseliteral_mn() {
       var s0;
 
-      var key    = peg$currPos * 122 + 42,
+      var key    = peg$currPos * 123 + 43,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3734,7 +3721,7 @@ module.exports = /*
     function peg$parseliteral_uf_lt() {
       var s0;
 
-      var key    = peg$currPos * 122 + 43,
+      var key    = peg$currPos * 123 + 44,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3743,12 +3730,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c116.test(input.charAt(peg$currPos))) {
+      if (peg$c115.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c117); }
+        if (peg$silentFails === 0) { peg$fail(peg$c116); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3759,7 +3746,7 @@ module.exports = /*
     function peg$parsedelimiter_uf_lt() {
       var s0;
 
-      var key    = peg$currPos * 122 + 44,
+      var key    = peg$currPos * 123 + 45,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3768,12 +3755,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c118.test(input.charAt(peg$currPos))) {
+      if (peg$c117.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c119); }
+        if (peg$silentFails === 0) { peg$fail(peg$c118); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3784,7 +3771,7 @@ module.exports = /*
     function peg$parseliteral_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 122 + 45,
+      var key    = peg$currPos * 123 + 46,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3793,12 +3780,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c120.test(input.charAt(peg$currPos))) {
+      if (peg$c119.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+        if (peg$silentFails === 0) { peg$fail(peg$c120); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3809,7 +3796,7 @@ module.exports = /*
     function peg$parsedelimiter_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 122 + 46,
+      var key    = peg$currPos * 123 + 47,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3818,12 +3805,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c122.test(input.charAt(peg$currPos))) {
+      if (peg$c121.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c123); }
+        if (peg$silentFails === 0) { peg$fail(peg$c122); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3834,7 +3821,7 @@ module.exports = /*
     function peg$parseboxchars() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 47,
+      var key    = peg$currPos * 123 + 48,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3843,33 +3830,33 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c124.test(input.charAt(peg$currPos))) {
+      if (peg$c123.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c125); }
+        if (peg$silentFails === 0) { peg$fail(peg$c124); }
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (peg$c126.test(input.charAt(peg$currPos))) {
+        if (peg$c125.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c127); }
+          if (peg$silentFails === 0) { peg$fail(peg$c126); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c128.test(input.charAt(peg$currPos))) {
+          if (peg$c127.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c129); }
+            if (peg$silentFails === 0) { peg$fail(peg$c128); }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c130(s1, s2);
+            s1 = peg$c129(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3889,7 +3876,7 @@ module.exports = /*
     function peg$parseBOX() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
-      var key    = peg$currPos * 122 + 48,
+      var key    = peg$currPos * 123 + 49,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3902,7 +3889,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c131(s1);
+        s2 = peg$c130(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -3912,11 +3899,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c132;
+              s4 = peg$c131;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c133); }
+              if (peg$silentFails === 0) { peg$fail(peg$c132); }
             }
             if (s4 !== peg$FAILED) {
               s5 = [];
@@ -3941,7 +3928,7 @@ module.exports = /*
                   s7 = peg$parse_();
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c134(s1, s5);
+                    s1 = peg$c133(s1, s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3980,7 +3967,7 @@ module.exports = /*
     function peg$parseLITERAL() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-      var key    = peg$currPos * 122 + 49,
+      var key    = peg$currPos * 123 + 50,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3997,11 +3984,11 @@ module.exports = /*
           s1 = peg$parseliteral_uf_lt();
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 45) {
-              s1 = peg$c135;
+              s1 = peg$c134;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c136); }
+              if (peg$silentFails === 0) { peg$fail(peg$c135); }
             }
             if (s1 === peg$FAILED) {
               s1 = peg$parseliteral_uf_op();
@@ -4013,7 +4000,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c137(s1);
+          s1 = peg$c136(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4028,7 +4015,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c138(s1);
+          s2 = peg$c137(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -4038,11 +4025,11 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s4 = peg$c139;
+                s4 = peg$c138;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c140); }
+                if (peg$silentFails === 0) { peg$fail(peg$c139); }
               }
               if (s4 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 91) {
@@ -4053,19 +4040,19 @@ module.exports = /*
                   if (peg$silentFails === 0) { peg$fail(peg$c79); }
                 }
                 if (s4 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c141) {
-                    s4 = peg$c141;
+                  if (input.substr(peg$currPos, 2) === peg$c140) {
+                    s4 = peg$c140;
                     peg$currPos += 2;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c142); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c141); }
                   }
                   if (s4 === peg$FAILED) {
                     s4 = peg$currPos;
                     s5 = peg$c6;
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s4;
-                      s5 = peg$c143(s1);
+                      s5 = peg$c142(s1);
                     }
                     s4 = s5;
                   }
@@ -4075,7 +4062,7 @@ module.exports = /*
                 s5 = peg$parse_();
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c144(s1, s4);
+                  s1 = peg$c143(s1, s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4102,7 +4089,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c145(s1);
+            s2 = peg$c144(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -4112,11 +4099,11 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s4 = peg$c139;
+                  s4 = peg$c138;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c140); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c139); }
                 }
                 if (s4 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 91) {
@@ -4127,19 +4114,19 @@ module.exports = /*
                     if (peg$silentFails === 0) { peg$fail(peg$c79); }
                   }
                   if (s4 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 2) === peg$c141) {
-                      s4 = peg$c141;
+                    if (input.substr(peg$currPos, 2) === peg$c140) {
+                      s4 = peg$c140;
                       peg$currPos += 2;
                     } else {
                       s4 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c142); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c141); }
                     }
                     if (s4 === peg$FAILED) {
                       s4 = peg$currPos;
                       s5 = peg$c6;
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s4;
-                        s5 = peg$c143(s1);
+                        s5 = peg$c142(s1);
                       }
                       s4 = s5;
                     }
@@ -4149,7 +4136,7 @@ module.exports = /*
                   s5 = peg$parse_();
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c146(s1, s4);
+                    s1 = peg$c145(s1, s4);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4176,7 +4163,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c147(s1);
+              s2 = peg$c146(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -4186,7 +4173,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c148(s1);
+                  s1 = peg$c147(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4205,7 +4192,7 @@ module.exports = /*
               s1 = peg$parsegeneric_func();
               if (s1 !== peg$FAILED) {
                 peg$savedPos = peg$currPos;
-                s2 = peg$c149(s1);
+                s2 = peg$c148(s1);
                 if (s2) {
                   s2 = void 0;
                 } else {
@@ -4215,7 +4202,7 @@ module.exports = /*
                   s3 = peg$parse_();
                   if (s3 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c150(s1);
+                    s1 = peg$c149(s1);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4234,7 +4221,7 @@ module.exports = /*
                 s1 = peg$parsegeneric_func();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = peg$currPos;
-                  s2 = peg$c151(s1);
+                  s2 = peg$c150(s1);
                   if (s2) {
                     s2 = void 0;
                   } else {
@@ -4244,17 +4231,17 @@ module.exports = /*
                     s3 = peg$parse_();
                     if (s3 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 123) {
-                        s4 = peg$c132;
+                        s4 = peg$c131;
                         peg$currPos++;
                       } else {
                         s4 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c132); }
                       }
                       if (s4 !== peg$FAILED) {
                         s5 = peg$parsegeneric_func();
                         if (s5 !== peg$FAILED) {
                           peg$savedPos = peg$currPos;
-                          s6 = peg$c152(s1, s5);
+                          s6 = peg$c151(s1, s5);
                           if (s6) {
                             s6 = void 0;
                           } else {
@@ -4274,7 +4261,7 @@ module.exports = /*
                                 s9 = peg$parse_();
                                 if (s9 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c153(s1, s5);
+                                  s1 = peg$c152(s1, s5);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -4317,7 +4304,7 @@ module.exports = /*
                   s1 = peg$parsegeneric_func();
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = peg$currPos;
-                    s2 = peg$c154(s1);
+                    s2 = peg$c153(s1);
                     if (s2) {
                       s2 = void 0;
                     } else {
@@ -4327,7 +4314,7 @@ module.exports = /*
                       s3 = peg$parse_();
                       if (s3 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c155(s1);
+                        s1 = peg$c154(s1);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -4346,7 +4333,7 @@ module.exports = /*
                     s1 = peg$parsegeneric_func();
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = peg$currPos;
-                      s2 = peg$c156(s1);
+                      s2 = peg$c155(s1);
                       if (s2) {
                         s2 = void 0;
                       } else {
@@ -4356,17 +4343,17 @@ module.exports = /*
                         s3 = peg$parse_();
                         if (s3 !== peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 123) {
-                            s4 = peg$c132;
+                            s4 = peg$c131;
                             peg$currPos++;
                           } else {
                             s4 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c133); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c132); }
                           }
                           if (s4 !== peg$FAILED) {
                             s5 = peg$parsegeneric_func();
                             if (s5 !== peg$FAILED) {
                               peg$savedPos = peg$currPos;
-                              s6 = peg$c157(s1, s5);
+                              s6 = peg$c156(s1, s5);
                               if (s6) {
                                 s6 = void 0;
                               } else {
@@ -4386,7 +4373,7 @@ module.exports = /*
                                     s9 = peg$parse_();
                                     if (s9 !== peg$FAILED) {
                                       peg$savedPos = s0;
-                                      s1 = peg$c158(s1, s5);
+                                      s1 = peg$c157(s1, s5);
                                       s0 = s1;
                                     } else {
                                       peg$currPos = s0;
@@ -4432,31 +4419,31 @@ module.exports = /*
                       }
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c159(s1);
+                        s1 = peg$c158(s1);
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
                         if (input.charCodeAt(peg$currPos) === 92) {
-                          s1 = peg$c111;
+                          s1 = peg$c159;
                           peg$currPos++;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c112); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c160); }
                         }
                         if (s1 !== peg$FAILED) {
-                          if (peg$c160.test(input.charAt(peg$currPos))) {
+                          if (peg$c161.test(input.charAt(peg$currPos))) {
                             s2 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s2 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c161); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c162); }
                           }
                           if (s2 !== peg$FAILED) {
                             s3 = peg$parse_();
                             if (s3 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c162(s2);
+                              s1 = peg$c163(s2);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -4472,18 +4459,18 @@ module.exports = /*
                         }
                         if (s0 === peg$FAILED) {
                           s0 = peg$currPos;
-                          if (peg$c163.test(input.charAt(peg$currPos))) {
+                          if (peg$c164.test(input.charAt(peg$currPos))) {
                             s1 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c164); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c165); }
                           }
                           if (s1 !== peg$FAILED) {
                             s2 = peg$parse_();
                             if (s2 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c137(s1);
+                              s1 = peg$c136(s1);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -4495,18 +4482,18 @@ module.exports = /*
                           }
                           if (s0 === peg$FAILED) {
                             s0 = peg$currPos;
-                            if (peg$c165.test(input.charAt(peg$currPos))) {
+                            if (peg$c166.test(input.charAt(peg$currPos))) {
                               s1 = input.charAt(peg$currPos);
                               peg$currPos++;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c166); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c167); }
                             }
                             if (s1 !== peg$FAILED) {
                               s2 = peg$parse_();
                               if (s2 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c167(s1);
+                                s1 = peg$c168(s1);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -4536,7 +4523,7 @@ module.exports = /*
     function peg$parseDELIMITER() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 50,
+      var key    = peg$currPos * 123 + 51,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4563,7 +4550,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c137(s1);
+          s1 = peg$c136(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4576,25 +4563,25 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c111;
+          s1 = peg$c159;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c112); }
+          if (peg$silentFails === 0) { peg$fail(peg$c160); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c168.test(input.charAt(peg$currPos))) {
+          if (peg$c169.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c169); }
+            if (peg$silentFails === 0) { peg$fail(peg$c170); }
           }
           if (s2 !== peg$FAILED) {
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c162(s2);
+              s1 = peg$c163(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4613,7 +4600,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c170(s1);
+            s2 = peg$c171(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -4623,7 +4610,7 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c148(s1);
+                s1 = peg$c147(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4642,7 +4629,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c171(s1);
+              s2 = peg$c172(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -4652,7 +4639,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c172(s1);
+                  s1 = peg$c173(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4678,7 +4665,7 @@ module.exports = /*
     function peg$parseFUN_AR1nb() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 51,
+      var key    = peg$currPos * 123 + 52,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4691,7 +4678,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c173(s1);
+        s2 = peg$c174(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -4701,7 +4688,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c174(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4724,7 +4711,7 @@ module.exports = /*
     function peg$parseFUN_AR1opt() {
       var s0, s1, s2, s3, s4, s5;
 
-      var key    = peg$currPos * 122 + 52,
+      var key    = peg$currPos * 123 + 53,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4737,7 +4724,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c175(s1);
+        s2 = peg$c176(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -4757,7 +4744,7 @@ module.exports = /*
               s5 = peg$parse_();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c174(s1);
+                s1 = peg$c175(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4788,7 +4775,7 @@ module.exports = /*
     function peg$parseNEXT_CELL() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 53,
+      var key    = peg$currPos * 123 + 54,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4799,11 +4786,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 38) {
-        s1 = peg$c176;
+        s1 = peg$c177;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c177); }
+        if (peg$silentFails === 0) { peg$fail(peg$c178); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4827,7 +4814,7 @@ module.exports = /*
     function peg$parseNEXT_ROW() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 54,
+      var key    = peg$currPos * 123 + 55,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4837,12 +4824,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c178) {
-        s1 = peg$c178;
+      if (input.substr(peg$currPos, 2) === peg$c179) {
+        s1 = peg$c179;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c180); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4866,7 +4853,7 @@ module.exports = /*
     function peg$parseBEGIN() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 55,
+      var key    = peg$currPos * 123 + 56,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4876,12 +4863,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c180) {
-        s1 = peg$c180;
+      if (input.substr(peg$currPos, 6) === peg$c181) {
+        s1 = peg$c181;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c181); }
+        if (peg$silentFails === 0) { peg$fail(peg$c182); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4905,7 +4892,7 @@ module.exports = /*
     function peg$parseEND() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 56,
+      var key    = peg$currPos * 123 + 57,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4915,12 +4902,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c182) {
-        s1 = peg$c182;
+      if (input.substr(peg$currPos, 4) === peg$c183) {
+        s1 = peg$c183;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c184); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4944,7 +4931,7 @@ module.exports = /*
     function peg$parseBEGIN_MATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 57,
+      var key    = peg$currPos * 123 + 58,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4956,12 +4943,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c184) {
-          s2 = peg$c184;
+        if (input.substr(peg$currPos, 8) === peg$c185) {
+          s2 = peg$c185;
           peg$currPos += 8;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c185); }
+          if (peg$silentFails === 0) { peg$fail(peg$c186); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4989,7 +4976,7 @@ module.exports = /*
     function peg$parseEND_MATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 58,
+      var key    = peg$currPos * 123 + 59,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5001,12 +4988,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c184) {
-          s2 = peg$c184;
+        if (input.substr(peg$currPos, 8) === peg$c185) {
+          s2 = peg$c185;
           peg$currPos += 8;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c185); }
+          if (peg$silentFails === 0) { peg$fail(peg$c186); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5034,7 +5021,7 @@ module.exports = /*
     function peg$parseBEGIN_PMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 59,
+      var key    = peg$currPos * 123 + 60,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5046,12 +5033,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c186) {
-          s2 = peg$c186;
+        if (input.substr(peg$currPos, 9) === peg$c187) {
+          s2 = peg$c187;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c187); }
+          if (peg$silentFails === 0) { peg$fail(peg$c188); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5079,7 +5066,7 @@ module.exports = /*
     function peg$parseEND_PMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 60,
+      var key    = peg$currPos * 123 + 61,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5091,12 +5078,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c186) {
-          s2 = peg$c186;
+        if (input.substr(peg$currPos, 9) === peg$c187) {
+          s2 = peg$c187;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c187); }
+          if (peg$silentFails === 0) { peg$fail(peg$c188); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5124,7 +5111,7 @@ module.exports = /*
     function peg$parseBEGIN_BMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 61,
+      var key    = peg$currPos * 123 + 62,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5136,12 +5123,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c188) {
-          s2 = peg$c188;
+        if (input.substr(peg$currPos, 9) === peg$c189) {
+          s2 = peg$c189;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c189); }
+          if (peg$silentFails === 0) { peg$fail(peg$c190); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5169,7 +5156,7 @@ module.exports = /*
     function peg$parseEND_BMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 62,
+      var key    = peg$currPos * 123 + 63,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5181,12 +5168,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c188) {
-          s2 = peg$c188;
+        if (input.substr(peg$currPos, 9) === peg$c189) {
+          s2 = peg$c189;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c189); }
+          if (peg$silentFails === 0) { peg$fail(peg$c190); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5214,7 +5201,7 @@ module.exports = /*
     function peg$parseBEGIN_BBMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 63,
+      var key    = peg$currPos * 123 + 64,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5226,12 +5213,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c190) {
-          s2 = peg$c190;
+        if (input.substr(peg$currPos, 9) === peg$c191) {
+          s2 = peg$c191;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c191); }
+          if (peg$silentFails === 0) { peg$fail(peg$c192); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5259,7 +5246,7 @@ module.exports = /*
     function peg$parseEND_BBMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 64,
+      var key    = peg$currPos * 123 + 65,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5271,12 +5258,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c190) {
-          s2 = peg$c190;
+        if (input.substr(peg$currPos, 9) === peg$c191) {
+          s2 = peg$c191;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c191); }
+          if (peg$silentFails === 0) { peg$fail(peg$c192); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5304,7 +5291,7 @@ module.exports = /*
     function peg$parseBEGIN_VMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 65,
+      var key    = peg$currPos * 123 + 66,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5316,12 +5303,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c192) {
-          s2 = peg$c192;
+        if (input.substr(peg$currPos, 9) === peg$c193) {
+          s2 = peg$c193;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c193); }
+          if (peg$silentFails === 0) { peg$fail(peg$c194); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5349,7 +5336,7 @@ module.exports = /*
     function peg$parseEND_VMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 66,
+      var key    = peg$currPos * 123 + 67,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5361,12 +5348,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c192) {
-          s2 = peg$c192;
+        if (input.substr(peg$currPos, 9) === peg$c193) {
+          s2 = peg$c193;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c193); }
+          if (peg$silentFails === 0) { peg$fail(peg$c194); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5394,7 +5381,7 @@ module.exports = /*
     function peg$parseBEGIN_VVMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 67,
+      var key    = peg$currPos * 123 + 68,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5406,12 +5393,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c194) {
-          s2 = peg$c194;
+        if (input.substr(peg$currPos, 9) === peg$c195) {
+          s2 = peg$c195;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c195); }
+          if (peg$silentFails === 0) { peg$fail(peg$c196); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5439,7 +5426,7 @@ module.exports = /*
     function peg$parseEND_VVMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 68,
+      var key    = peg$currPos * 123 + 69,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5451,12 +5438,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c194) {
-          s2 = peg$c194;
+        if (input.substr(peg$currPos, 9) === peg$c195) {
+          s2 = peg$c195;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c195); }
+          if (peg$silentFails === 0) { peg$fail(peg$c196); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5484,7 +5471,7 @@ module.exports = /*
     function peg$parseBEGIN_ARRAY() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 69,
+      var key    = peg$currPos * 123 + 70,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5496,12 +5483,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c196) {
-          s2 = peg$c196;
+        if (input.substr(peg$currPos, 7) === peg$c197) {
+          s2 = peg$c197;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c197); }
+          if (peg$silentFails === 0) { peg$fail(peg$c198); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5529,7 +5516,7 @@ module.exports = /*
     function peg$parseEND_ARRAY() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 70,
+      var key    = peg$currPos * 123 + 71,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5541,12 +5528,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c196) {
-          s2 = peg$c196;
+        if (input.substr(peg$currPos, 7) === peg$c197) {
+          s2 = peg$c197;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c197); }
+          if (peg$silentFails === 0) { peg$fail(peg$c198); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5574,7 +5561,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGN() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 71,
+      var key    = peg$currPos * 123 + 72,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5586,12 +5573,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c198) {
-          s2 = peg$c198;
+        if (input.substr(peg$currPos, 7) === peg$c199) {
+          s2 = peg$c199;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c199); }
+          if (peg$silentFails === 0) { peg$fail(peg$c200); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5619,7 +5606,7 @@ module.exports = /*
     function peg$parseEND_ALIGN() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 72,
+      var key    = peg$currPos * 123 + 73,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5631,12 +5618,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c198) {
-          s2 = peg$c198;
+        if (input.substr(peg$currPos, 7) === peg$c199) {
+          s2 = peg$c199;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c199); }
+          if (peg$silentFails === 0) { peg$fail(peg$c200); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5664,7 +5651,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNED() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 73,
+      var key    = peg$currPos * 123 + 74,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5676,12 +5663,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c200) {
-          s2 = peg$c200;
+        if (input.substr(peg$currPos, 9) === peg$c201) {
+          s2 = peg$c201;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c201); }
+          if (peg$silentFails === 0) { peg$fail(peg$c202); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5709,7 +5696,7 @@ module.exports = /*
     function peg$parseEND_ALIGNED() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 74,
+      var key    = peg$currPos * 123 + 75,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5721,12 +5708,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c200) {
-          s2 = peg$c200;
+        if (input.substr(peg$currPos, 9) === peg$c201) {
+          s2 = peg$c201;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c201); }
+          if (peg$silentFails === 0) { peg$fail(peg$c202); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5754,7 +5741,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 75,
+      var key    = peg$currPos * 123 + 76,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5766,12 +5753,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c202) {
-          s2 = peg$c202;
+        if (input.substr(peg$currPos, 9) === peg$c203) {
+          s2 = peg$c203;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c203); }
+          if (peg$silentFails === 0) { peg$fail(peg$c204); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5799,7 +5786,7 @@ module.exports = /*
     function peg$parseEND_ALIGNAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 76,
+      var key    = peg$currPos * 123 + 77,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5811,12 +5798,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c202) {
-          s2 = peg$c202;
+        if (input.substr(peg$currPos, 9) === peg$c203) {
+          s2 = peg$c203;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c203); }
+          if (peg$silentFails === 0) { peg$fail(peg$c204); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5844,7 +5831,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNEDAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 77,
+      var key    = peg$currPos * 123 + 78,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5856,12 +5843,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c204) {
-          s2 = peg$c204;
+        if (input.substr(peg$currPos, 11) === peg$c205) {
+          s2 = peg$c205;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c205); }
+          if (peg$silentFails === 0) { peg$fail(peg$c206); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5889,7 +5876,7 @@ module.exports = /*
     function peg$parseEND_ALIGNEDAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 78,
+      var key    = peg$currPos * 123 + 79,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5901,12 +5888,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c204) {
-          s2 = peg$c204;
+        if (input.substr(peg$currPos, 11) === peg$c205) {
+          s2 = peg$c205;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c205); }
+          if (peg$silentFails === 0) { peg$fail(peg$c206); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5934,7 +5921,7 @@ module.exports = /*
     function peg$parseBEGIN_SMALLMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 79,
+      var key    = peg$currPos * 123 + 80,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5946,12 +5933,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c206) {
-          s2 = peg$c206;
+        if (input.substr(peg$currPos, 13) === peg$c207) {
+          s2 = peg$c207;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c207); }
+          if (peg$silentFails === 0) { peg$fail(peg$c208); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5979,7 +5966,7 @@ module.exports = /*
     function peg$parseEND_SMALLMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 80,
+      var key    = peg$currPos * 123 + 81,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5991,12 +5978,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c206) {
-          s2 = peg$c206;
+        if (input.substr(peg$currPos, 13) === peg$c207) {
+          s2 = peg$c207;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c207); }
+          if (peg$silentFails === 0) { peg$fail(peg$c208); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6024,7 +6011,7 @@ module.exports = /*
     function peg$parseBEGIN_CASES() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 81,
+      var key    = peg$currPos * 123 + 82,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6036,12 +6023,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c208) {
-          s2 = peg$c208;
+        if (input.substr(peg$currPos, 7) === peg$c209) {
+          s2 = peg$c209;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c209); }
+          if (peg$silentFails === 0) { peg$fail(peg$c210); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6069,7 +6056,7 @@ module.exports = /*
     function peg$parseEND_CASES() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 82,
+      var key    = peg$currPos * 123 + 83,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6081,12 +6068,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c208) {
-          s2 = peg$c208;
+        if (input.substr(peg$currPos, 7) === peg$c209) {
+          s2 = peg$c209;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c209); }
+          if (peg$silentFails === 0) { peg$fail(peg$c210); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6114,7 +6101,7 @@ module.exports = /*
     function peg$parseSQ_CLOSE() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 83,
+      var key    = peg$currPos * 123 + 84,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6153,7 +6140,7 @@ module.exports = /*
     function peg$parseCURLY_OPEN() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 84,
+      var key    = peg$currPos * 123 + 85,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6164,11 +6151,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c131;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c132); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6192,7 +6179,7 @@ module.exports = /*
     function peg$parseCURLY_CLOSE() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 85,
+      var key    = peg$currPos * 123 + 86,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6231,7 +6218,7 @@ module.exports = /*
     function peg$parseSUP() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 86,
+      var key    = peg$currPos * 123 + 87,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6270,7 +6257,7 @@ module.exports = /*
     function peg$parseSUB() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 87,
+      var key    = peg$currPos * 123 + 88,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6281,11 +6268,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 95) {
-        s1 = peg$c106;
+        s1 = peg$c107;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c107); }
+        if (peg$silentFails === 0) { peg$fail(peg$c108); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6309,7 +6296,7 @@ module.exports = /*
     function peg$parsegeneric_func() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 88,
+      var key    = peg$currPos * 123 + 89,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6320,11 +6307,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c111;
+        s1 = peg$c159;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c112); }
+        if (peg$silentFails === 0) { peg$fail(peg$c160); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -6358,53 +6345,7 @@ module.exports = /*
     function peg$parseBIG() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 89,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      s1 = peg$parsegeneric_func();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = peg$currPos;
-        s2 = peg$c210(s1);
-        if (s2) {
-          s2 = void 0;
-        } else {
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c174(s1);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseFUN_AR1() {
-      var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 122 + 90,
+      var key    = peg$currPos * 123 + 90,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6427,7 +6368,53 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c174(s1);
+            s1 = peg$c175(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseFUN_AR1() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 123 + 91,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c212(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6446,7 +6433,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c212(s1);
+          s2 = peg$c213(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -6456,7 +6443,7 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c212(s1);
+              s1 = peg$c213(s1);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6480,53 +6467,7 @@ module.exports = /*
     function peg$parseFUN_MHCHEM() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 91,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      s1 = peg$parsegeneric_func();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = peg$currPos;
-        s2 = peg$c213(s1);
-        if (s2) {
-          s2 = void 0;
-        } else {
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c174(s1);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseFUN_AR2() {
-      var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 122 + 92,
+      var key    = peg$currPos * 123 + 92,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6549,7 +6490,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c174(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6569,10 +6510,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseFUN_INFIX() {
+    function peg$parseFUN_AR2() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 93,
+      var key    = peg$currPos * 123 + 93,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6595,7 +6536,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c174(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6615,10 +6556,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseDECLh() {
+    function peg$parseFUN_INFIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 94,
+      var key    = peg$currPos * 123 + 94,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6641,7 +6582,53 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c217(s1);
+            s1 = peg$c175(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseDECLh() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 123 + 95,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c217(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c218(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6664,7 +6651,7 @@ module.exports = /*
     function peg$parseFUN_AR2nb() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 95,
+      var key    = peg$currPos * 123 + 96,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6677,7 +6664,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c218(s1);
+        s2 = peg$c219(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6687,7 +6674,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c174(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6710,52 +6697,7 @@ module.exports = /*
     function peg$parseLEFT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 96,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      s1 = peg$parsegeneric_func();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = peg$currPos;
-        s2 = peg$c219(s1);
-        if (s2) {
-          s2 = void 0;
-        } else {
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            s1 = [s1, s2, s3];
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseRIGHT() {
-      var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 122 + 97,
+      var key    = peg$currPos * 123 + 97,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6797,10 +6739,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseHLINE() {
+    function peg$parseRIGHT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 98,
+      var key    = peg$currPos * 123 + 98,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6822,8 +6764,53 @@ module.exports = /*
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
+            s1 = [s1, s2, s3];
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseHLINE() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 123 + 99,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c222(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c174(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6846,7 +6833,7 @@ module.exports = /*
     function peg$parseCOLOR() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 122 + 99,
+      var key    = peg$currPos * 123 + 100,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6859,7 +6846,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c222(s1);
+        s2 = peg$c223(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6871,7 +6858,7 @@ module.exports = /*
             s4 = peg$parseCOLOR_SPEC();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c223(s1, s4);
+              s1 = peg$c224(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6898,7 +6885,7 @@ module.exports = /*
     function peg$parseDEFINECOLOR() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17;
 
-      var key    = peg$currPos * 122 + 100,
+      var key    = peg$currPos * 123 + 101,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6911,7 +6898,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c224(s1);
+        s2 = peg$c225(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6921,11 +6908,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c132;
+              s4 = peg$c131;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c133); }
+              if (peg$silentFails === 0) { peg$fail(peg$c132); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -6954,22 +6941,22 @@ module.exports = /*
                       s9 = peg$parse_();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 123) {
-                          s10 = peg$c132;
+                          s10 = peg$c131;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c133); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c132); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             s12 = peg$currPos;
-                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c225) {
+                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c226) {
                               s13 = input.substr(peg$currPos, 5);
                               peg$currPos += 5;
                             } else {
                               s13 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c226); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c227); }
                             }
                             if (s13 !== peg$FAILED) {
                               s14 = peg$parse_();
@@ -6987,7 +6974,7 @@ module.exports = /*
                                     s17 = peg$parseCOLOR_SPEC_NAMED();
                                     if (s17 !== peg$FAILED) {
                                       peg$savedPos = s12;
-                                      s13 = peg$c227(s1, s6, s17);
+                                      s13 = peg$c228(s1, s6, s17);
                                       s12 = s13;
                                     } else {
                                       peg$currPos = s12;
@@ -7011,12 +6998,12 @@ module.exports = /*
                             }
                             if (s12 === peg$FAILED) {
                               s12 = peg$currPos;
-                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c228) {
+                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c229) {
                                 s13 = input.substr(peg$currPos, 4);
                                 peg$currPos += 4;
                               } else {
                                 s13 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c229); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c230); }
                               }
                               if (s13 !== peg$FAILED) {
                                 s14 = peg$parse_();
@@ -7034,7 +7021,7 @@ module.exports = /*
                                       s17 = peg$parseCOLOR_SPEC_GRAY();
                                       if (s17 !== peg$FAILED) {
                                         peg$savedPos = s12;
-                                        s13 = peg$c230(s1, s6, s17);
+                                        s13 = peg$c231(s1, s6, s17);
                                         s12 = s13;
                                       } else {
                                         peg$currPos = s12;
@@ -7058,12 +7045,12 @@ module.exports = /*
                               }
                               if (s12 === peg$FAILED) {
                                 s12 = peg$currPos;
-                                if (input.substr(peg$currPos, 3) === peg$c231) {
-                                  s13 = peg$c231;
+                                if (input.substr(peg$currPos, 3) === peg$c232) {
+                                  s13 = peg$c232;
                                   peg$currPos += 3;
                                 } else {
                                   s13 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c232); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c233); }
                                 }
                                 if (s13 !== peg$FAILED) {
                                   s14 = peg$parse_();
@@ -7081,7 +7068,7 @@ module.exports = /*
                                         s17 = peg$parseCOLOR_SPEC_rgb();
                                         if (s17 !== peg$FAILED) {
                                           peg$savedPos = s12;
-                                          s13 = peg$c233(s1, s6, s17);
+                                          s13 = peg$c234(s1, s6, s17);
                                           s12 = s13;
                                         } else {
                                           peg$currPos = s12;
@@ -7105,12 +7092,12 @@ module.exports = /*
                                 }
                                 if (s12 === peg$FAILED) {
                                   s12 = peg$currPos;
-                                  if (input.substr(peg$currPos, 3) === peg$c234) {
-                                    s13 = peg$c234;
+                                  if (input.substr(peg$currPos, 3) === peg$c235) {
+                                    s13 = peg$c235;
                                     peg$currPos += 3;
                                   } else {
                                     s13 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c235); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c236); }
                                   }
                                   if (s13 !== peg$FAILED) {
                                     s14 = peg$parse_();
@@ -7128,7 +7115,7 @@ module.exports = /*
                                           s17 = peg$parseCOLOR_SPEC_RGB();
                                           if (s17 !== peg$FAILED) {
                                             peg$savedPos = s12;
-                                            s13 = peg$c233(s1, s6, s17);
+                                            s13 = peg$c234(s1, s6, s17);
                                             s12 = s13;
                                           } else {
                                             peg$currPos = s12;
@@ -7152,12 +7139,12 @@ module.exports = /*
                                   }
                                   if (s12 === peg$FAILED) {
                                     s12 = peg$currPos;
-                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c236) {
+                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c237) {
                                       s13 = input.substr(peg$currPos, 4);
                                       peg$currPos += 4;
                                     } else {
                                       s13 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c237); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c238); }
                                     }
                                     if (s13 !== peg$FAILED) {
                                       s14 = peg$parse_();
@@ -7175,7 +7162,7 @@ module.exports = /*
                                             s17 = peg$parseCOLOR_SPEC_CMYK();
                                             if (s17 !== peg$FAILED) {
                                               peg$savedPos = s12;
-                                              s13 = peg$c238(s1, s6, s17);
+                                              s13 = peg$c239(s1, s6, s17);
                                               s12 = s13;
                                             } else {
                                               peg$currPos = s12;
@@ -7203,7 +7190,7 @@ module.exports = /*
                             }
                             if (s12 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c239(s1, s6, s12);
+                              s1 = peg$c240(s1, s6, s12);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -7262,7 +7249,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
-      var key    = peg$currPos * 122 + 101,
+      var key    = peg$currPos * 123 + 102,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7284,12 +7271,12 @@ module.exports = /*
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c225) {
+            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c226) {
               s3 = input.substr(peg$currPos, 5);
               peg$currPos += 5;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c226); }
+              if (peg$silentFails === 0) { peg$fail(peg$c227); }
             }
             if (s3 !== peg$FAILED) {
               s4 = peg$parse_();
@@ -7307,7 +7294,7 @@ module.exports = /*
                     s7 = peg$parseCOLOR_SPEC_NAMED();
                     if (s7 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c240(s7);
+                      s1 = peg$c241(s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -7349,12 +7336,12 @@ module.exports = /*
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c228) {
+              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c229) {
                 s3 = input.substr(peg$currPos, 4);
                 peg$currPos += 4;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c229); }
+                if (peg$silentFails === 0) { peg$fail(peg$c230); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -7372,7 +7359,7 @@ module.exports = /*
                       s7 = peg$parseCOLOR_SPEC_GRAY();
                       if (s7 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c241(s7);
+                        s1 = peg$c242(s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -7414,12 +7401,12 @@ module.exports = /*
             if (s1 !== peg$FAILED) {
               s2 = peg$parse_();
               if (s2 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 3) === peg$c231) {
-                  s3 = peg$c231;
+                if (input.substr(peg$currPos, 3) === peg$c232) {
+                  s3 = peg$c232;
                   peg$currPos += 3;
                 } else {
                   s3 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c232); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c233); }
                 }
                 if (s3 !== peg$FAILED) {
                   s4 = peg$parse_();
@@ -7437,7 +7424,7 @@ module.exports = /*
                         s7 = peg$parseCOLOR_SPEC_rgb();
                         if (s7 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c242(s7);
+                          s1 = peg$c243(s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -7479,12 +7466,12 @@ module.exports = /*
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse_();
                 if (s2 !== peg$FAILED) {
-                  if (input.substr(peg$currPos, 3) === peg$c234) {
-                    s3 = peg$c234;
+                  if (input.substr(peg$currPos, 3) === peg$c235) {
+                    s3 = peg$c235;
                     peg$currPos += 3;
                   } else {
                     s3 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c235); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c236); }
                   }
                   if (s3 !== peg$FAILED) {
                     s4 = peg$parse_();
@@ -7502,7 +7489,7 @@ module.exports = /*
                           s7 = peg$parseCOLOR_SPEC_RGB();
                           if (s7 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c242(s7);
+                            s1 = peg$c243(s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7544,12 +7531,12 @@ module.exports = /*
                 if (s1 !== peg$FAILED) {
                   s2 = peg$parse_();
                   if (s2 !== peg$FAILED) {
-                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c236) {
+                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c237) {
                       s3 = input.substr(peg$currPos, 4);
                       peg$currPos += 4;
                     } else {
                       s3 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c237); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c238); }
                     }
                     if (s3 !== peg$FAILED) {
                       s4 = peg$parse_();
@@ -7567,7 +7554,7 @@ module.exports = /*
                             s7 = peg$parseCOLOR_SPEC_CMYK();
                             if (s7 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c243(s7);
+                              s1 = peg$c244(s7);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -7611,7 +7598,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_NAMED() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 122 + 102,
+      var key    = peg$currPos * 123 + 103,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7622,11 +7609,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c131;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c132); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7655,7 +7642,7 @@ module.exports = /*
                 s6 = peg$parse_();
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c244(s3);
+                  s1 = peg$c245(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7690,7 +7677,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_GRAY() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 122 + 103,
+      var key    = peg$currPos * 123 + 104,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7701,11 +7688,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c131;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c132); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7730,7 +7717,7 @@ module.exports = /*
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c245(s3);
+              s1 = peg$c246(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7757,7 +7744,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_rgb() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-      var key    = peg$currPos * 122 + 104,
+      var key    = peg$currPos * 123 + 105,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7768,11 +7755,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c131;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c132); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7780,11 +7767,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c246;
+              s4 = peg$c247;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c247); }
+              if (peg$silentFails === 0) { peg$fail(peg$c248); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7792,11 +7779,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c246;
+                    s7 = peg$c247;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c247); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c248); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -7814,7 +7801,7 @@ module.exports = /*
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c248(s3, s6, s9);
+                            s1 = peg$c249(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7869,7 +7856,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_RGB() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-      var key    = peg$currPos * 122 + 105,
+      var key    = peg$currPos * 123 + 106,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7880,11 +7867,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c131;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c132); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7892,11 +7879,11 @@ module.exports = /*
           s3 = peg$parseCNUM255();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c246;
+              s4 = peg$c247;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c247); }
+              if (peg$silentFails === 0) { peg$fail(peg$c248); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7904,11 +7891,11 @@ module.exports = /*
                 s6 = peg$parseCNUM255();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c246;
+                    s7 = peg$c247;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c247); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c248); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -7926,7 +7913,7 @@ module.exports = /*
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c248(s3, s6, s9);
+                            s1 = peg$c249(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7981,7 +7968,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_CMYK() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14;
 
-      var key    = peg$currPos * 122 + 106,
+      var key    = peg$currPos * 123 + 107,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7992,11 +7979,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c131;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c132); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -8004,11 +7991,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c246;
+              s4 = peg$c247;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c247); }
+              if (peg$silentFails === 0) { peg$fail(peg$c248); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -8016,11 +8003,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c246;
+                    s7 = peg$c247;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c247); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c248); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -8028,11 +8015,11 @@ module.exports = /*
                       s9 = peg$parseCNUM();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 44) {
-                          s10 = peg$c246;
+                          s10 = peg$c247;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c247); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c248); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
@@ -8050,7 +8037,7 @@ module.exports = /*
                                 s14 = peg$parse_();
                                 if (s14 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c249(s3, s6, s9, s12);
+                                  s1 = peg$c250(s3, s6, s9, s12);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -8117,7 +8104,7 @@ module.exports = /*
     function peg$parseCNUM255() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 122 + 107,
+      var key    = peg$currPos * 123 + 108,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8129,20 +8116,20 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s2 = peg$c250;
+        s2 = peg$c251;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c251); }
+        if (peg$silentFails === 0) { peg$fail(peg$c252); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$currPos;
-        if (peg$c252.test(input.charAt(peg$currPos))) {
+        if (peg$c253.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c253); }
+          if (peg$silentFails === 0) { peg$fail(peg$c254); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -8197,7 +8184,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c254(s1);
+        s2 = peg$c255(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8207,7 +8194,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c255(s1);
+            s1 = peg$c256(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8230,7 +8217,7 @@ module.exports = /*
     function peg$parseCNUM() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 122 + 108,
+      var key    = peg$currPos * 123 + 109,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8243,22 +8230,22 @@ module.exports = /*
       s1 = peg$currPos;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s3 = peg$c250;
+        s3 = peg$c251;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c251); }
+        if (peg$silentFails === 0) { peg$fail(peg$c252); }
       }
       if (s3 === peg$FAILED) {
         s3 = null;
       }
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c256;
+          s4 = peg$c257;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c257); }
+          if (peg$silentFails === 0) { peg$fail(peg$c258); }
         }
         if (s4 !== peg$FAILED) {
           s5 = [];
@@ -8307,7 +8294,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c258(s1);
+          s1 = peg$c259(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8321,20 +8308,20 @@ module.exports = /*
         s0 = peg$currPos;
         s1 = peg$currPos;
         s2 = peg$currPos;
-        if (peg$c259.test(input.charAt(peg$currPos))) {
+        if (peg$c260.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c260); }
+          if (peg$silentFails === 0) { peg$fail(peg$c261); }
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c256;
+            s4 = peg$c257;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c257); }
+            if (peg$silentFails === 0) { peg$fail(peg$c258); }
           }
           if (s4 === peg$FAILED) {
             s4 = null;
@@ -8359,7 +8346,7 @@ module.exports = /*
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c258(s1);
+            s1 = peg$c259(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8379,32 +8366,7 @@ module.exports = /*
     function peg$parseimpossible() {
       var s0;
 
-      var key    = peg$currPos * 122 + 109,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      peg$savedPos = peg$currPos;
-      s0 = peg$c261();
-      if (s0) {
-        s0 = void 0;
-      } else {
-        s0 = peg$FAILED;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseEOF() {
-      var s0;
-
-      var key    = peg$currPos * 122 + 110,
+      var key    = peg$currPos * 123 + 110,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8426,10 +8388,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseCHEM_LETTER() {
+    function peg$parseEOF() {
       var s0;
 
-      var key    = peg$currPos * 122 + 111,
+      var key    = peg$currPos * 123 + 111,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8438,12 +8400,37 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c114.test(input.charAt(peg$currPos))) {
+      peg$savedPos = peg$currPos;
+      s0 = peg$c263();
+      if (s0) {
+        s0 = void 0;
+      } else {
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_LETTER() {
+      var s0;
+
+      var key    = peg$currPos * 123 + 112,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (peg$c113.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c114); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -8454,7 +8441,7 @@ module.exports = /*
     function peg$parseCHEM_SINGLE_MACRO() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 112,
+      var key    = peg$currPos * 123 + 113,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8467,7 +8454,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c263(s1);
+        s2 = peg$c264(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8475,7 +8462,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c174(s1);
+          s1 = peg$c175(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8494,7 +8481,7 @@ module.exports = /*
     function peg$parseCHEM_SCRIPT_FOLLOW() {
       var s0;
 
-      var key    = peg$currPos * 122 + 113,
+      var key    = peg$currPos * 123 + 114,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8507,12 +8494,12 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$parseliteral_id();
         if (s0 === peg$FAILED) {
-          if (peg$c264.test(input.charAt(peg$currPos))) {
+          if (peg$c265.test(input.charAt(peg$currPos))) {
             s0 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c265); }
+            if (peg$silentFails === 0) { peg$fail(peg$c266); }
           }
         }
       }
@@ -8525,7 +8512,7 @@ module.exports = /*
     function peg$parseCHEM_SUPERSUB() {
       var s0;
 
-      var key    = peg$currPos * 122 + 114,
+      var key    = peg$currPos * 123 + 115,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8535,11 +8522,11 @@ module.exports = /*
       }
 
       if (input.charCodeAt(peg$currPos) === 95) {
-        s0 = peg$c106;
+        s0 = peg$c107;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c107); }
+        if (peg$silentFails === 0) { peg$fail(peg$c108); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 94) {
@@ -8559,7 +8546,7 @@ module.exports = /*
     function peg$parseCHEM_BOND_TYPE() {
       var s0;
 
-      var key    = peg$currPos * 122 + 115,
+      var key    = peg$currPos * 123 + 116,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8569,123 +8556,123 @@ module.exports = /*
       }
 
       if (input.charCodeAt(peg$currPos) === 61) {
-        s0 = peg$c266;
+        s0 = peg$c267;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c267); }
+        if (peg$silentFails === 0) { peg$fail(peg$c268); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 35) {
-          s0 = peg$c268;
+          s0 = peg$c269;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c269); }
+          if (peg$silentFails === 0) { peg$fail(peg$c270); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c270) {
-            s0 = peg$c270;
+          if (input.substr(peg$currPos, 3) === peg$c271) {
+            s0 = peg$c271;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c271); }
+            if (peg$silentFails === 0) { peg$fail(peg$c272); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c272) {
-              s0 = peg$c272;
+            if (input.substr(peg$currPos, 2) === peg$c273) {
+              s0 = peg$c273;
               peg$currPos += 2;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c273); }
+              if (peg$silentFails === 0) { peg$fail(peg$c274); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c274) {
-                s0 = peg$c274;
+              if (input.substr(peg$currPos, 2) === peg$c275) {
+                s0 = peg$c275;
                 peg$currPos += 2;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c275); }
+                if (peg$silentFails === 0) { peg$fail(peg$c276); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 126) {
-                  s0 = peg$c276;
+                  s0 = peg$c277;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c277); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c278); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 3) === peg$c278) {
-                    s0 = peg$c278;
+                  if (input.substr(peg$currPos, 3) === peg$c279) {
+                    s0 = peg$c279;
                     peg$currPos += 3;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c279); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c280); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 4) === peg$c280) {
-                      s0 = peg$c280;
+                    if (input.substr(peg$currPos, 4) === peg$c281) {
+                      s0 = peg$c281;
                       peg$currPos += 4;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c281); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c282); }
                     }
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 3) === peg$c282) {
-                        s0 = peg$c282;
+                      if (input.substr(peg$currPos, 3) === peg$c283) {
+                        s0 = peg$c283;
                         peg$currPos += 3;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c283); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c284); }
                       }
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 2) === peg$c284) {
-                          s0 = peg$c284;
+                        if (input.substr(peg$currPos, 2) === peg$c285) {
+                          s0 = peg$c285;
                           peg$currPos += 2;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c285); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c286); }
                         }
                         if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c286) {
-                            s0 = peg$c286;
+                          if (input.substr(peg$currPos, 2) === peg$c287) {
+                            s0 = peg$c287;
                             peg$currPos += 2;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c287); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c288); }
                           }
                           if (s0 === peg$FAILED) {
                             if (input.charCodeAt(peg$currPos) === 45) {
-                              s0 = peg$c135;
+                              s0 = peg$c134;
                               peg$currPos++;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c136); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c135); }
                             }
                             if (s0 === peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 49) {
-                                s0 = peg$c288;
+                                s0 = peg$c289;
                                 peg$currPos++;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c290); }
                               }
                               if (s0 === peg$FAILED) {
                                 if (input.charCodeAt(peg$currPos) === 50) {
-                                  s0 = peg$c290;
+                                  s0 = peg$c291;
                                   peg$currPos++;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c291); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c292); }
                                 }
                                 if (s0 === peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 51) {
-                                    s0 = peg$c292;
+                                    s0 = peg$c293;
                                     peg$currPos++;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c294); }
                                   }
                                 }
                               }
@@ -8710,7 +8697,7 @@ module.exports = /*
     function peg$parseCHEM_DOLLAR() {
       var s0;
 
-      var key    = peg$currPos * 122 + 116,
+      var key    = peg$currPos * 123 + 117,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8719,12 +8706,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (input.charCodeAt(peg$currPos) === 36) {
-        s0 = peg$c294;
+      if (input.charCodeAt(peg$currPos) === 167) {
+        s0 = peg$c295;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c295); }
+        if (peg$silentFails === 0) { peg$fail(peg$c296); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -8735,7 +8722,7 @@ module.exports = /*
     function peg$parseCHEM_BOND() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 117,
+      var key    = peg$currPos * 123 + 118,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8748,7 +8735,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c296(s1);
+        s2 = peg$c297(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8758,7 +8745,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c174(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8781,7 +8768,7 @@ module.exports = /*
     function peg$parseCHEM_NONLETTER() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 122 + 118,
+      var key    = peg$currPos * 123 + 119,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8791,44 +8778,44 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c141) {
-        s1 = peg$c141;
+      if (input.substr(peg$currPos, 2) === peg$c140) {
+        s1 = peg$c140;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c142); }
+        if (peg$silentFails === 0) { peg$fail(peg$c141); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c297(s1);
+        s1 = peg$c298(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c298) {
-          s1 = peg$c298;
+        if (input.substr(peg$currPos, 2) === peg$c299) {
+          s1 = peg$c299;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c299); }
+          if (peg$silentFails === 0) { peg$fail(peg$c300); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c297(s1);
+          s1 = peg$c298(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (peg$c300.test(input.charAt(peg$currPos))) {
+          if (peg$c301.test(input.charAt(peg$currPos))) {
             s1 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c301); }
+            if (peg$silentFails === 0) { peg$fail(peg$c302); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c297(s1);
+            s1 = peg$c298(s1);
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -8836,7 +8823,7 @@ module.exports = /*
             s1 = peg$parseliteral_mn();
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c297(s1);
+              s1 = peg$c298(s1);
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
@@ -8846,7 +8833,7 @@ module.exports = /*
                 s2 = peg$parseCURLY_CLOSE();
                 if (s2 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c302();
+                  s1 = peg$c303();
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8869,53 +8856,7 @@ module.exports = /*
     function peg$parseCHEM_MACRO_1P() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 119,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      s1 = peg$parsegeneric_func();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = peg$currPos;
-        s2 = peg$c303(s1);
-        if (s2) {
-          s2 = void 0;
-        } else {
-          s2 = peg$FAILED;
-        }
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parse_();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c174(s1);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseCHEM_MACRO_2P() {
-      var s0, s1, s2, s3;
-
-      var key    = peg$currPos * 122 + 120,
+      var key    = peg$currPos * 123 + 120,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8938,7 +8879,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c174(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8958,10 +8899,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseCHEM_MACRO_2PU() {
+    function peg$parseCHEM_MACRO_2P() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 122 + 121,
+      var key    = peg$currPos * 123 + 121,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8984,7 +8925,53 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c174(s1);
+            s1 = peg$c175(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_MACRO_2PU() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 123 + 122,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c306(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parse_();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -230,7 +230,12 @@ module.exports = /*
         peg$c82 = "]",
         peg$c83 = peg$literalExpectation("]", false),
         peg$c84 = function(p, s) { return ast.LList(p,s); },
-        peg$c85 = function(m) { return ast.RenderT.TEX_ONLY(m); },
+        peg$c85 = function(m) {
+                var s = "";
+                for (var c in m)
+                    s += m[c];
+                return ast.RenderT.TEX_ONLY(s);
+            },
         peg$c86 = /^[a-zA-Z]/,
         peg$c87 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
         peg$c88 = /^[,:;?!']/,
@@ -3003,7 +3008,7 @@ module.exports = /*
     }
 
     function peg$parsechem_word() {
-      var s0, s1;
+      var s0, s1, s2;
 
       var key    = peg$currPos * 105 + 33,
           cached = peg$resultsCache[key];
@@ -3015,7 +3020,16 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      s1 = peg$parsealpha();
+      s1 = [];
+      s2 = peg$parseboxchars();
+      if (s2 !== peg$FAILED) {
+        while (s2 !== peg$FAILED) {
+          s1.push(s2);
+          s2 = peg$parseboxchars();
+        }
+      } else {
+        s1 = peg$FAILED;
+      }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
         s1 = peg$c85(s1);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -229,277 +229,239 @@ module.exports = /*
         peg$c81 = peg$classExpectation(["t", "c", "b"], false, false),
         peg$c82 = "]",
         peg$c83 = peg$literalExpectation("]", false),
-        peg$c84 = " ",
-        peg$c85 = peg$literalExpectation(" ", false),
-        peg$c86 = function(p, s) { return ast.LList(p,s); },
-        peg$c87 = function(p) { return ast.LList(p,ast.LList.EMPTY); },
-        peg$c88 = function(m) { return ast.Tex.LITERAL(m); },
-        peg$c89 = function(m) { return ast.RenderT.TEX_ONLY(m); },
-        peg$c90 = function(m, n) { return ast.RenderT.TEX_ONLY(m + n); },
-        peg$c91 = "^",
-        peg$c92 = peg$literalExpectation("^", false),
-        peg$c93 = function(m) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); },
-        peg$c94 = "(^)",
-        peg$c95 = peg$literalExpectation("(^)", false),
-        peg$c96 = /^[a-zA-Z]/,
-        peg$c97 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
-        peg$c98 = function(m, n) { return ast.RenderT.TEX_ONLY("baz"); },
-        peg$c99 = function(m, n) { return ast.RenderT.TEX_ONLY("bar"); },
-        peg$c100 = function(m, n, o) { return ast.RenderT.TEX_ONLY("foo"); },
-        peg$c101 = function() { return ast.RenderT.TEX_ONLY(""); },
-        peg$c102 = function(m) { return m;},
-        peg$c103 = function(e) { return ast.RenderT.TEX_ONLY("{some text}"); },
-        peg$c104 = "$",
-        peg$c105 = peg$literalExpectation("$", false),
-        peg$c106 = function(b) { return ast.RenderT.TEX_ONLY("baz"); },
-        peg$c107 = "\\bond",
-        peg$c108 = peg$literalExpectation("\\bond", false),
-        peg$c109 = function() { return ast.RenderT.TEX_ONLY("\bond{some bond}");},
-        peg$c110 = function() { return ast.RenderT.TEX_ONLY("{}"); },
-        peg$c111 = "+",
-        peg$c112 = peg$literalExpectation("+", false),
-        peg$c113 = "-",
-        peg$c114 = peg$literalExpectation("-", false),
-        peg$c115 = "=",
-        peg$c116 = peg$literalExpectation("=", false),
-        peg$c117 = "#",
-        peg$c118 = peg$literalExpectation("#", false),
-        peg$c119 = "(",
-        peg$c120 = peg$literalExpectation("(", false),
-        peg$c121 = ")",
-        peg$c122 = peg$literalExpectation(")", false),
-        peg$c123 = "\\{",
-        peg$c124 = peg$literalExpectation("\\{", false),
-        peg$c125 = "\\}",
-        peg$c126 = peg$literalExpectation("\\}", false),
-        peg$c127 = ".",
-        peg$c128 = peg$literalExpectation(".", false),
-        peg$c129 = ",",
-        peg$c130 = peg$literalExpectation(",", false),
-        peg$c131 = ";",
-        peg$c132 = peg$literalExpectation(";", false),
-        peg$c133 = "/",
-        peg$c134 = peg$literalExpectation("/", false),
-        peg$c135 = "<",
-        peg$c136 = peg$literalExpectation("<", false),
-        peg$c137 = ">",
-        peg$c138 = peg$literalExpectation(">", false),
-        peg$c139 = "&",
-        peg$c140 = peg$literalExpectation("&", false),
-        peg$c141 = "\\",
-        peg$c142 = peg$literalExpectation("\\", false),
-        peg$c143 = function() { return ast.RenderT.TEX_ONLY("some char"); },
-        peg$c144 = function(a, b) { return ast.RenderT.TEX_ONLY("foo"); },
-        peg$c145 = function(a, b) { return ast.RenderT.TEX_ONLY("bar"); },
-        peg$c146 = function(a, b) { return ast.RenderT.TEX_ONLY("baz"); },
-        peg$c147 = "_",
-        peg$c148 = peg$literalExpectation("_", false),
-        peg$c149 = "~--",
-        peg$c150 = peg$literalExpectation("~--", false),
-        peg$c151 = "~-",
-        peg$c152 = peg$literalExpectation("~-", false),
-        peg$c153 = "~=",
-        peg$c154 = peg$literalExpectation("~=", false),
-        peg$c155 = "~",
-        peg$c156 = peg$literalExpectation("~", false),
-        peg$c157 = "-~-",
-        peg$c158 = peg$literalExpectation("-~-", false),
-        peg$c159 = "....",
-        peg$c160 = peg$literalExpectation("....", false),
-        peg$c161 = "...",
-        peg$c162 = peg$literalExpectation("...", false),
-        peg$c163 = "<-",
-        peg$c164 = peg$literalExpectation("<-", false),
-        peg$c165 = "->",
-        peg$c166 = peg$literalExpectation("->", false),
-        peg$c167 = "1",
-        peg$c168 = peg$literalExpectation("1", false),
-        peg$c169 = "2",
-        peg$c170 = peg$literalExpectation("2", false),
-        peg$c171 = "3",
-        peg$c172 = peg$literalExpectation("3", false),
-        peg$c173 = "\\alpha",
-        peg$c174 = peg$literalExpectation("\\alpha", false),
-        peg$c175 = "\\delta",
-        peg$c176 = peg$literalExpectation("\\delta", false),
-        peg$c177 = "\\mu",
-        peg$c178 = peg$literalExpectation("\\mu", false),
-        peg$c179 = "\\eta",
-        peg$c180 = peg$literalExpectation("\\eta", false),
-        peg$c181 = "\\gamma",
-        peg$c182 = peg$literalExpectation("\\gamma", false),
-        peg$c183 = "\\pm",
-        peg$c184 = peg$literalExpectation("\\pm", false),
-        peg$c185 = "\\approx",
-        peg$c186 = peg$literalExpectation("\\approx", false),
-        peg$c187 = "\\ca",
-        peg$c188 = peg$literalExpectation("\\ca", false),
-        peg$c189 = "ce",
-        peg$c190 = peg$literalExpectation("ce", false),
-        peg$c191 = "mathbf",
-        peg$c192 = peg$literalExpectation("mathbf", false),
-        peg$c193 = "\\frac",
-        peg$c194 = peg$literalExpectation("\\frac", false),
-        peg$c195 = function(name, l1, l2) { return ast.Tex.MHCHEM2(name, l1, l2); },
-        peg$c196 = "\\color",
-        peg$c197 = peg$literalExpectation("\\color", false),
-        peg$c198 = "\\overset",
-        peg$c199 = peg$literalExpectation("\\overset", false),
-        peg$c200 = "\\underset",
-        peg$c201 = peg$literalExpectation("\\underset", false),
-        peg$c202 = "\\underbrace",
-        peg$c203 = peg$literalExpectation("\\underbrace", false),
-        peg$c204 = function(name, l1, l2) { return ast.Tex.MHCHEM2ub(name, l1, l2); },
-        peg$c205 = "\\red",
-        peg$c206 = peg$literalExpectation("\\red", false),
-        peg$c207 = "red",
-        peg$c208 = peg$literalExpectation("red", false),
-        peg$c209 = function(m) {
+        peg$c84 = function(p) { return ast.LList(p,ast.LList.EMPTY); },
+        peg$c85 = function(m) { return m; },
+        peg$c86 = function(m, n) { return ast.LList(m, n); },
+        peg$c87 = function(name, l) { return ast.Tex.CHEM_BOND(name, l);},
+        peg$c88 = function(e) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(e))]); },
+        peg$c89 = function(a, b) { return a + b; },
+        peg$c90 = function(a, b) { return a + "$" + b + "$"; },
+        peg$c91 = "\\alpha",
+        peg$c92 = peg$literalExpectation("\\alpha", false),
+        peg$c93 = "\\delta",
+        peg$c94 = peg$literalExpectation("\\delta", false),
+        peg$c95 = "\\mu",
+        peg$c96 = peg$literalExpectation("\\mu", false),
+        peg$c97 = "\\eta",
+        peg$c98 = peg$literalExpectation("\\eta", false),
+        peg$c99 = "\\gamma",
+        peg$c100 = peg$literalExpectation("\\gamma", false),
+        peg$c101 = "\\pm",
+        peg$c102 = peg$literalExpectation("\\pm", false),
+        peg$c103 = "\\approx",
+        peg$c104 = peg$literalExpectation("\\approx", false),
+        peg$c105 = "\\ca",
+        peg$c106 = peg$literalExpectation("\\ca", false),
+        peg$c107 = "_",
+        peg$c108 = peg$literalExpectation("_", false),
+        peg$c109 = "\\red",
+        peg$c110 = peg$literalExpectation("\\red", false),
+        peg$c111 = "red",
+        peg$c112 = peg$literalExpectation("red", false),
+        peg$c113 = function(m) {
                 var s = "";
                 for (var c in m)
                     s += m[c];
-                return ast.RenderT.TEX_ONLY(s);
+                return s;//ast.RenderT.TEX_ONLY(s);
             },
-        peg$c210 = /^[,:;?!']/,
-        peg$c211 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
-        peg$c212 = /^[().]/,
-        peg$c213 = peg$classExpectation(["(", ")", "."], false, false),
-        peg$c214 = /^[\-+*=]/,
-        peg$c215 = peg$classExpectation(["-", "+", "*", "="], false, false),
-        peg$c216 = /^[\/|]/,
-        peg$c217 = peg$classExpectation(["/", "|"], false, false),
-        peg$c218 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
-        peg$c219 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
-        peg$c220 = /^[\uD800-\uDBFF]/,
-        peg$c221 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
-        peg$c222 = /^[\uDC00-\uDFFF]/,
-        peg$c223 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
-        peg$c224 = function(l, h) { return text(); },
-        peg$c225 = function(b) { return tu.box_functions[b]; },
-        peg$c226 = "{",
-        peg$c227 = peg$literalExpectation("{", false),
-        peg$c228 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
-        peg$c229 = function(c) { return ast.RenderT.TEX_ONLY(c); },
-        peg$c230 = function(f) { return tu.latex_function_names[f]; },
-        peg$c231 = function(f) { return " ";},
-        peg$c232 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
-        peg$c233 = function(f) { return tu.mediawiki_function_names[f]; },
-        peg$c234 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
-        peg$c235 = function(f) { return tu.other_literals1[f]; },
-        peg$c236 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
-        peg$c237 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c238 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c239 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
-        peg$c240 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c241 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c242 = function(f) { return tu.other_literals2[f]; },
-        peg$c243 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c244 = function(mbox) { return mbox === "\\mbox"; },
-        peg$c245 = function(mbox, f) { return tu.other_literals2[f]; },
-        peg$c246 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c247 = function(f) { return ast.RenderT.TEX_ONLY(f); },
-        peg$c248 = /^[, ;!_#%$&]/,
-        peg$c249 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
-        peg$c250 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
-        peg$c251 = /^[><~]/,
-        peg$c252 = peg$classExpectation([">", "<", "~"], false, false),
-        peg$c253 = /^[%$]/,
-        peg$c254 = peg$classExpectation(["%", "$"], false, false),
-        peg$c255 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */},
-        peg$c256 = /^[{}|]/,
-        peg$c257 = peg$classExpectation(["{", "}", "|"], false, false),
-        peg$c258 = function(f) { return tu.other_delimiters1[f]; },
-        peg$c259 = function(f) { return tu.other_delimiters2[f]; },
-        peg$c260 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
+        peg$c114 = /^[a-zA-Z]/,
+        peg$c115 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
+        peg$c116 = /^[,:;?!']/,
+        peg$c117 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
+        peg$c118 = /^[().]/,
+        peg$c119 = peg$classExpectation(["(", ")", "."], false, false),
+        peg$c120 = /^[\-+*=]/,
+        peg$c121 = peg$classExpectation(["-", "+", "*", "="], false, false),
+        peg$c122 = /^[\/|]/,
+        peg$c123 = peg$classExpectation(["/", "|"], false, false),
+        peg$c124 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
+        peg$c125 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
+        peg$c126 = /^[\uD800-\uDBFF]/,
+        peg$c127 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
+        peg$c128 = /^[\uDC00-\uDFFF]/,
+        peg$c129 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
+        peg$c130 = function(l, h) { return text(); },
+        peg$c131 = function(b) { return tu.box_functions[b]; },
+        peg$c132 = "{",
+        peg$c133 = peg$literalExpectation("{", false),
+        peg$c134 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
+        peg$c135 = "-",
+        peg$c136 = peg$literalExpectation("-", false),
+        peg$c137 = function(c) { return ast.RenderT.TEX_ONLY(c); },
+        peg$c138 = function(f) { return tu.latex_function_names[f]; },
+        peg$c139 = "(",
+        peg$c140 = peg$literalExpectation("(", false),
+        peg$c141 = "\\{",
+        peg$c142 = peg$literalExpectation("\\{", false),
+        peg$c143 = function(f) { return " ";},
+        peg$c144 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
+        peg$c145 = function(f) { return tu.mediawiki_function_names[f]; },
+        peg$c146 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
+        peg$c147 = function(f) { return tu.other_literals1[f]; },
+        peg$c148 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
+        peg$c149 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c150 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c151 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
+        peg$c152 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c153 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c154 = function(f) { return tu.other_literals2[f]; },
+        peg$c155 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c156 = function(mbox) { return mbox === "\\mbox"; },
+        peg$c157 = function(mbox, f) { return tu.other_literals2[f]; },
+        peg$c158 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c159 = function(f) { return ast.RenderT.TEX_ONLY(f); },
+        peg$c160 = "\\",
+        peg$c161 = peg$literalExpectation("\\", false),
+        peg$c162 = /^[, ;!_#%$&]/,
+        peg$c163 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
+        peg$c164 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
+        peg$c165 = /^[><~]/,
+        peg$c166 = peg$classExpectation([">", "<", "~"], false, false),
+        peg$c167 = /^[%$]/,
+        peg$c168 = peg$classExpectation(["%", "$"], false, false),
+        peg$c169 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */},
+        peg$c170 = /^[{}|]/,
+        peg$c171 = peg$classExpectation(["{", "}", "|"], false, false),
+        peg$c172 = function(f) { return tu.other_delimiters1[f]; },
+        peg$c173 = function(f) { return tu.other_delimiters2[f]; },
+        peg$c174 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
              console.assert(Array.isArray(p) && p.length === 1);
              console.assert(p[0].constructor === ast.Tex.LITERAL);
              console.assert(p[0][0].constructor === ast.RenderT.TEX_ONLY);
              return p[0][0];
            },
-        peg$c261 = function(f) { return tu.fun_ar1nb[f]; },
-        peg$c262 = function(f) { return f; },
-        peg$c263 = function(f) { return tu.fun_ar1opt[f]; },
-        peg$c264 = "\\\\",
-        peg$c265 = peg$literalExpectation("\\\\", false),
-        peg$c266 = "\\begin",
-        peg$c267 = peg$literalExpectation("\\begin", false),
-        peg$c268 = "\\end",
-        peg$c269 = peg$literalExpectation("\\end", false),
-        peg$c270 = "{matrix}",
-        peg$c271 = peg$literalExpectation("{matrix}", false),
-        peg$c272 = "{pmatrix}",
-        peg$c273 = peg$literalExpectation("{pmatrix}", false),
-        peg$c274 = "{bmatrix}",
-        peg$c275 = peg$literalExpectation("{bmatrix}", false),
-        peg$c276 = "{Bmatrix}",
-        peg$c277 = peg$literalExpectation("{Bmatrix}", false),
-        peg$c278 = "{vmatrix}",
-        peg$c279 = peg$literalExpectation("{vmatrix}", false),
-        peg$c280 = "{Vmatrix}",
-        peg$c281 = peg$literalExpectation("{Vmatrix}", false),
-        peg$c282 = "{array}",
-        peg$c283 = peg$literalExpectation("{array}", false),
-        peg$c284 = "{align}",
-        peg$c285 = peg$literalExpectation("{align}", false),
-        peg$c286 = "{aligned}",
-        peg$c287 = peg$literalExpectation("{aligned}", false),
-        peg$c288 = "{alignat}",
-        peg$c289 = peg$literalExpectation("{alignat}", false),
-        peg$c290 = "{alignedat}",
-        peg$c291 = peg$literalExpectation("{alignedat}", false),
-        peg$c292 = "{smallmatrix}",
-        peg$c293 = peg$literalExpectation("{smallmatrix}", false),
-        peg$c294 = "{cases}",
-        peg$c295 = peg$literalExpectation("{cases}", false),
-        peg$c296 = function(f) { return tu.big_literals[f]; },
-        peg$c297 = function(f) { return tu.fun_ar1[f]; },
-        peg$c298 = function(f) { return tu.other_fun_ar1[f]; },
-        peg$c299 = function(f) { return tu.fun_mhchem[f]; },
-        peg$c300 = function(f) { return tu.fun_ar2[f]; },
-        peg$c301 = function(f) { return tu.fun_infix[f]; },
-        peg$c302 = function(f) { return tu.declh_function[f]; },
-        peg$c303 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
-        peg$c304 = function(f) { return tu.fun_ar2nb[f]; },
-        peg$c305 = function(f) { return tu.left_function[f]; },
-        peg$c306 = function(f) { return tu.right_function[f]; },
-        peg$c307 = function(f) { return tu.hline_function[f]; },
-        peg$c308 = function(f) { return tu.color_function[f]; },
-        peg$c309 = function(f, cs) { return f + " " + cs; },
-        peg$c310 = function(f) { return tu.definecolor_function[f]; },
-        peg$c311 = "named",
-        peg$c312 = peg$literalExpectation("named", true),
-        peg$c313 = function(f, name, cs) { return "{named}" + cs; },
-        peg$c314 = "gray",
-        peg$c315 = peg$literalExpectation("gray", true),
-        peg$c316 = function(f, name, cs) { return "{gray}" + cs; },
-        peg$c317 = "rgb",
-        peg$c318 = peg$literalExpectation("rgb", false),
-        peg$c319 = function(f, name, cs) { return "{rgb}" + cs; },
-        peg$c320 = "RGB",
-        peg$c321 = peg$literalExpectation("RGB", false),
-        peg$c322 = "cmyk",
-        peg$c323 = peg$literalExpectation("cmyk", true),
-        peg$c324 = function(f, name, cs) { return "{cmyk}" + cs; },
-        peg$c325 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
-        peg$c326 = function(cs) { return "[named]" + cs; },
-        peg$c327 = function(cs) { return "[gray]" + cs; },
-        peg$c328 = function(cs) { return "[rgb]" + cs; },
-        peg$c329 = function(cs) { return "[cmyk]" + cs; },
-        peg$c330 = function(name) { return "{" + name.join('') + "}"; },
-        peg$c331 = function(k) { return "{"+k+"}"; },
-        peg$c332 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
-        peg$c333 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
-        peg$c334 = "0",
-        peg$c335 = peg$literalExpectation("0", false),
-        peg$c336 = /^[1-9]/,
-        peg$c337 = peg$classExpectation([["1", "9"]], false, false),
-        peg$c338 = function(n) { return parseInt(n, 10) <= 255; },
-        peg$c339 = function(n) { return n / 255; },
-        peg$c340 = function(n) { return n; },
-        peg$c341 = /^[01]/,
-        peg$c342 = peg$classExpectation(["0", "1"], false, false),
-        peg$c343 = function() { return false; },
-        peg$c344 = function() { return peg$currPos === input.length; },
+        peg$c175 = function(f) { return tu.fun_ar1nb[f]; },
+        peg$c176 = function(f) { return f; },
+        peg$c177 = function(f) { return tu.fun_ar1opt[f]; },
+        peg$c178 = "&",
+        peg$c179 = peg$literalExpectation("&", false),
+        peg$c180 = "\\\\",
+        peg$c181 = peg$literalExpectation("\\\\", false),
+        peg$c182 = "\\begin",
+        peg$c183 = peg$literalExpectation("\\begin", false),
+        peg$c184 = "\\end",
+        peg$c185 = peg$literalExpectation("\\end", false),
+        peg$c186 = "{matrix}",
+        peg$c187 = peg$literalExpectation("{matrix}", false),
+        peg$c188 = "{pmatrix}",
+        peg$c189 = peg$literalExpectation("{pmatrix}", false),
+        peg$c190 = "{bmatrix}",
+        peg$c191 = peg$literalExpectation("{bmatrix}", false),
+        peg$c192 = "{Bmatrix}",
+        peg$c193 = peg$literalExpectation("{Bmatrix}", false),
+        peg$c194 = "{vmatrix}",
+        peg$c195 = peg$literalExpectation("{vmatrix}", false),
+        peg$c196 = "{Vmatrix}",
+        peg$c197 = peg$literalExpectation("{Vmatrix}", false),
+        peg$c198 = "{array}",
+        peg$c199 = peg$literalExpectation("{array}", false),
+        peg$c200 = "{align}",
+        peg$c201 = peg$literalExpectation("{align}", false),
+        peg$c202 = "{aligned}",
+        peg$c203 = peg$literalExpectation("{aligned}", false),
+        peg$c204 = "{alignat}",
+        peg$c205 = peg$literalExpectation("{alignat}", false),
+        peg$c206 = "{alignedat}",
+        peg$c207 = peg$literalExpectation("{alignedat}", false),
+        peg$c208 = "{smallmatrix}",
+        peg$c209 = peg$literalExpectation("{smallmatrix}", false),
+        peg$c210 = "{cases}",
+        peg$c211 = peg$literalExpectation("{cases}", false),
+        peg$c212 = "^",
+        peg$c213 = peg$literalExpectation("^", false),
+        peg$c214 = function(f) { return tu.big_literals[f]; },
+        peg$c215 = function(f) { return tu.fun_ar1[f]; },
+        peg$c216 = function(f) { return tu.other_fun_ar1[f]; },
+        peg$c217 = function(f) { return tu.fun_mhchem[f]; },
+        peg$c218 = function(f) { return tu.fun_ar2[f]; },
+        peg$c219 = function(f) { return tu.fun_infix[f]; },
+        peg$c220 = function(f) { return tu.declh_function[f]; },
+        peg$c221 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
+        peg$c222 = function(f) { return tu.fun_ar2nb[f]; },
+        peg$c223 = function(f) { return tu.left_function[f]; },
+        peg$c224 = function(f) { return tu.right_function[f]; },
+        peg$c225 = function(f) { return tu.hline_function[f]; },
+        peg$c226 = function(f) { return tu.color_function[f]; },
+        peg$c227 = function(f, cs) { return f + " " + cs; },
+        peg$c228 = function(f) { return tu.definecolor_function[f]; },
+        peg$c229 = "named",
+        peg$c230 = peg$literalExpectation("named", true),
+        peg$c231 = function(f, name, cs) { return "{named}" + cs; },
+        peg$c232 = "gray",
+        peg$c233 = peg$literalExpectation("gray", true),
+        peg$c234 = function(f, name, cs) { return "{gray}" + cs; },
+        peg$c235 = "rgb",
+        peg$c236 = peg$literalExpectation("rgb", false),
+        peg$c237 = function(f, name, cs) { return "{rgb}" + cs; },
+        peg$c238 = "RGB",
+        peg$c239 = peg$literalExpectation("RGB", false),
+        peg$c240 = "cmyk",
+        peg$c241 = peg$literalExpectation("cmyk", true),
+        peg$c242 = function(f, name, cs) { return "{cmyk}" + cs; },
+        peg$c243 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
+        peg$c244 = function(cs) { return "[named]" + cs; },
+        peg$c245 = function(cs) { return "[gray]" + cs; },
+        peg$c246 = function(cs) { return "[rgb]" + cs; },
+        peg$c247 = function(cs) { return "[cmyk]" + cs; },
+        peg$c248 = function(name) { return "{" + name.join('') + "}"; },
+        peg$c249 = function(k) { return "{"+k+"}"; },
+        peg$c250 = ",",
+        peg$c251 = peg$literalExpectation(",", false),
+        peg$c252 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
+        peg$c253 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
+        peg$c254 = "0",
+        peg$c255 = peg$literalExpectation("0", false),
+        peg$c256 = /^[1-9]/,
+        peg$c257 = peg$classExpectation([["1", "9"]], false, false),
+        peg$c258 = function(n) { return parseInt(n, 10) <= 255; },
+        peg$c259 = function(n) { return n / 255; },
+        peg$c260 = ".",
+        peg$c261 = peg$literalExpectation(".", false),
+        peg$c262 = function(n) { return n; },
+        peg$c263 = /^[01]/,
+        peg$c264 = peg$classExpectation(["0", "1"], false, false),
+        peg$c265 = function() { return false; },
+        peg$c266 = function() { return peg$currPos === input.length; },
+        peg$c267 = /^[+-.*']/,
+        peg$c268 = peg$classExpectation([["+", "."], "*", "'"], false, false),
+        peg$c269 = "=",
+        peg$c270 = peg$literalExpectation("=", false),
+        peg$c271 = "#",
+        peg$c272 = peg$literalExpectation("#", false),
+        peg$c273 = "~--",
+        peg$c274 = peg$literalExpectation("~--", false),
+        peg$c275 = "~-",
+        peg$c276 = peg$literalExpectation("~-", false),
+        peg$c277 = "~=",
+        peg$c278 = peg$literalExpectation("~=", false),
+        peg$c279 = "~",
+        peg$c280 = peg$literalExpectation("~", false),
+        peg$c281 = "-~-",
+        peg$c282 = peg$literalExpectation("-~-", false),
+        peg$c283 = "....",
+        peg$c284 = peg$literalExpectation("....", false),
+        peg$c285 = "...",
+        peg$c286 = peg$literalExpectation("...", false),
+        peg$c287 = "<-",
+        peg$c288 = peg$literalExpectation("<-", false),
+        peg$c289 = "->",
+        peg$c290 = peg$literalExpectation("->", false),
+        peg$c291 = "1",
+        peg$c292 = peg$literalExpectation("1", false),
+        peg$c293 = "2",
+        peg$c294 = peg$literalExpectation("2", false),
+        peg$c295 = "3",
+        peg$c296 = peg$literalExpectation("3", false),
+        peg$c297 = "$",
+        peg$c298 = peg$literalExpectation("$", false),
+        peg$c299 = function(f) { return tu.mhchem_bond[f]; },
+        peg$c300 = "\\}",
+        peg$c301 = peg$literalExpectation("\\}", false),
+        peg$c302 = /^[+-=#().,;\/*<>|@&'\\[\]]/,
+        peg$c303 = peg$classExpectation([["+", "="], "#", "(", ")", ".", ",", ";", "/", "*", "<", ">", "|", "@", "&", "'", "\\", "[", "]"], false, false),
+        peg$c304 = function(f) { return tu.mhchem_macro_1p[f]; },
+        peg$c305 = function(f) { return tu.mhchem_macro_2p[f]; },
+        peg$c306 = function(f) { return tu.mhchem_macro_2pu[f]; },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -642,7 +604,7 @@ module.exports = /*
     function peg$parsestart() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 0,
+      var key    = peg$currPos * 122 + 0,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -676,7 +638,7 @@ module.exports = /*
     function peg$parse_() {
       var s0, s1;
 
-      var key    = peg$currPos * 115 + 1,
+      var key    = peg$currPos * 122 + 1,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -712,7 +674,7 @@ module.exports = /*
     function peg$parsetex_expr() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 115 + 2,
+      var key    = peg$currPos * 122 + 2,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -806,7 +768,7 @@ module.exports = /*
     function peg$parseexpr() {
       var s0, s1;
 
-      var key    = peg$currPos * 115 + 3,
+      var key    = peg$currPos * 122 + 3,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -834,7 +796,7 @@ module.exports = /*
     function peg$parsene_expr() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 4,
+      var key    = peg$currPos * 122 + 4,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -904,7 +866,7 @@ module.exports = /*
     function peg$parselitsq_aq() {
       var s0;
 
-      var key    = peg$currPos * 115 + 5,
+      var key    = peg$currPos * 122 + 5,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -932,7 +894,7 @@ module.exports = /*
     function peg$parselitsq_fq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 6,
+      var key    = peg$currPos * 122 + 6,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -996,7 +958,7 @@ module.exports = /*
     function peg$parselitsq_uq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 7,
+      var key    = peg$currPos * 122 + 7,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1036,7 +998,7 @@ module.exports = /*
     function peg$parselitsq_dq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 8,
+      var key    = peg$currPos * 122 + 8,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1076,7 +1038,7 @@ module.exports = /*
     function peg$parselitsq_zq() {
       var s0, s1;
 
-      var key    = peg$currPos * 115 + 9,
+      var key    = peg$currPos * 122 + 9,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1101,7 +1063,7 @@ module.exports = /*
     function peg$parseexpr_nosqc() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 10,
+      var key    = peg$currPos * 122 + 10,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1144,7 +1106,7 @@ module.exports = /*
     function peg$parselit_aq() {
       var s0;
 
-      var key    = peg$currPos * 115 + 11,
+      var key    = peg$currPos * 122 + 11,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1178,7 +1140,7 @@ module.exports = /*
     function peg$parselit_fq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 12,
+      var key    = peg$currPos * 122 + 12,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1266,7 +1228,7 @@ module.exports = /*
     function peg$parselit_uq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 13,
+      var key    = peg$currPos * 122 + 13,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1306,7 +1268,7 @@ module.exports = /*
     function peg$parselit_dq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 14,
+      var key    = peg$currPos * 122 + 14,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1346,7 +1308,7 @@ module.exports = /*
     function peg$parselit_uqn() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 15,
+      var key    = peg$currPos * 122 + 15,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1380,7 +1342,7 @@ module.exports = /*
     function peg$parselit_dqn() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 16,
+      var key    = peg$currPos * 122 + 16,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1414,7 +1376,7 @@ module.exports = /*
     function peg$parseleft() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 17,
+      var key    = peg$currPos * 122 + 17,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1466,7 +1428,7 @@ module.exports = /*
     function peg$parseright() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 18,
+      var key    = peg$currPos * 122 + 18,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1518,7 +1480,7 @@ module.exports = /*
     function peg$parselit() {
       var s0, s1, s2, s3, s4, s5;
 
-      var key    = peg$currPos * 115 + 19,
+      var key    = peg$currPos * 122 + 19,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2293,7 +2255,7 @@ module.exports = /*
     function peg$parsearray() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 20,
+      var key    = peg$currPos * 122 + 20,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2327,7 +2289,7 @@ module.exports = /*
     function peg$parsealignat() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 21,
+      var key    = peg$currPos * 122 + 21,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2361,7 +2323,7 @@ module.exports = /*
     function peg$parsematrix() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 115 + 22,
+      var key    = peg$currPos * 122 + 22,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2413,7 +2375,7 @@ module.exports = /*
     function peg$parseline_start() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 23,
+      var key    = peg$currPos * 122 + 23,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2450,7 +2412,7 @@ module.exports = /*
     function peg$parseline() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 115 + 24,
+      var key    = peg$currPos * 122 + 24,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2502,7 +2464,7 @@ module.exports = /*
     function peg$parsecolumn_spec() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 115 + 25,
+      var key    = peg$currPos * 122 + 25,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2557,7 +2519,7 @@ module.exports = /*
     function peg$parseone_col() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-      var key    = peg$currPos * 115 + 26,
+      var key    = peg$currPos * 122 + 26,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2836,7 +2798,7 @@ module.exports = /*
     function peg$parsealignat_spec() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 115 + 27,
+      var key    = peg$currPos * 122 + 27,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2909,7 +2871,7 @@ module.exports = /*
     function peg$parseopt_pos() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 115 + 28,
+      var key    = peg$currPos * 122 + 28,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2987,7 +2949,7 @@ module.exports = /*
     function peg$parsechem_lit() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 29,
+      var key    = peg$currPos * 122 + 29,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3027,7 +2989,7 @@ module.exports = /*
     function peg$parsechem_sentence() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 30,
+      var key    = peg$currPos * 122 + 30,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3037,20 +2999,14 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      s1 = peg$parsechem_phrase();
+      s1 = peg$parse_();
       if (s1 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 32) {
-          s2 = peg$c84;
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c85); }
-        }
+        s2 = peg$parsechem_phrase();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parsechem_sentence();
+          s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c86(s1, s3);
+            s1 = peg$c84(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3064,24 +3020,6 @@ module.exports = /*
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parsechem_phrase();
-        if (s1 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c87(s1);
-        }
-        s0 = s1;
-        if (s0 === peg$FAILED) {
-          s0 = peg$currPos;
-          s1 = peg$c6;
-          if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c7();
-          }
-          s0 = s1;
-        }
-      }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
@@ -3089,9 +3027,9 @@ module.exports = /*
     }
 
     function peg$parsechem_phrase() {
-      var s0, s1, s2;
+      var s0, s1;
 
-      var key    = peg$currPos * 115 + 31,
+      var key    = peg$currPos * 122 + 31,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3104,66 +3042,9 @@ module.exports = /*
       s1 = peg$parsechem_word();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c88(s1);
+        s1 = peg$c85(s1);
       }
       s0 = s1;
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parsechem_single_macro();
-        if (s1 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c89(s1);
-        }
-        s0 = s1;
-        if (s0 === peg$FAILED) {
-          s0 = peg$currPos;
-          s1 = peg$parsechem_word();
-          if (s1 !== peg$FAILED) {
-            s2 = peg$parsechem_single_macro();
-            if (s2 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c90(s1, s2);
-              s0 = s1;
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-          if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            if (input.charCodeAt(peg$currPos) === 94) {
-              s1 = peg$c91;
-              peg$currPos++;
-            } else {
-              s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c92); }
-            }
-            if (s1 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c93(s1);
-            }
-            s0 = s1;
-            if (s0 === peg$FAILED) {
-              s0 = peg$currPos;
-              if (input.substr(peg$currPos, 3) === peg$c94) {
-                s1 = peg$c94;
-                peg$currPos += 3;
-              } else {
-                s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c95); }
-              }
-              if (s1 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c89(s1);
-              }
-              s0 = s1;
-            }
-          }
-        }
-      }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
@@ -3171,9 +3052,9 @@ module.exports = /*
     }
 
     function peg$parsechem_word() {
-      var s0, s1, s2, s3;
+      var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 32,
+      var key    = peg$currPos * 122 + 32,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3183,18 +3064,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (peg$c96.test(input.charAt(peg$currPos))) {
-        s1 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c97); }
-      }
+      s1 = peg$parsechem_nonletter();
       if (s1 !== peg$FAILED) {
-        s2 = peg$parsechem_word();
+        s2 = peg$parsechem_word_nt();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c98(s1, s2);
+          s1 = peg$c86(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3204,67 +3079,16 @@ module.exports = /*
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$parsechem_nonletter();
-        if (s1 !== peg$FAILED) {
-          s2 = peg$parsechem_word();
-          if (s2 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c99(s1, s2);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-        if (s0 === peg$FAILED) {
-          s0 = peg$currPos;
-          s1 = peg$parsechem_single_macro();
-          if (s1 !== peg$FAILED) {
-            s2 = peg$parsechem_nonletter();
-            if (s2 !== peg$FAILED) {
-              s3 = peg$parsechem_word();
-              if (s3 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c100(s1, s2, s3);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-          if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            s1 = peg$c6;
-            if (s1 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c101();
-            }
-            s0 = s1;
-          }
-        }
-      }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
       return s0;
     }
 
-    function peg$parsechem_nonletter() {
-      var s0, s1, s2, s3, s4;
+    function peg$parsechem_word_nt() {
+      var s0, s1;
 
-      var key    = peg$currPos * 115 + 33,
+      var key    = peg$currPos * 122 + 33,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3274,27 +3098,83 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      s1 = peg$parsechem_script();
+      s1 = peg$parsechem_word();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102(s1);
+        s1 = peg$c85(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parseCURLY_OPEN();
+        s1 = peg$c6;
         if (s1 !== peg$FAILED) {
-          s2 = peg$parsechem_text();
-          if (s2 !== peg$FAILED) {
-            s3 = peg$parseCURLY_CLOSE();
-            if (s3 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c103(s2);
-              s0 = s1;
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
+          peg$savedPos = s0;
+          s1 = peg$c7();
+        }
+        s0 = s1;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_nonletter() {
+      var s0, s1, s2;
+
+      var key    = peg$currPos * 122 + 34,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parseCHEM_BOND();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsechem_bond();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c87(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_bond() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 122 + 35,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parseCURLY_OPEN();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseCHEM_BOND_TYPE();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseCURLY_CLOSE();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c88(s2);
+            s0 = s1;
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
@@ -3303,324 +3183,9 @@ module.exports = /*
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
-        if (s0 === peg$FAILED) {
-          s0 = peg$currPos;
-          if (input.charCodeAt(peg$currPos) === 36) {
-            s1 = peg$c104;
-            peg$currPos++;
-          } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c105); }
-          }
-          if (s1 !== peg$FAILED) {
-            s2 = peg$parsechem_latex();
-            if (s2 !== peg$FAILED) {
-              if (input.charCodeAt(peg$currPos) === 36) {
-                s3 = peg$c104;
-                peg$currPos++;
-              } else {
-                s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c105); }
-              }
-              if (s3 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c106(s2);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-          if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            if (input.substr(peg$currPos, 5) === peg$c107) {
-              s1 = peg$c107;
-              peg$currPos += 5;
-            } else {
-              s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c108); }
-            }
-            if (s1 !== peg$FAILED) {
-              s2 = peg$parseCURLY_OPEN();
-              if (s2 !== peg$FAILED) {
-                s3 = peg$parsechem_bond_type();
-                if (s3 !== peg$FAILED) {
-                  s4 = peg$parseCURLY_CLOSE();
-                  if (s4 !== peg$FAILED) {
-                    peg$savedPos = s0;
-                    s1 = peg$c109();
-                    s0 = s1;
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-            if (s0 === peg$FAILED) {
-              s0 = peg$currPos;
-              s1 = peg$parsechem_macro_1p();
-              if (s1 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c102(s1);
-              }
-              s0 = s1;
-              if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                s1 = peg$parsechem_macro_2p();
-                if (s1 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c102(s1);
-                }
-                s0 = s1;
-                if (s0 === peg$FAILED) {
-                  s0 = peg$currPos;
-                  s1 = peg$parseCURLY_OPEN();
-                  if (s1 !== peg$FAILED) {
-                    s2 = peg$parseCURLY_CLOSE();
-                    if (s2 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c110();
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                  if (s0 === peg$FAILED) {
-                    s0 = peg$currPos;
-                    if (peg$c69.test(input.charAt(peg$currPos))) {
-                      s1 = input.charAt(peg$currPos);
-                      peg$currPos++;
-                    } else {
-                      s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c70); }
-                    }
-                    if (s1 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c89(s1);
-                    }
-                    s0 = s1;
-                    if (s0 === peg$FAILED) {
-                      if (input.charCodeAt(peg$currPos) === 43) {
-                        s0 = peg$c111;
-                        peg$currPos++;
-                      } else {
-                        s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c112); }
-                      }
-                      if (s0 === peg$FAILED) {
-                        if (input.charCodeAt(peg$currPos) === 45) {
-                          s0 = peg$c113;
-                          peg$currPos++;
-                        } else {
-                          s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c114); }
-                        }
-                        if (s0 === peg$FAILED) {
-                          if (input.charCodeAt(peg$currPos) === 61) {
-                            s0 = peg$c115;
-                            peg$currPos++;
-                          } else {
-                            s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c116); }
-                          }
-                          if (s0 === peg$FAILED) {
-                            if (input.charCodeAt(peg$currPos) === 35) {
-                              s0 = peg$c117;
-                              peg$currPos++;
-                            } else {
-                              s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c118); }
-                            }
-                            if (s0 === peg$FAILED) {
-                              if (input.charCodeAt(peg$currPos) === 40) {
-                                s0 = peg$c119;
-                                peg$currPos++;
-                              } else {
-                                s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c120); }
-                              }
-                              if (s0 === peg$FAILED) {
-                                if (input.charCodeAt(peg$currPos) === 41) {
-                                  s0 = peg$c121;
-                                  peg$currPos++;
-                                } else {
-                                  s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c122); }
-                                }
-                                if (s0 === peg$FAILED) {
-                                  if (input.charCodeAt(peg$currPos) === 91) {
-                                    s0 = peg$c78;
-                                    peg$currPos++;
-                                  } else {
-                                    s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c79); }
-                                  }
-                                  if (s0 === peg$FAILED) {
-                                    if (input.charCodeAt(peg$currPos) === 93) {
-                                      s0 = peg$c82;
-                                      peg$currPos++;
-                                    } else {
-                                      s0 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c83); }
-                                    }
-                                    if (s0 === peg$FAILED) {
-                                      if (input.substr(peg$currPos, 2) === peg$c123) {
-                                        s0 = peg$c123;
-                                        peg$currPos += 2;
-                                      } else {
-                                        s0 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c124); }
-                                      }
-                                      if (s0 === peg$FAILED) {
-                                        if (input.substr(peg$currPos, 2) === peg$c125) {
-                                          s0 = peg$c125;
-                                          peg$currPos += 2;
-                                        } else {
-                                          s0 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c126); }
-                                        }
-                                        if (s0 === peg$FAILED) {
-                                          if (input.charCodeAt(peg$currPos) === 46) {
-                                            s0 = peg$c127;
-                                            peg$currPos++;
-                                          } else {
-                                            s0 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c128); }
-                                          }
-                                          if (s0 === peg$FAILED) {
-                                            if (input.charCodeAt(peg$currPos) === 44) {
-                                              s0 = peg$c129;
-                                              peg$currPos++;
-                                            } else {
-                                              s0 = peg$FAILED;
-                                              if (peg$silentFails === 0) { peg$fail(peg$c130); }
-                                            }
-                                            if (s0 === peg$FAILED) {
-                                              if (input.charCodeAt(peg$currPos) === 59) {
-                                                s0 = peg$c131;
-                                                peg$currPos++;
-                                              } else {
-                                                s0 = peg$FAILED;
-                                                if (peg$silentFails === 0) { peg$fail(peg$c132); }
-                                              }
-                                              if (s0 === peg$FAILED) {
-                                                if (input.charCodeAt(peg$currPos) === 47) {
-                                                  s0 = peg$c133;
-                                                  peg$currPos++;
-                                                } else {
-                                                  s0 = peg$FAILED;
-                                                  if (peg$silentFails === 0) { peg$fail(peg$c134); }
-                                                }
-                                                if (s0 === peg$FAILED) {
-                                                  if (input.charCodeAt(peg$currPos) === 42) {
-                                                    s0 = peg$c67;
-                                                    peg$currPos++;
-                                                  } else {
-                                                    s0 = peg$FAILED;
-                                                    if (peg$silentFails === 0) { peg$fail(peg$c68); }
-                                                  }
-                                                  if (s0 === peg$FAILED) {
-                                                    if (input.charCodeAt(peg$currPos) === 60) {
-                                                      s0 = peg$c135;
-                                                      peg$currPos++;
-                                                    } else {
-                                                      s0 = peg$FAILED;
-                                                      if (peg$silentFails === 0) { peg$fail(peg$c136); }
-                                                    }
-                                                    if (s0 === peg$FAILED) {
-                                                      if (input.charCodeAt(peg$currPos) === 62) {
-                                                        s0 = peg$c137;
-                                                        peg$currPos++;
-                                                      } else {
-                                                        s0 = peg$FAILED;
-                                                        if (peg$silentFails === 0) { peg$fail(peg$c138); }
-                                                      }
-                                                      if (s0 === peg$FAILED) {
-                                                        if (input.charCodeAt(peg$currPos) === 47) {
-                                                          s0 = peg$c133;
-                                                          peg$currPos++;
-                                                        } else {
-                                                          s0 = peg$FAILED;
-                                                          if (peg$silentFails === 0) { peg$fail(peg$c134); }
-                                                        }
-                                                        if (s0 === peg$FAILED) {
-                                                          if (input.charCodeAt(peg$currPos) === 64) {
-                                                            s0 = peg$c75;
-                                                            peg$currPos++;
-                                                          } else {
-                                                            s0 = peg$FAILED;
-                                                            if (peg$silentFails === 0) { peg$fail(peg$c76); }
-                                                          }
-                                                          if (s0 === peg$FAILED) {
-                                                            if (input.charCodeAt(peg$currPos) === 38) {
-                                                              s0 = peg$c139;
-                                                              peg$currPos++;
-                                                            } else {
-                                                              s0 = peg$FAILED;
-                                                              if (peg$silentFails === 0) { peg$fail(peg$c140); }
-                                                            }
-                                                            if (s0 === peg$FAILED) {
-                                                              s0 = peg$currPos;
-                                                              if (input.charCodeAt(peg$currPos) === 92) {
-                                                                s1 = peg$c141;
-                                                                peg$currPos++;
-                                                              } else {
-                                                                s1 = peg$FAILED;
-                                                                if (peg$silentFails === 0) { peg$fail(peg$c142); }
-                                                              }
-                                                              if (s1 !== peg$FAILED) {
-                                                                peg$savedPos = s0;
-                                                                s1 = peg$c143();
-                                                              }
-                                                              s0 = s1;
-                                                            }
-                                                          }
-                                                        }
-                                                      }
-                                                    }
-                                                  }
-                                                }
-                                              }
-                                            }
-                                          }
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3631,7 +3196,7 @@ module.exports = /*
     function peg$parsechem_script() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 115 + 34,
+      var key    = peg$currPos * 122 + 36,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3641,12 +3206,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      s1 = peg$parsechem_supersub();
+      s1 = peg$parseCHEM_SUPERSUB();
       if (s1 !== peg$FAILED) {
-        s2 = peg$parsechem_script_follow();
+        s2 = peg$parseCHEM_SCRIPT_FOLLOW();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c144(s1, s2);
+          s1 = peg$c89(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3658,12 +3223,12 @@ module.exports = /*
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parsechem_supersub();
+        s1 = peg$parseCHEM_SUPERSUB();
         if (s1 !== peg$FAILED) {
           s2 = peg$parsechem_lit();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c145(s1, s2);
+            s1 = peg$c89(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3675,28 +3240,16 @@ module.exports = /*
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$parsechem_supersub();
+          s1 = peg$parseCHEM_SUPERSUB();
           if (s1 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 36) {
-              s2 = peg$c104;
-              peg$currPos++;
-            } else {
-              s2 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c105); }
-            }
+            s2 = peg$parseCHEM_DOLLAR();
             if (s2 !== peg$FAILED) {
               s3 = peg$parsechem_latex();
               if (s3 !== peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 36) {
-                  s4 = peg$c104;
-                  peg$currPos++;
-                } else {
-                  s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c105); }
-                }
+                s4 = peg$parseCHEM_DOLLAR();
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c146(s1, s3);
+                  s1 = peg$c90(s1, s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3713,279 +3266,6 @@ module.exports = /*
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
-          }
-        }
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parsechem_supersub() {
-      var s0, s1;
-
-      var key    = peg$currPos * 115 + 35,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      if (input.charCodeAt(peg$currPos) === 95) {
-        s0 = peg$c147;
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c148); }
-      }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        if (input.charCodeAt(peg$currPos) === 94) {
-          s1 = peg$c91;
-          peg$currPos++;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c92); }
-        }
-        if (s1 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c89(s1);
-        }
-        s0 = s1;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parsechem_script_follow() {
-      var s0, s1;
-
-      var key    = peg$currPos * 115 + 36,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      if (peg$c69.test(input.charAt(peg$currPos))) {
-        s0 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c70); }
-      }
-      if (s0 === peg$FAILED) {
-        if (peg$c96.test(input.charAt(peg$currPos))) {
-          s0 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c97); }
-        }
-        if (s0 === peg$FAILED) {
-          if (input.charCodeAt(peg$currPos) === 43) {
-            s0 = peg$c111;
-            peg$currPos++;
-          } else {
-            s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c112); }
-          }
-          if (s0 === peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 45) {
-              s0 = peg$c113;
-              peg$currPos++;
-            } else {
-              s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c114); }
-            }
-            if (s0 === peg$FAILED) {
-              if (input.charCodeAt(peg$currPos) === 46) {
-                s0 = peg$c127;
-                peg$currPos++;
-              } else {
-                s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c128); }
-              }
-              if (s0 === peg$FAILED) {
-                s0 = peg$currPos;
-                if (input.charCodeAt(peg$currPos) === 42) {
-                  s1 = peg$c67;
-                  peg$currPos++;
-                } else {
-                  s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c68); }
-                }
-                if (s1 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c89(s1);
-                }
-                s0 = s1;
-              }
-            }
-          }
-        }
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parsechem_bond_type() {
-      var s0, s1;
-
-      var key    = peg$currPos * 115 + 37,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      if (input.charCodeAt(peg$currPos) === 61) {
-        s0 = peg$c115;
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c116); }
-      }
-      if (s0 === peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 35) {
-          s0 = peg$c117;
-          peg$currPos++;
-        } else {
-          s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c118); }
-        }
-        if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c149) {
-            s0 = peg$c149;
-            peg$currPos += 3;
-          } else {
-            s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c150); }
-          }
-          if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c151) {
-              s0 = peg$c151;
-              peg$currPos += 2;
-            } else {
-              s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c152); }
-            }
-            if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c153) {
-                s0 = peg$c153;
-                peg$currPos += 2;
-              } else {
-                s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c154); }
-              }
-              if (s0 === peg$FAILED) {
-                if (input.charCodeAt(peg$currPos) === 126) {
-                  s0 = peg$c155;
-                  peg$currPos++;
-                } else {
-                  s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c156); }
-                }
-                if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 3) === peg$c157) {
-                    s0 = peg$c157;
-                    peg$currPos += 3;
-                  } else {
-                    s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c158); }
-                  }
-                  if (s0 === peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 45) {
-                      s0 = peg$c113;
-                      peg$currPos++;
-                    } else {
-                      s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c114); }
-                    }
-                    if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 4) === peg$c159) {
-                        s0 = peg$c159;
-                        peg$currPos += 4;
-                      } else {
-                        s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c160); }
-                      }
-                      if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 3) === peg$c161) {
-                          s0 = peg$c161;
-                          peg$currPos += 3;
-                        } else {
-                          s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c162); }
-                        }
-                        if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c163) {
-                            s0 = peg$c163;
-                            peg$currPos += 2;
-                          } else {
-                            s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c164); }
-                          }
-                          if (s0 === peg$FAILED) {
-                            if (input.substr(peg$currPos, 2) === peg$c165) {
-                              s0 = peg$c165;
-                              peg$currPos += 2;
-                            } else {
-                              s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c166); }
-                            }
-                            if (s0 === peg$FAILED) {
-                              if (input.charCodeAt(peg$currPos) === 49) {
-                                s0 = peg$c167;
-                                peg$currPos++;
-                              } else {
-                                s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c168); }
-                              }
-                              if (s0 === peg$FAILED) {
-                                if (input.charCodeAt(peg$currPos) === 50) {
-                                  s0 = peg$c169;
-                                  peg$currPos++;
-                                } else {
-                                  s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c170); }
-                                }
-                                if (s0 === peg$FAILED) {
-                                  s0 = peg$currPos;
-                                  if (input.charCodeAt(peg$currPos) === 51) {
-                                    s1 = peg$c171;
-                                    peg$currPos++;
-                                  } else {
-                                    s1 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c172); }
-                                  }
-                                  if (s1 !== peg$FAILED) {
-                                    peg$savedPos = s0;
-                                    s1 = peg$c89(s1);
-                                  }
-                                  s0 = s1;
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
           }
         }
       }
@@ -3998,7 +3278,7 @@ module.exports = /*
     function peg$parsechem_single_macro() {
       var s0, s1;
 
-      var key    = peg$currPos * 115 + 38,
+      var key    = peg$currPos * 122 + 37,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4007,73 +3287,73 @@ module.exports = /*
         return cached.result;
       }
 
-      if (input.substr(peg$currPos, 6) === peg$c173) {
-        s0 = peg$c173;
+      if (input.substr(peg$currPos, 6) === peg$c91) {
+        s0 = peg$c91;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c174); }
+        if (peg$silentFails === 0) { peg$fail(peg$c92); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c175) {
-          s0 = peg$c175;
+        if (input.substr(peg$currPos, 6) === peg$c93) {
+          s0 = peg$c93;
           peg$currPos += 6;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c176); }
+          if (peg$silentFails === 0) { peg$fail(peg$c94); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c177) {
-            s0 = peg$c177;
+          if (input.substr(peg$currPos, 3) === peg$c95) {
+            s0 = peg$c95;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c178); }
+            if (peg$silentFails === 0) { peg$fail(peg$c96); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 4) === peg$c179) {
-              s0 = peg$c179;
+            if (input.substr(peg$currPos, 4) === peg$c97) {
+              s0 = peg$c97;
               peg$currPos += 4;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c180); }
+              if (peg$silentFails === 0) { peg$fail(peg$c98); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 6) === peg$c181) {
-                s0 = peg$c181;
+              if (input.substr(peg$currPos, 6) === peg$c99) {
+                s0 = peg$c99;
                 peg$currPos += 6;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c182); }
+                if (peg$silentFails === 0) { peg$fail(peg$c100); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 3) === peg$c183) {
-                  s0 = peg$c183;
+                if (input.substr(peg$currPos, 3) === peg$c101) {
+                  s0 = peg$c101;
                   peg$currPos += 3;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c184); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c102); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 7) === peg$c185) {
-                    s0 = peg$c185;
+                  if (input.substr(peg$currPos, 7) === peg$c103) {
+                    s0 = peg$c103;
                     peg$currPos += 7;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c186); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c104); }
                   }
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
-                    if (input.substr(peg$currPos, 3) === peg$c187) {
-                      s1 = peg$c187;
+                    if (input.substr(peg$currPos, 3) === peg$c105) {
+                      s1 = peg$c105;
                       peg$currPos += 3;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c188); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c106); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c89(s1);
+                      s1 = peg$c85(s1);
                     }
                     s0 = s1;
                   }
@@ -4089,10 +3369,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parsechem_macro_1p() {
-      var s0, s1, s2;
+    function peg$parsechem_macro() {
+      var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 115 + 39,
+      var key    = peg$currPos * 122 + 38,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4102,19 +3382,30 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c189) {
-        s1 = peg$c189;
-        peg$currPos += 2;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c190); }
-      }
+      s1 = peg$parseCHEM_MACRO_2PU();
       if (s1 !== peg$FAILED) {
         s2 = peg$parsechem_lit();
         if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c30(s1, s2);
-          s0 = s1;
+          if (input.charCodeAt(peg$currPos) === 95) {
+            s3 = peg$c107;
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c108); }
+          }
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parsechem_lit();
+            if (s4 !== peg$FAILED) {
+              s1 = [s1, s2, s3, s4];
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -4125,90 +3416,13 @@ module.exports = /*
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 6) === peg$c191) {
-          s1 = peg$c191;
-          peg$currPos += 6;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c192); }
-        }
+        s1 = peg$parseCHEM_MACRO_2P();
         if (s1 !== peg$FAILED) {
           s2 = peg$parsechem_lit();
           if (s2 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c30(s1, s2);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parsechem_macro_2p() {
-      var s0, s1, s2, s3, s4;
-
-      var key    = peg$currPos * 115 + 40,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c193) {
-        s1 = peg$c193;
-        peg$currPos += 5;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c194); }
-      }
-      if (s1 !== peg$FAILED) {
-        s2 = peg$parsechem_lit();
-        if (s2 !== peg$FAILED) {
-          s3 = peg$parsechem_lit();
-          if (s3 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c195(s1, s2, s3);
-            s0 = s1;
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s0;
-          s0 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        if (input.substr(peg$currPos, 6) === peg$c196) {
-          s1 = peg$c196;
-          peg$currPos += 6;
-        } else {
-          s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c197); }
-        }
-        if (s1 !== peg$FAILED) {
-          s2 = peg$parsechem_color();
-          if (s2 !== peg$FAILED) {
             s3 = peg$parsechem_lit();
             if (s3 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c195(s1, s2, s3);
+              s1 = [s1, s2, s3];
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4224,25 +3438,12 @@ module.exports = /*
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 8) === peg$c198) {
-            s1 = peg$c198;
-            peg$currPos += 8;
-          } else {
-            s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c199); }
-          }
+          s1 = peg$parseCHEM_MACRO_1P();
           if (s1 !== peg$FAILED) {
             s2 = peg$parsechem_lit();
             if (s2 !== peg$FAILED) {
-              s3 = peg$parsechem_lit();
-              if (s3 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c195(s1, s2, s3);
-                s0 = s1;
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
+              s1 = [s1, s2];
+              s0 = s1;
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -4250,78 +3451,6 @@ module.exports = /*
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
-          }
-          if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            if (input.substr(peg$currPos, 9) === peg$c200) {
-              s1 = peg$c200;
-              peg$currPos += 9;
-            } else {
-              s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c201); }
-            }
-            if (s1 !== peg$FAILED) {
-              s2 = peg$parsechem_lit();
-              if (s2 !== peg$FAILED) {
-                s3 = peg$parsechem_lit();
-                if (s3 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c195(s1, s2, s3);
-                  s0 = s1;
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
-            }
-            if (s0 === peg$FAILED) {
-              s0 = peg$currPos;
-              if (input.substr(peg$currPos, 11) === peg$c202) {
-                s1 = peg$c202;
-                peg$currPos += 11;
-              } else {
-                s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c203); }
-              }
-              if (s1 !== peg$FAILED) {
-                s2 = peg$parsechem_lit();
-                if (s2 !== peg$FAILED) {
-                  if (input.charCodeAt(peg$currPos) === 95) {
-                    s3 = peg$c147;
-                    peg$currPos++;
-                  } else {
-                    s3 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c148); }
-                  }
-                  if (s3 !== peg$FAILED) {
-                    s4 = peg$parsechem_lit();
-                    if (s4 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c204(s1, s2, s4);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
-            }
           }
         }
       }
@@ -4334,7 +3463,7 @@ module.exports = /*
     function peg$parsechem_color() {
       var s0, s1;
 
-      var key    = peg$currPos * 115 + 41,
+      var key    = peg$currPos * 122 + 39,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4343,25 +3472,25 @@ module.exports = /*
         return cached.result;
       }
 
-      if (input.substr(peg$currPos, 4) === peg$c205) {
-        s0 = peg$c205;
+      if (input.substr(peg$currPos, 4) === peg$c109) {
+        s0 = peg$c109;
         peg$currPos += 4;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c206); }
+        if (peg$silentFails === 0) { peg$fail(peg$c110); }
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 3) === peg$c207) {
-          s1 = peg$c207;
+        if (input.substr(peg$currPos, 3) === peg$c111) {
+          s1 = peg$c111;
           peg$currPos += 3;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c208); }
+          if (peg$silentFails === 0) { peg$fail(peg$c112); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c89(s1);
+          s1 = peg$c85(s1);
         }
         s0 = s1;
       }
@@ -4374,7 +3503,7 @@ module.exports = /*
     function peg$parsechem_latex() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 42,
+      var key    = peg$currPos * 122 + 40,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4396,7 +3525,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c209(s1);
+        s1 = peg$c113(s1);
       }
       s0 = s1;
 
@@ -4408,7 +3537,7 @@ module.exports = /*
     function peg$parsechem_text() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 43,
+      var key    = peg$currPos * 122 + 41,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4430,7 +3559,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c209(s1);
+        s1 = peg$c113(s1);
       }
       s0 = s1;
 
@@ -4442,7 +3571,7 @@ module.exports = /*
     function peg$parsealpha() {
       var s0;
 
-      var key    = peg$currPos * 115 + 44,
+      var key    = peg$currPos * 122 + 42,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4451,12 +3580,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c96.test(input.charAt(peg$currPos))) {
+      if (peg$c114.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c97); }
+        if (peg$silentFails === 0) { peg$fail(peg$c115); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -4467,7 +3596,7 @@ module.exports = /*
     function peg$parseliteral_id() {
       var s0;
 
-      var key    = peg$currPos * 115 + 45,
+      var key    = peg$currPos * 122 + 43,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4476,12 +3605,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c96.test(input.charAt(peg$currPos))) {
+      if (peg$c114.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c97); }
+        if (peg$silentFails === 0) { peg$fail(peg$c115); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -4492,7 +3621,7 @@ module.exports = /*
     function peg$parseliteral_mn() {
       var s0;
 
-      var key    = peg$currPos * 115 + 46,
+      var key    = peg$currPos * 122 + 44,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4517,7 +3646,7 @@ module.exports = /*
     function peg$parseliteral_uf_lt() {
       var s0;
 
-      var key    = peg$currPos * 115 + 47,
+      var key    = peg$currPos * 122 + 45,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4526,12 +3655,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c210.test(input.charAt(peg$currPos))) {
+      if (peg$c116.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c211); }
+        if (peg$silentFails === 0) { peg$fail(peg$c117); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -4542,7 +3671,7 @@ module.exports = /*
     function peg$parsedelimiter_uf_lt() {
       var s0;
 
-      var key    = peg$currPos * 115 + 48,
+      var key    = peg$currPos * 122 + 46,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4551,12 +3680,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c212.test(input.charAt(peg$currPos))) {
+      if (peg$c118.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c213); }
+        if (peg$silentFails === 0) { peg$fail(peg$c119); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -4567,7 +3696,7 @@ module.exports = /*
     function peg$parseliteral_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 115 + 49,
+      var key    = peg$currPos * 122 + 47,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4576,12 +3705,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c214.test(input.charAt(peg$currPos))) {
+      if (peg$c120.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c215); }
+        if (peg$silentFails === 0) { peg$fail(peg$c121); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -4592,7 +3721,7 @@ module.exports = /*
     function peg$parsedelimiter_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 115 + 50,
+      var key    = peg$currPos * 122 + 48,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4601,12 +3730,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c216.test(input.charAt(peg$currPos))) {
+      if (peg$c122.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c217); }
+        if (peg$silentFails === 0) { peg$fail(peg$c123); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -4617,7 +3746,7 @@ module.exports = /*
     function peg$parseboxchars() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 51,
+      var key    = peg$currPos * 122 + 49,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4626,33 +3755,33 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c218.test(input.charAt(peg$currPos))) {
+      if (peg$c124.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c219); }
+        if (peg$silentFails === 0) { peg$fail(peg$c125); }
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (peg$c220.test(input.charAt(peg$currPos))) {
+        if (peg$c126.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c221); }
+          if (peg$silentFails === 0) { peg$fail(peg$c127); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c222.test(input.charAt(peg$currPos))) {
+          if (peg$c128.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c223); }
+            if (peg$silentFails === 0) { peg$fail(peg$c129); }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c224(s1, s2);
+            s1 = peg$c130(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4672,7 +3801,7 @@ module.exports = /*
     function peg$parseBOX() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
-      var key    = peg$currPos * 115 + 52,
+      var key    = peg$currPos * 122 + 50,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4685,7 +3814,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c225(s1);
+        s2 = peg$c131(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -4695,11 +3824,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c226;
+              s4 = peg$c132;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c227); }
+              if (peg$silentFails === 0) { peg$fail(peg$c133); }
             }
             if (s4 !== peg$FAILED) {
               s5 = [];
@@ -4724,7 +3853,7 @@ module.exports = /*
                   s7 = peg$parse_();
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c228(s1, s5);
+                    s1 = peg$c134(s1, s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4763,7 +3892,7 @@ module.exports = /*
     function peg$parseLITERAL() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-      var key    = peg$currPos * 115 + 53,
+      var key    = peg$currPos * 122 + 51,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4780,11 +3909,11 @@ module.exports = /*
           s1 = peg$parseliteral_uf_lt();
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 45) {
-              s1 = peg$c113;
+              s1 = peg$c135;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c114); }
+              if (peg$silentFails === 0) { peg$fail(peg$c136); }
             }
             if (s1 === peg$FAILED) {
               s1 = peg$parseliteral_uf_op();
@@ -4796,7 +3925,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c229(s1);
+          s1 = peg$c137(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4811,7 +3940,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c230(s1);
+          s2 = peg$c138(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -4821,11 +3950,11 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s4 = peg$c119;
+                s4 = peg$c139;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                if (peg$silentFails === 0) { peg$fail(peg$c140); }
               }
               if (s4 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 91) {
@@ -4836,19 +3965,19 @@ module.exports = /*
                   if (peg$silentFails === 0) { peg$fail(peg$c79); }
                 }
                 if (s4 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c123) {
-                    s4 = peg$c123;
+                  if (input.substr(peg$currPos, 2) === peg$c141) {
+                    s4 = peg$c141;
                     peg$currPos += 2;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c124); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c142); }
                   }
                   if (s4 === peg$FAILED) {
                     s4 = peg$currPos;
                     s5 = peg$c6;
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s4;
-                      s5 = peg$c231(s1);
+                      s5 = peg$c143(s1);
                     }
                     s4 = s5;
                   }
@@ -4858,7 +3987,7 @@ module.exports = /*
                 s5 = peg$parse_();
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c232(s1, s4);
+                  s1 = peg$c144(s1, s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4885,7 +4014,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c233(s1);
+            s2 = peg$c145(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -4895,11 +4024,11 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s4 = peg$c119;
+                  s4 = peg$c139;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c140); }
                 }
                 if (s4 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 91) {
@@ -4910,19 +4039,19 @@ module.exports = /*
                     if (peg$silentFails === 0) { peg$fail(peg$c79); }
                   }
                   if (s4 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 2) === peg$c123) {
-                      s4 = peg$c123;
+                    if (input.substr(peg$currPos, 2) === peg$c141) {
+                      s4 = peg$c141;
                       peg$currPos += 2;
                     } else {
                       s4 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c124); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c142); }
                     }
                     if (s4 === peg$FAILED) {
                       s4 = peg$currPos;
                       s5 = peg$c6;
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s4;
-                        s5 = peg$c231(s1);
+                        s5 = peg$c143(s1);
                       }
                       s4 = s5;
                     }
@@ -4932,7 +4061,7 @@ module.exports = /*
                   s5 = peg$parse_();
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c234(s1, s4);
+                    s1 = peg$c146(s1, s4);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4959,7 +4088,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c235(s1);
+              s2 = peg$c147(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -4969,7 +4098,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c236(s1);
+                  s1 = peg$c148(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4988,7 +4117,7 @@ module.exports = /*
               s1 = peg$parsegeneric_func();
               if (s1 !== peg$FAILED) {
                 peg$savedPos = peg$currPos;
-                s2 = peg$c237(s1);
+                s2 = peg$c149(s1);
                 if (s2) {
                   s2 = void 0;
                 } else {
@@ -4998,7 +4127,7 @@ module.exports = /*
                   s3 = peg$parse_();
                   if (s3 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c238(s1);
+                    s1 = peg$c150(s1);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5017,7 +4146,7 @@ module.exports = /*
                 s1 = peg$parsegeneric_func();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = peg$currPos;
-                  s2 = peg$c239(s1);
+                  s2 = peg$c151(s1);
                   if (s2) {
                     s2 = void 0;
                   } else {
@@ -5027,17 +4156,17 @@ module.exports = /*
                     s3 = peg$parse_();
                     if (s3 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 123) {
-                        s4 = peg$c226;
+                        s4 = peg$c132;
                         peg$currPos++;
                       } else {
                         s4 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c227); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c133); }
                       }
                       if (s4 !== peg$FAILED) {
                         s5 = peg$parsegeneric_func();
                         if (s5 !== peg$FAILED) {
                           peg$savedPos = peg$currPos;
-                          s6 = peg$c240(s1, s5);
+                          s6 = peg$c152(s1, s5);
                           if (s6) {
                             s6 = void 0;
                           } else {
@@ -5057,7 +4186,7 @@ module.exports = /*
                                 s9 = peg$parse_();
                                 if (s9 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c241(s1, s5);
+                                  s1 = peg$c153(s1, s5);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -5100,7 +4229,7 @@ module.exports = /*
                   s1 = peg$parsegeneric_func();
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = peg$currPos;
-                    s2 = peg$c242(s1);
+                    s2 = peg$c154(s1);
                     if (s2) {
                       s2 = void 0;
                     } else {
@@ -5110,7 +4239,7 @@ module.exports = /*
                       s3 = peg$parse_();
                       if (s3 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c243(s1);
+                        s1 = peg$c155(s1);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -5129,7 +4258,7 @@ module.exports = /*
                     s1 = peg$parsegeneric_func();
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = peg$currPos;
-                      s2 = peg$c244(s1);
+                      s2 = peg$c156(s1);
                       if (s2) {
                         s2 = void 0;
                       } else {
@@ -5139,17 +4268,17 @@ module.exports = /*
                         s3 = peg$parse_();
                         if (s3 !== peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 123) {
-                            s4 = peg$c226;
+                            s4 = peg$c132;
                             peg$currPos++;
                           } else {
                             s4 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c227); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c133); }
                           }
                           if (s4 !== peg$FAILED) {
                             s5 = peg$parsegeneric_func();
                             if (s5 !== peg$FAILED) {
                               peg$savedPos = peg$currPos;
-                              s6 = peg$c245(s1, s5);
+                              s6 = peg$c157(s1, s5);
                               if (s6) {
                                 s6 = void 0;
                               } else {
@@ -5169,7 +4298,7 @@ module.exports = /*
                                     s9 = peg$parse_();
                                     if (s9 !== peg$FAILED) {
                                       peg$savedPos = s0;
-                                      s1 = peg$c246(s1, s5);
+                                      s1 = peg$c158(s1, s5);
                                       s0 = s1;
                                     } else {
                                       peg$currPos = s0;
@@ -5215,31 +4344,31 @@ module.exports = /*
                       }
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c247(s1);
+                        s1 = peg$c159(s1);
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
                         if (input.charCodeAt(peg$currPos) === 92) {
-                          s1 = peg$c141;
+                          s1 = peg$c160;
                           peg$currPos++;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c142); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c161); }
                         }
                         if (s1 !== peg$FAILED) {
-                          if (peg$c248.test(input.charAt(peg$currPos))) {
+                          if (peg$c162.test(input.charAt(peg$currPos))) {
                             s2 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s2 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c249); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c163); }
                           }
                           if (s2 !== peg$FAILED) {
                             s3 = peg$parse_();
                             if (s3 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c250(s2);
+                              s1 = peg$c164(s2);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -5255,18 +4384,18 @@ module.exports = /*
                         }
                         if (s0 === peg$FAILED) {
                           s0 = peg$currPos;
-                          if (peg$c251.test(input.charAt(peg$currPos))) {
+                          if (peg$c165.test(input.charAt(peg$currPos))) {
                             s1 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c252); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c166); }
                           }
                           if (s1 !== peg$FAILED) {
                             s2 = peg$parse_();
                             if (s2 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c229(s1);
+                              s1 = peg$c137(s1);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -5278,18 +4407,18 @@ module.exports = /*
                           }
                           if (s0 === peg$FAILED) {
                             s0 = peg$currPos;
-                            if (peg$c253.test(input.charAt(peg$currPos))) {
+                            if (peg$c167.test(input.charAt(peg$currPos))) {
                               s1 = input.charAt(peg$currPos);
                               peg$currPos++;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c254); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c168); }
                             }
                             if (s1 !== peg$FAILED) {
                               s2 = peg$parse_();
                               if (s2 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c255(s1);
+                                s1 = peg$c169(s1);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -5319,7 +4448,7 @@ module.exports = /*
     function peg$parseDELIMITER() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 54,
+      var key    = peg$currPos * 122 + 52,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5346,7 +4475,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c229(s1);
+          s1 = peg$c137(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5359,25 +4488,25 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c141;
+          s1 = peg$c160;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c142); }
+          if (peg$silentFails === 0) { peg$fail(peg$c161); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c256.test(input.charAt(peg$currPos))) {
+          if (peg$c170.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c257); }
+            if (peg$silentFails === 0) { peg$fail(peg$c171); }
           }
           if (s2 !== peg$FAILED) {
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c250(s2);
+              s1 = peg$c164(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5396,7 +4525,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c258(s1);
+            s2 = peg$c172(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -5406,7 +4535,7 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c236(s1);
+                s1 = peg$c148(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -5425,7 +4554,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c259(s1);
+              s2 = peg$c173(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -5435,7 +4564,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c260(s1);
+                  s1 = peg$c174(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -5461,7 +4590,7 @@ module.exports = /*
     function peg$parseFUN_AR1nb() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 55,
+      var key    = peg$currPos * 122 + 53,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5474,7 +4603,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c261(s1);
+        s2 = peg$c175(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -5484,7 +4613,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c262(s1);
+            s1 = peg$c176(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5507,7 +4636,7 @@ module.exports = /*
     function peg$parseFUN_AR1opt() {
       var s0, s1, s2, s3, s4, s5;
 
-      var key    = peg$currPos * 115 + 56,
+      var key    = peg$currPos * 122 + 54,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5520,7 +4649,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c263(s1);
+        s2 = peg$c177(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -5540,7 +4669,7 @@ module.exports = /*
               s5 = peg$parse_();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c262(s1);
+                s1 = peg$c176(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -5571,7 +4700,7 @@ module.exports = /*
     function peg$parseNEXT_CELL() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 57,
+      var key    = peg$currPos * 122 + 55,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5582,11 +4711,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 38) {
-        s1 = peg$c139;
+        s1 = peg$c178;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c140); }
+        if (peg$silentFails === 0) { peg$fail(peg$c179); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -5610,7 +4739,7 @@ module.exports = /*
     function peg$parseNEXT_ROW() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 58,
+      var key    = peg$currPos * 122 + 56,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5620,12 +4749,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c264) {
-        s1 = peg$c264;
+      if (input.substr(peg$currPos, 2) === peg$c180) {
+        s1 = peg$c180;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c265); }
+        if (peg$silentFails === 0) { peg$fail(peg$c181); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -5649,7 +4778,7 @@ module.exports = /*
     function peg$parseBEGIN() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 59,
+      var key    = peg$currPos * 122 + 57,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5659,12 +4788,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c266) {
-        s1 = peg$c266;
+      if (input.substr(peg$currPos, 6) === peg$c182) {
+        s1 = peg$c182;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c267); }
+        if (peg$silentFails === 0) { peg$fail(peg$c183); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -5688,7 +4817,7 @@ module.exports = /*
     function peg$parseEND() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 60,
+      var key    = peg$currPos * 122 + 58,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5698,12 +4827,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c268) {
-        s1 = peg$c268;
+      if (input.substr(peg$currPos, 4) === peg$c184) {
+        s1 = peg$c184;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c269); }
+        if (peg$silentFails === 0) { peg$fail(peg$c185); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -5727,7 +4856,7 @@ module.exports = /*
     function peg$parseBEGIN_MATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 61,
+      var key    = peg$currPos * 122 + 59,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5739,12 +4868,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c270) {
-          s2 = peg$c270;
+        if (input.substr(peg$currPos, 8) === peg$c186) {
+          s2 = peg$c186;
           peg$currPos += 8;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c271); }
+          if (peg$silentFails === 0) { peg$fail(peg$c187); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5772,7 +4901,7 @@ module.exports = /*
     function peg$parseEND_MATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 62,
+      var key    = peg$currPos * 122 + 60,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5784,12 +4913,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c270) {
-          s2 = peg$c270;
+        if (input.substr(peg$currPos, 8) === peg$c186) {
+          s2 = peg$c186;
           peg$currPos += 8;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c271); }
+          if (peg$silentFails === 0) { peg$fail(peg$c187); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5817,7 +4946,7 @@ module.exports = /*
     function peg$parseBEGIN_PMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 63,
+      var key    = peg$currPos * 122 + 61,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5829,12 +4958,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c272) {
-          s2 = peg$c272;
+        if (input.substr(peg$currPos, 9) === peg$c188) {
+          s2 = peg$c188;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c273); }
+          if (peg$silentFails === 0) { peg$fail(peg$c189); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5862,7 +4991,7 @@ module.exports = /*
     function peg$parseEND_PMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 64,
+      var key    = peg$currPos * 122 + 62,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5874,12 +5003,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c272) {
-          s2 = peg$c272;
+        if (input.substr(peg$currPos, 9) === peg$c188) {
+          s2 = peg$c188;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c273); }
+          if (peg$silentFails === 0) { peg$fail(peg$c189); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5907,7 +5036,7 @@ module.exports = /*
     function peg$parseBEGIN_BMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 65,
+      var key    = peg$currPos * 122 + 63,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5919,12 +5048,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c274) {
-          s2 = peg$c274;
+        if (input.substr(peg$currPos, 9) === peg$c190) {
+          s2 = peg$c190;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c275); }
+          if (peg$silentFails === 0) { peg$fail(peg$c191); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5952,7 +5081,7 @@ module.exports = /*
     function peg$parseEND_BMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 66,
+      var key    = peg$currPos * 122 + 64,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5964,12 +5093,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c274) {
-          s2 = peg$c274;
+        if (input.substr(peg$currPos, 9) === peg$c190) {
+          s2 = peg$c190;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c275); }
+          if (peg$silentFails === 0) { peg$fail(peg$c191); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5997,7 +5126,7 @@ module.exports = /*
     function peg$parseBEGIN_BBMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 67,
+      var key    = peg$currPos * 122 + 65,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6009,12 +5138,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c276) {
-          s2 = peg$c276;
+        if (input.substr(peg$currPos, 9) === peg$c192) {
+          s2 = peg$c192;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c277); }
+          if (peg$silentFails === 0) { peg$fail(peg$c193); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6042,7 +5171,7 @@ module.exports = /*
     function peg$parseEND_BBMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 68,
+      var key    = peg$currPos * 122 + 66,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6054,12 +5183,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c276) {
-          s2 = peg$c276;
+        if (input.substr(peg$currPos, 9) === peg$c192) {
+          s2 = peg$c192;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c277); }
+          if (peg$silentFails === 0) { peg$fail(peg$c193); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6087,7 +5216,7 @@ module.exports = /*
     function peg$parseBEGIN_VMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 69,
+      var key    = peg$currPos * 122 + 67,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6099,12 +5228,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c278) {
-          s2 = peg$c278;
+        if (input.substr(peg$currPos, 9) === peg$c194) {
+          s2 = peg$c194;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c279); }
+          if (peg$silentFails === 0) { peg$fail(peg$c195); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6132,7 +5261,7 @@ module.exports = /*
     function peg$parseEND_VMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 70,
+      var key    = peg$currPos * 122 + 68,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6144,12 +5273,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c278) {
-          s2 = peg$c278;
+        if (input.substr(peg$currPos, 9) === peg$c194) {
+          s2 = peg$c194;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c279); }
+          if (peg$silentFails === 0) { peg$fail(peg$c195); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6177,7 +5306,7 @@ module.exports = /*
     function peg$parseBEGIN_VVMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 71,
+      var key    = peg$currPos * 122 + 69,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6189,12 +5318,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c280) {
-          s2 = peg$c280;
+        if (input.substr(peg$currPos, 9) === peg$c196) {
+          s2 = peg$c196;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c281); }
+          if (peg$silentFails === 0) { peg$fail(peg$c197); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6222,7 +5351,7 @@ module.exports = /*
     function peg$parseEND_VVMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 72,
+      var key    = peg$currPos * 122 + 70,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6234,12 +5363,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c280) {
-          s2 = peg$c280;
+        if (input.substr(peg$currPos, 9) === peg$c196) {
+          s2 = peg$c196;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c281); }
+          if (peg$silentFails === 0) { peg$fail(peg$c197); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6267,7 +5396,7 @@ module.exports = /*
     function peg$parseBEGIN_ARRAY() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 73,
+      var key    = peg$currPos * 122 + 71,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6279,12 +5408,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c282) {
-          s2 = peg$c282;
+        if (input.substr(peg$currPos, 7) === peg$c198) {
+          s2 = peg$c198;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c283); }
+          if (peg$silentFails === 0) { peg$fail(peg$c199); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6312,7 +5441,7 @@ module.exports = /*
     function peg$parseEND_ARRAY() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 74,
+      var key    = peg$currPos * 122 + 72,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6324,12 +5453,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c282) {
-          s2 = peg$c282;
+        if (input.substr(peg$currPos, 7) === peg$c198) {
+          s2 = peg$c198;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c283); }
+          if (peg$silentFails === 0) { peg$fail(peg$c199); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6357,7 +5486,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGN() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 75,
+      var key    = peg$currPos * 122 + 73,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6369,12 +5498,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c284) {
-          s2 = peg$c284;
+        if (input.substr(peg$currPos, 7) === peg$c200) {
+          s2 = peg$c200;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c285); }
+          if (peg$silentFails === 0) { peg$fail(peg$c201); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6402,7 +5531,7 @@ module.exports = /*
     function peg$parseEND_ALIGN() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 76,
+      var key    = peg$currPos * 122 + 74,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6414,12 +5543,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c284) {
-          s2 = peg$c284;
+        if (input.substr(peg$currPos, 7) === peg$c200) {
+          s2 = peg$c200;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c285); }
+          if (peg$silentFails === 0) { peg$fail(peg$c201); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6447,7 +5576,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNED() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 77,
+      var key    = peg$currPos * 122 + 75,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6459,12 +5588,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c286) {
-          s2 = peg$c286;
+        if (input.substr(peg$currPos, 9) === peg$c202) {
+          s2 = peg$c202;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c287); }
+          if (peg$silentFails === 0) { peg$fail(peg$c203); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6492,7 +5621,7 @@ module.exports = /*
     function peg$parseEND_ALIGNED() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 78,
+      var key    = peg$currPos * 122 + 76,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6504,12 +5633,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c286) {
-          s2 = peg$c286;
+        if (input.substr(peg$currPos, 9) === peg$c202) {
+          s2 = peg$c202;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c287); }
+          if (peg$silentFails === 0) { peg$fail(peg$c203); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6537,7 +5666,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 79,
+      var key    = peg$currPos * 122 + 77,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6549,12 +5678,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c288) {
-          s2 = peg$c288;
+        if (input.substr(peg$currPos, 9) === peg$c204) {
+          s2 = peg$c204;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c289); }
+          if (peg$silentFails === 0) { peg$fail(peg$c205); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6582,7 +5711,7 @@ module.exports = /*
     function peg$parseEND_ALIGNAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 80,
+      var key    = peg$currPos * 122 + 78,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6594,12 +5723,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c288) {
-          s2 = peg$c288;
+        if (input.substr(peg$currPos, 9) === peg$c204) {
+          s2 = peg$c204;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c289); }
+          if (peg$silentFails === 0) { peg$fail(peg$c205); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6627,7 +5756,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNEDAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 81,
+      var key    = peg$currPos * 122 + 79,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6639,12 +5768,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c290) {
-          s2 = peg$c290;
+        if (input.substr(peg$currPos, 11) === peg$c206) {
+          s2 = peg$c206;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c291); }
+          if (peg$silentFails === 0) { peg$fail(peg$c207); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6672,7 +5801,7 @@ module.exports = /*
     function peg$parseEND_ALIGNEDAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 82,
+      var key    = peg$currPos * 122 + 80,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6684,12 +5813,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c290) {
-          s2 = peg$c290;
+        if (input.substr(peg$currPos, 11) === peg$c206) {
+          s2 = peg$c206;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c291); }
+          if (peg$silentFails === 0) { peg$fail(peg$c207); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6717,7 +5846,7 @@ module.exports = /*
     function peg$parseBEGIN_SMALLMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 83,
+      var key    = peg$currPos * 122 + 81,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6729,12 +5858,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c292) {
-          s2 = peg$c292;
+        if (input.substr(peg$currPos, 13) === peg$c208) {
+          s2 = peg$c208;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c293); }
+          if (peg$silentFails === 0) { peg$fail(peg$c209); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6762,7 +5891,7 @@ module.exports = /*
     function peg$parseEND_SMALLMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 84,
+      var key    = peg$currPos * 122 + 82,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6774,12 +5903,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c292) {
-          s2 = peg$c292;
+        if (input.substr(peg$currPos, 13) === peg$c208) {
+          s2 = peg$c208;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c293); }
+          if (peg$silentFails === 0) { peg$fail(peg$c209); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6807,7 +5936,7 @@ module.exports = /*
     function peg$parseBEGIN_CASES() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 85,
+      var key    = peg$currPos * 122 + 83,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6819,12 +5948,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c294) {
-          s2 = peg$c294;
+        if (input.substr(peg$currPos, 7) === peg$c210) {
+          s2 = peg$c210;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c295); }
+          if (peg$silentFails === 0) { peg$fail(peg$c211); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6852,7 +5981,7 @@ module.exports = /*
     function peg$parseEND_CASES() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 86,
+      var key    = peg$currPos * 122 + 84,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6864,12 +5993,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c294) {
-          s2 = peg$c294;
+        if (input.substr(peg$currPos, 7) === peg$c210) {
+          s2 = peg$c210;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c295); }
+          if (peg$silentFails === 0) { peg$fail(peg$c211); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6897,7 +6026,7 @@ module.exports = /*
     function peg$parseSQ_CLOSE() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 87,
+      var key    = peg$currPos * 122 + 85,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6936,7 +6065,7 @@ module.exports = /*
     function peg$parseCURLY_OPEN() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 88,
+      var key    = peg$currPos * 122 + 86,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6947,11 +6076,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c226;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c227); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6975,7 +6104,7 @@ module.exports = /*
     function peg$parseCURLY_CLOSE() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 89,
+      var key    = peg$currPos * 122 + 87,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7014,7 +6143,7 @@ module.exports = /*
     function peg$parseSUP() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 90,
+      var key    = peg$currPos * 122 + 88,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7025,11 +6154,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 94) {
-        s1 = peg$c91;
+        s1 = peg$c212;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c92); }
+        if (peg$silentFails === 0) { peg$fail(peg$c213); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7053,7 +6182,7 @@ module.exports = /*
     function peg$parseSUB() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 91,
+      var key    = peg$currPos * 122 + 89,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7064,11 +6193,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 95) {
-        s1 = peg$c147;
+        s1 = peg$c107;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c148); }
+        if (peg$silentFails === 0) { peg$fail(peg$c108); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7092,7 +6221,7 @@ module.exports = /*
     function peg$parsegeneric_func() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 92,
+      var key    = peg$currPos * 122 + 90,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7103,11 +6232,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c141;
+        s1 = peg$c160;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c142); }
+        if (peg$silentFails === 0) { peg$fail(peg$c161); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -7141,7 +6270,7 @@ module.exports = /*
     function peg$parseBIG() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 93,
+      var key    = peg$currPos * 122 + 91,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7154,7 +6283,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c296(s1);
+        s2 = peg$c214(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -7164,7 +6293,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c262(s1);
+            s1 = peg$c176(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7187,7 +6316,7 @@ module.exports = /*
     function peg$parseFUN_AR1() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 94,
+      var key    = peg$currPos * 122 + 92,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7200,7 +6329,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c297(s1);
+        s2 = peg$c215(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -7210,7 +6339,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c262(s1);
+            s1 = peg$c176(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7229,7 +6358,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c298(s1);
+          s2 = peg$c216(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -7239,7 +6368,7 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c298(s1);
+              s1 = peg$c216(s1);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7263,7 +6392,7 @@ module.exports = /*
     function peg$parseFUN_MHCHEM() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 115 + 95,
+      var key    = peg$currPos * 122 + 93,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7276,7 +6405,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c299(s1);
+        s2 = peg$c217(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -7284,7 +6413,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c262(s1);
+          s1 = peg$c176(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7303,7 +6432,7 @@ module.exports = /*
     function peg$parseFUN_AR2() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 96,
+      var key    = peg$currPos * 122 + 94,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7316,7 +6445,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c300(s1);
+        s2 = peg$c218(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -7326,7 +6455,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c262(s1);
+            s1 = peg$c176(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7349,7 +6478,7 @@ module.exports = /*
     function peg$parseFUN_INFIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 97,
+      var key    = peg$currPos * 122 + 95,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7362,7 +6491,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c301(s1);
+        s2 = peg$c219(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -7372,7 +6501,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c262(s1);
+            s1 = peg$c176(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7395,7 +6524,7 @@ module.exports = /*
     function peg$parseDECLh() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 98,
+      var key    = peg$currPos * 122 + 96,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7408,7 +6537,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c302(s1);
+        s2 = peg$c220(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -7418,7 +6547,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c303(s1);
+            s1 = peg$c221(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7441,7 +6570,7 @@ module.exports = /*
     function peg$parseFUN_AR2nb() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 99,
+      var key    = peg$currPos * 122 + 97,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7454,7 +6583,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c304(s1);
+        s2 = peg$c222(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -7464,7 +6593,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c262(s1);
+            s1 = peg$c176(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7487,7 +6616,7 @@ module.exports = /*
     function peg$parseLEFT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 100,
+      var key    = peg$currPos * 122 + 98,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7500,7 +6629,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c305(s1);
+        s2 = peg$c223(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -7532,7 +6661,7 @@ module.exports = /*
     function peg$parseRIGHT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 101,
+      var key    = peg$currPos * 122 + 99,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7545,7 +6674,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c306(s1);
+        s2 = peg$c224(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -7577,7 +6706,7 @@ module.exports = /*
     function peg$parseHLINE() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 115 + 102,
+      var key    = peg$currPos * 122 + 100,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7590,7 +6719,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c307(s1);
+        s2 = peg$c225(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -7600,7 +6729,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c262(s1);
+            s1 = peg$c176(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7623,7 +6752,7 @@ module.exports = /*
     function peg$parseCOLOR() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 115 + 103,
+      var key    = peg$currPos * 122 + 101,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7636,7 +6765,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c308(s1);
+        s2 = peg$c226(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -7648,7 +6777,7 @@ module.exports = /*
             s4 = peg$parseCOLOR_SPEC();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c309(s1, s4);
+              s1 = peg$c227(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7675,7 +6804,7 @@ module.exports = /*
     function peg$parseDEFINECOLOR() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17;
 
-      var key    = peg$currPos * 115 + 104,
+      var key    = peg$currPos * 122 + 102,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7688,7 +6817,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c310(s1);
+        s2 = peg$c228(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -7698,11 +6827,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c226;
+              s4 = peg$c132;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c227); }
+              if (peg$silentFails === 0) { peg$fail(peg$c133); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7731,22 +6860,22 @@ module.exports = /*
                       s9 = peg$parse_();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 123) {
-                          s10 = peg$c226;
+                          s10 = peg$c132;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c227); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c133); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             s12 = peg$currPos;
-                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c311) {
+                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c229) {
                               s13 = input.substr(peg$currPos, 5);
                               peg$currPos += 5;
                             } else {
                               s13 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c230); }
                             }
                             if (s13 !== peg$FAILED) {
                               s14 = peg$parse_();
@@ -7764,7 +6893,7 @@ module.exports = /*
                                     s17 = peg$parseCOLOR_SPEC_NAMED();
                                     if (s17 !== peg$FAILED) {
                                       peg$savedPos = s12;
-                                      s13 = peg$c313(s1, s6, s17);
+                                      s13 = peg$c231(s1, s6, s17);
                                       s12 = s13;
                                     } else {
                                       peg$currPos = s12;
@@ -7788,12 +6917,12 @@ module.exports = /*
                             }
                             if (s12 === peg$FAILED) {
                               s12 = peg$currPos;
-                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c314) {
+                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c232) {
                                 s13 = input.substr(peg$currPos, 4);
                                 peg$currPos += 4;
                               } else {
                                 s13 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c315); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c233); }
                               }
                               if (s13 !== peg$FAILED) {
                                 s14 = peg$parse_();
@@ -7811,7 +6940,7 @@ module.exports = /*
                                       s17 = peg$parseCOLOR_SPEC_GRAY();
                                       if (s17 !== peg$FAILED) {
                                         peg$savedPos = s12;
-                                        s13 = peg$c316(s1, s6, s17);
+                                        s13 = peg$c234(s1, s6, s17);
                                         s12 = s13;
                                       } else {
                                         peg$currPos = s12;
@@ -7835,12 +6964,12 @@ module.exports = /*
                               }
                               if (s12 === peg$FAILED) {
                                 s12 = peg$currPos;
-                                if (input.substr(peg$currPos, 3) === peg$c317) {
-                                  s13 = peg$c317;
+                                if (input.substr(peg$currPos, 3) === peg$c235) {
+                                  s13 = peg$c235;
                                   peg$currPos += 3;
                                 } else {
                                   s13 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c318); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c236); }
                                 }
                                 if (s13 !== peg$FAILED) {
                                   s14 = peg$parse_();
@@ -7858,7 +6987,7 @@ module.exports = /*
                                         s17 = peg$parseCOLOR_SPEC_rgb();
                                         if (s17 !== peg$FAILED) {
                                           peg$savedPos = s12;
-                                          s13 = peg$c319(s1, s6, s17);
+                                          s13 = peg$c237(s1, s6, s17);
                                           s12 = s13;
                                         } else {
                                           peg$currPos = s12;
@@ -7882,12 +7011,12 @@ module.exports = /*
                                 }
                                 if (s12 === peg$FAILED) {
                                   s12 = peg$currPos;
-                                  if (input.substr(peg$currPos, 3) === peg$c320) {
-                                    s13 = peg$c320;
+                                  if (input.substr(peg$currPos, 3) === peg$c238) {
+                                    s13 = peg$c238;
                                     peg$currPos += 3;
                                   } else {
                                     s13 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c321); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c239); }
                                   }
                                   if (s13 !== peg$FAILED) {
                                     s14 = peg$parse_();
@@ -7905,7 +7034,7 @@ module.exports = /*
                                           s17 = peg$parseCOLOR_SPEC_RGB();
                                           if (s17 !== peg$FAILED) {
                                             peg$savedPos = s12;
-                                            s13 = peg$c319(s1, s6, s17);
+                                            s13 = peg$c237(s1, s6, s17);
                                             s12 = s13;
                                           } else {
                                             peg$currPos = s12;
@@ -7929,12 +7058,12 @@ module.exports = /*
                                   }
                                   if (s12 === peg$FAILED) {
                                     s12 = peg$currPos;
-                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c322) {
+                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c240) {
                                       s13 = input.substr(peg$currPos, 4);
                                       peg$currPos += 4;
                                     } else {
                                       s13 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c323); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c241); }
                                     }
                                     if (s13 !== peg$FAILED) {
                                       s14 = peg$parse_();
@@ -7952,7 +7081,7 @@ module.exports = /*
                                             s17 = peg$parseCOLOR_SPEC_CMYK();
                                             if (s17 !== peg$FAILED) {
                                               peg$savedPos = s12;
-                                              s13 = peg$c324(s1, s6, s17);
+                                              s13 = peg$c242(s1, s6, s17);
                                               s12 = s13;
                                             } else {
                                               peg$currPos = s12;
@@ -7980,7 +7109,7 @@ module.exports = /*
                             }
                             if (s12 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c325(s1, s6, s12);
+                              s1 = peg$c243(s1, s6, s12);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -8039,7 +7168,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
-      var key    = peg$currPos * 115 + 105,
+      var key    = peg$currPos * 122 + 103,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8061,12 +7190,12 @@ module.exports = /*
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c311) {
+            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c229) {
               s3 = input.substr(peg$currPos, 5);
               peg$currPos += 5;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c312); }
+              if (peg$silentFails === 0) { peg$fail(peg$c230); }
             }
             if (s3 !== peg$FAILED) {
               s4 = peg$parse_();
@@ -8084,7 +7213,7 @@ module.exports = /*
                     s7 = peg$parseCOLOR_SPEC_NAMED();
                     if (s7 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c326(s7);
+                      s1 = peg$c244(s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -8126,12 +7255,12 @@ module.exports = /*
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c314) {
+              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c232) {
                 s3 = input.substr(peg$currPos, 4);
                 peg$currPos += 4;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c315); }
+                if (peg$silentFails === 0) { peg$fail(peg$c233); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -8149,7 +7278,7 @@ module.exports = /*
                       s7 = peg$parseCOLOR_SPEC_GRAY();
                       if (s7 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c327(s7);
+                        s1 = peg$c245(s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -8191,12 +7320,12 @@ module.exports = /*
             if (s1 !== peg$FAILED) {
               s2 = peg$parse_();
               if (s2 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 3) === peg$c317) {
-                  s3 = peg$c317;
+                if (input.substr(peg$currPos, 3) === peg$c235) {
+                  s3 = peg$c235;
                   peg$currPos += 3;
                 } else {
                   s3 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c318); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c236); }
                 }
                 if (s3 !== peg$FAILED) {
                   s4 = peg$parse_();
@@ -8214,7 +7343,7 @@ module.exports = /*
                         s7 = peg$parseCOLOR_SPEC_rgb();
                         if (s7 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c328(s7);
+                          s1 = peg$c246(s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -8256,12 +7385,12 @@ module.exports = /*
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse_();
                 if (s2 !== peg$FAILED) {
-                  if (input.substr(peg$currPos, 3) === peg$c320) {
-                    s3 = peg$c320;
+                  if (input.substr(peg$currPos, 3) === peg$c238) {
+                    s3 = peg$c238;
                     peg$currPos += 3;
                   } else {
                     s3 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c321); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c239); }
                   }
                   if (s3 !== peg$FAILED) {
                     s4 = peg$parse_();
@@ -8279,7 +7408,7 @@ module.exports = /*
                           s7 = peg$parseCOLOR_SPEC_RGB();
                           if (s7 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c328(s7);
+                            s1 = peg$c246(s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -8321,12 +7450,12 @@ module.exports = /*
                 if (s1 !== peg$FAILED) {
                   s2 = peg$parse_();
                   if (s2 !== peg$FAILED) {
-                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c322) {
+                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c240) {
                       s3 = input.substr(peg$currPos, 4);
                       peg$currPos += 4;
                     } else {
                       s3 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c323); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c241); }
                     }
                     if (s3 !== peg$FAILED) {
                       s4 = peg$parse_();
@@ -8344,7 +7473,7 @@ module.exports = /*
                             s7 = peg$parseCOLOR_SPEC_CMYK();
                             if (s7 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c329(s7);
+                              s1 = peg$c247(s7);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -8388,7 +7517,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_NAMED() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 115 + 106,
+      var key    = peg$currPos * 122 + 104,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8399,11 +7528,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c226;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c227); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -8432,7 +7561,7 @@ module.exports = /*
                 s6 = peg$parse_();
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c330(s3);
+                  s1 = peg$c248(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -8467,7 +7596,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_GRAY() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 115 + 107,
+      var key    = peg$currPos * 122 + 105,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8478,11 +7607,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c226;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c227); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -8507,7 +7636,7 @@ module.exports = /*
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c331(s3);
+              s1 = peg$c249(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -8534,7 +7663,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_rgb() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-      var key    = peg$currPos * 115 + 108,
+      var key    = peg$currPos * 122 + 106,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8545,11 +7674,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c226;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c227); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -8557,11 +7686,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c129;
+              s4 = peg$c250;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c130); }
+              if (peg$silentFails === 0) { peg$fail(peg$c251); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -8569,11 +7698,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c129;
+                    s7 = peg$c250;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c130); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c251); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -8591,7 +7720,7 @@ module.exports = /*
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c332(s3, s6, s9);
+                            s1 = peg$c252(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -8646,7 +7775,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_RGB() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-      var key    = peg$currPos * 115 + 109,
+      var key    = peg$currPos * 122 + 107,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8657,11 +7786,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c226;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c227); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -8669,11 +7798,11 @@ module.exports = /*
           s3 = peg$parseCNUM255();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c129;
+              s4 = peg$c250;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c130); }
+              if (peg$silentFails === 0) { peg$fail(peg$c251); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -8681,11 +7810,11 @@ module.exports = /*
                 s6 = peg$parseCNUM255();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c129;
+                    s7 = peg$c250;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c130); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c251); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -8703,7 +7832,7 @@ module.exports = /*
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c332(s3, s6, s9);
+                            s1 = peg$c252(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -8758,7 +7887,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_CMYK() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14;
 
-      var key    = peg$currPos * 115 + 110,
+      var key    = peg$currPos * 122 + 108,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8769,11 +7898,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c226;
+        s1 = peg$c132;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c227); }
+        if (peg$silentFails === 0) { peg$fail(peg$c133); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -8781,11 +7910,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c129;
+              s4 = peg$c250;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c130); }
+              if (peg$silentFails === 0) { peg$fail(peg$c251); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -8793,11 +7922,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c129;
+                    s7 = peg$c250;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c130); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c251); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -8805,11 +7934,11 @@ module.exports = /*
                       s9 = peg$parseCNUM();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 44) {
-                          s10 = peg$c129;
+                          s10 = peg$c250;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c130); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c251); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
@@ -8827,7 +7956,7 @@ module.exports = /*
                                 s14 = peg$parse_();
                                 if (s14 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c333(s3, s6, s9, s12);
+                                  s1 = peg$c253(s3, s6, s9, s12);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -8894,7 +8023,7 @@ module.exports = /*
     function peg$parseCNUM255() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 115 + 111,
+      var key    = peg$currPos * 122 + 109,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8906,20 +8035,20 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s2 = peg$c334;
+        s2 = peg$c254;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c335); }
+        if (peg$silentFails === 0) { peg$fail(peg$c255); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$currPos;
-        if (peg$c336.test(input.charAt(peg$currPos))) {
+        if (peg$c256.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c337); }
+          if (peg$silentFails === 0) { peg$fail(peg$c257); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -8974,7 +8103,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c338(s1);
+        s2 = peg$c258(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8984,7 +8113,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c339(s1);
+            s1 = peg$c259(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9007,7 +8136,7 @@ module.exports = /*
     function peg$parseCNUM() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 115 + 112,
+      var key    = peg$currPos * 122 + 110,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -9020,22 +8149,22 @@ module.exports = /*
       s1 = peg$currPos;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s3 = peg$c334;
+        s3 = peg$c254;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c335); }
+        if (peg$silentFails === 0) { peg$fail(peg$c255); }
       }
       if (s3 === peg$FAILED) {
         s3 = null;
       }
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c127;
+          s4 = peg$c260;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c128); }
+          if (peg$silentFails === 0) { peg$fail(peg$c261); }
         }
         if (s4 !== peg$FAILED) {
           s5 = [];
@@ -9084,7 +8213,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c340(s1);
+          s1 = peg$c262(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9098,20 +8227,20 @@ module.exports = /*
         s0 = peg$currPos;
         s1 = peg$currPos;
         s2 = peg$currPos;
-        if (peg$c341.test(input.charAt(peg$currPos))) {
+        if (peg$c263.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c342); }
+          if (peg$silentFails === 0) { peg$fail(peg$c264); }
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c127;
+            s4 = peg$c260;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c128); }
+            if (peg$silentFails === 0) { peg$fail(peg$c261); }
           }
           if (s4 === peg$FAILED) {
             s4 = null;
@@ -9136,7 +8265,7 @@ module.exports = /*
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c340(s1);
+            s1 = peg$c262(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -9156,7 +8285,7 @@ module.exports = /*
     function peg$parseimpossible() {
       var s0;
 
-      var key    = peg$currPos * 115 + 113,
+      var key    = peg$currPos * 122 + 111,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -9166,7 +8295,7 @@ module.exports = /*
       }
 
       peg$savedPos = peg$currPos;
-      s0 = peg$c343();
+      s0 = peg$c265();
       if (s0) {
         s0 = void 0;
       } else {
@@ -9181,7 +8310,7 @@ module.exports = /*
     function peg$parseEOF() {
       var s0;
 
-      var key    = peg$currPos * 115 + 114,
+      var key    = peg$currPos * 122 + 112,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -9191,10 +8320,474 @@ module.exports = /*
       }
 
       peg$savedPos = peg$currPos;
-      s0 = peg$c344();
+      s0 = peg$c266();
       if (s0) {
         s0 = void 0;
       } else {
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_SCRIPT_FOLLOW() {
+      var s0;
+
+      var key    = peg$currPos * 122 + 113,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$parseliteral_mn();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseliteral_id();
+        if (s0 === peg$FAILED) {
+          if (peg$c267.test(input.charAt(peg$currPos))) {
+            s0 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s0 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c268); }
+          }
+        }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_SUPERSUB() {
+      var s0;
+
+      var key    = peg$currPos * 122 + 114,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (input.charCodeAt(peg$currPos) === 95) {
+        s0 = peg$c107;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c108); }
+      }
+      if (s0 === peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 94) {
+          s0 = peg$c212;
+          peg$currPos++;
+        } else {
+          s0 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c213); }
+        }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_BOND_TYPE() {
+      var s0;
+
+      var key    = peg$currPos * 122 + 115,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (input.charCodeAt(peg$currPos) === 61) {
+        s0 = peg$c269;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c270); }
+      }
+      if (s0 === peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 35) {
+          s0 = peg$c271;
+          peg$currPos++;
+        } else {
+          s0 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c272); }
+        }
+        if (s0 === peg$FAILED) {
+          if (input.substr(peg$currPos, 3) === peg$c273) {
+            s0 = peg$c273;
+            peg$currPos += 3;
+          } else {
+            s0 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c274); }
+          }
+          if (s0 === peg$FAILED) {
+            if (input.substr(peg$currPos, 2) === peg$c275) {
+              s0 = peg$c275;
+              peg$currPos += 2;
+            } else {
+              s0 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c276); }
+            }
+            if (s0 === peg$FAILED) {
+              if (input.substr(peg$currPos, 2) === peg$c277) {
+                s0 = peg$c277;
+                peg$currPos += 2;
+              } else {
+                s0 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c278); }
+              }
+              if (s0 === peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 126) {
+                  s0 = peg$c279;
+                  peg$currPos++;
+                } else {
+                  s0 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c280); }
+                }
+                if (s0 === peg$FAILED) {
+                  if (input.substr(peg$currPos, 3) === peg$c281) {
+                    s0 = peg$c281;
+                    peg$currPos += 3;
+                  } else {
+                    s0 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c282); }
+                  }
+                  if (s0 === peg$FAILED) {
+                    if (input.charCodeAt(peg$currPos) === 45) {
+                      s0 = peg$c135;
+                      peg$currPos++;
+                    } else {
+                      s0 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c136); }
+                    }
+                    if (s0 === peg$FAILED) {
+                      if (input.substr(peg$currPos, 4) === peg$c283) {
+                        s0 = peg$c283;
+                        peg$currPos += 4;
+                      } else {
+                        s0 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c284); }
+                      }
+                      if (s0 === peg$FAILED) {
+                        if (input.substr(peg$currPos, 3) === peg$c285) {
+                          s0 = peg$c285;
+                          peg$currPos += 3;
+                        } else {
+                          s0 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c286); }
+                        }
+                        if (s0 === peg$FAILED) {
+                          if (input.substr(peg$currPos, 2) === peg$c287) {
+                            s0 = peg$c287;
+                            peg$currPos += 2;
+                          } else {
+                            s0 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$c288); }
+                          }
+                          if (s0 === peg$FAILED) {
+                            if (input.substr(peg$currPos, 2) === peg$c289) {
+                              s0 = peg$c289;
+                              peg$currPos += 2;
+                            } else {
+                              s0 = peg$FAILED;
+                              if (peg$silentFails === 0) { peg$fail(peg$c290); }
+                            }
+                            if (s0 === peg$FAILED) {
+                              if (input.charCodeAt(peg$currPos) === 49) {
+                                s0 = peg$c291;
+                                peg$currPos++;
+                              } else {
+                                s0 = peg$FAILED;
+                                if (peg$silentFails === 0) { peg$fail(peg$c292); }
+                              }
+                              if (s0 === peg$FAILED) {
+                                if (input.charCodeAt(peg$currPos) === 50) {
+                                  s0 = peg$c293;
+                                  peg$currPos++;
+                                } else {
+                                  s0 = peg$FAILED;
+                                  if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                                }
+                                if (s0 === peg$FAILED) {
+                                  if (input.charCodeAt(peg$currPos) === 51) {
+                                    s0 = peg$c295;
+                                    peg$currPos++;
+                                  } else {
+                                    s0 = peg$FAILED;
+                                    if (peg$silentFails === 0) { peg$fail(peg$c296); }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_DOLLAR() {
+      var s0;
+
+      var key    = peg$currPos * 122 + 116,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (input.charCodeAt(peg$currPos) === 36) {
+        s0 = peg$c297;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c298); }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_BOND() {
+      var s0, s1, s2;
+
+      var key    = peg$currPos * 122 + 117,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c299(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c176(s1);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_NONLETTER() {
+      var s0, s1, s2;
+
+      var key    = peg$currPos * 122 + 118,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (input.substr(peg$currPos, 2) === peg$c141) {
+        s0 = peg$c141;
+        peg$currPos += 2;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c142); }
+      }
+      if (s0 === peg$FAILED) {
+        if (input.substr(peg$currPos, 2) === peg$c300) {
+          s0 = peg$c300;
+          peg$currPos += 2;
+        } else {
+          s0 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c301); }
+        }
+        if (s0 === peg$FAILED) {
+          if (peg$c302.test(input.charAt(peg$currPos))) {
+            s0 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s0 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c303); }
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseliteral_mn();
+            if (s0 === peg$FAILED) {
+              s0 = peg$currPos;
+              s1 = peg$parseCURLY_OPEN();
+              if (s1 !== peg$FAILED) {
+                s2 = peg$parseCURLY_CLOSE();
+                if (s2 !== peg$FAILED) {
+                  s1 = [s1, s2];
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            }
+          }
+        }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_MACRO_1P() {
+      var s0, s1, s2;
+
+      var key    = peg$currPos * 122 + 119,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c304(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c176(s1);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_MACRO_2P() {
+      var s0, s1, s2;
+
+      var key    = peg$currPos * 122 + 120,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c305(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c176(s1);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_MACRO_2PU() {
+      var s0, s1, s2;
+
+      var key    = peg$currPos * 122 + 121,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsegeneric_func();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = peg$currPos;
+        s2 = peg$c306(s1);
+        if (s2) {
+          s2 = void 0;
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c176(s1);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
         s0 = peg$FAILED;
       }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -247,218 +247,215 @@ module.exports = /*
         peg$c99 = function(c) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) },
         peg$c100 = function(c) { return ast.Tex.CURLY([c]); },
         peg$c101 = function(c) { return ast.Tex.DOLLAR(c.toArray()); },
-        peg$c102 = function(name, l) { return ast.Tex.CHEM_BOND(name, l); },
-        peg$c103 = function(e) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(e))]); },
-        peg$c104 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(b))); },
-        peg$c105 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), b); },
-        peg$c106 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.DOLLAR(b.toArray())); },
-        peg$c107 = "_",
-        peg$c108 = peg$literalExpectation("_", false),
-        peg$c109 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2u(name, l1, l2); },
-        peg$c110 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2c(l1, l2); },
-        peg$c111 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2(name, l1, l2); },
-        peg$c112 = function(name, l) { return ast.Tex.CHEM_FUN1(name, l); },
-        peg$c113 = function(cs) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); },
-        peg$c114 = /^[a-zA-Z]/,
-        peg$c115 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
-        peg$c116 = /^[,:;?!']/,
-        peg$c117 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
-        peg$c118 = /^[().]/,
-        peg$c119 = peg$classExpectation(["(", ")", "."], false, false),
-        peg$c120 = /^[\-+*=]/,
-        peg$c121 = peg$classExpectation(["-", "+", "*", "="], false, false),
-        peg$c122 = /^[\/|]/,
-        peg$c123 = peg$classExpectation(["/", "|"], false, false),
-        peg$c124 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
-        peg$c125 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
-        peg$c126 = /^[\uD800-\uDBFF]/,
-        peg$c127 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
-        peg$c128 = /^[\uDC00-\uDFFF]/,
-        peg$c129 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
-        peg$c130 = function(l, h) { return text(); },
-        peg$c131 = function(b) { return tu.box_functions[b]; },
-        peg$c132 = "{",
-        peg$c133 = peg$literalExpectation("{", false),
-        peg$c134 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
-        peg$c135 = "-",
-        peg$c136 = peg$literalExpectation("-", false),
-        peg$c137 = function(c) { return ast.RenderT.TEX_ONLY(c); },
-        peg$c138 = function(f) { return tu.latex_function_names[f]; },
-        peg$c139 = "(",
-        peg$c140 = peg$literalExpectation("(", false),
-        peg$c141 = "\\{",
-        peg$c142 = peg$literalExpectation("\\{", false),
-        peg$c143 = function(f) { return " ";},
-        peg$c144 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
-        peg$c145 = function(f) { return tu.mediawiki_function_names[f]; },
-        peg$c146 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
-        peg$c147 = function(f) { return tu.other_literals1[f]; },
-        peg$c148 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
-        peg$c149 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c150 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c151 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
-        peg$c152 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c153 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c154 = function(f) { return tu.other_literals2[f]; },
-        peg$c155 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c156 = function(mbox) { return mbox === "\\mbox"; },
-        peg$c157 = function(mbox, f) { return tu.other_literals2[f]; },
-        peg$c158 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c159 = function(f) { return ast.RenderT.TEX_ONLY(f); },
-        peg$c160 = "\\",
-        peg$c161 = peg$literalExpectation("\\", false),
-        peg$c162 = /^[, ;!_#%$&]/,
-        peg$c163 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
-        peg$c164 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
-        peg$c165 = /^[><~]/,
-        peg$c166 = peg$classExpectation([">", "<", "~"], false, false),
-        peg$c167 = /^[%$]/,
-        peg$c168 = peg$classExpectation(["%", "$"], false, false),
-        peg$c169 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */},
-        peg$c170 = /^[{}|]/,
-        peg$c171 = peg$classExpectation(["{", "}", "|"], false, false),
-        peg$c172 = function(f) { return tu.other_delimiters1[f]; },
-        peg$c173 = function(f) { return tu.other_delimiters2[f]; },
-        peg$c174 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
+        peg$c102 = function(e) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(e))]); },
+        peg$c103 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(b))); },
+        peg$c104 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), b); },
+        peg$c105 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.DOLLAR(b.toArray())); },
+        peg$c106 = "_",
+        peg$c107 = peg$literalExpectation("_", false),
+        peg$c108 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2u(name, l1, l2); },
+        peg$c109 = function(cs) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); },
+        peg$c110 = "{",
+        peg$c111 = peg$literalExpectation("{", false),
+        peg$c112 = function(name) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(name.join(''))); },
+        peg$c113 = /^[a-zA-Z]/,
+        peg$c114 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
+        peg$c115 = /^[,:;?!']/,
+        peg$c116 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
+        peg$c117 = /^[().]/,
+        peg$c118 = peg$classExpectation(["(", ")", "."], false, false),
+        peg$c119 = /^[\-+*=]/,
+        peg$c120 = peg$classExpectation(["-", "+", "*", "="], false, false),
+        peg$c121 = /^[\/|]/,
+        peg$c122 = peg$classExpectation(["/", "|"], false, false),
+        peg$c123 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
+        peg$c124 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
+        peg$c125 = /^[\uD800-\uDBFF]/,
+        peg$c126 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
+        peg$c127 = /^[\uDC00-\uDFFF]/,
+        peg$c128 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
+        peg$c129 = function(l, h) { return text(); },
+        peg$c130 = function(b) { return tu.box_functions[b]; },
+        peg$c131 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
+        peg$c132 = "-",
+        peg$c133 = peg$literalExpectation("-", false),
+        peg$c134 = function(c) { return ast.RenderT.TEX_ONLY(c); },
+        peg$c135 = function(f) { return tu.latex_function_names[f]; },
+        peg$c136 = "(",
+        peg$c137 = peg$literalExpectation("(", false),
+        peg$c138 = "\\{",
+        peg$c139 = peg$literalExpectation("\\{", false),
+        peg$c140 = function(f) { return " ";},
+        peg$c141 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
+        peg$c142 = function(f) { return tu.mediawiki_function_names[f]; },
+        peg$c143 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
+        peg$c144 = function(f) { return tu.other_literals1[f]; },
+        peg$c145 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
+        peg$c146 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c147 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c148 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
+        peg$c149 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c150 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c151 = function(f) { return tu.other_literals2[f]; },
+        peg$c152 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c153 = function(mbox) { return mbox === "\\mbox"; },
+        peg$c154 = function(mbox, f) { return tu.other_literals2[f]; },
+        peg$c155 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c156 = function(f) { return ast.RenderT.TEX_ONLY(f); },
+        peg$c157 = "\\",
+        peg$c158 = peg$literalExpectation("\\", false),
+        peg$c159 = /^[, ;!_#%$&]/,
+        peg$c160 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
+        peg$c161 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
+        peg$c162 = /^[><~]/,
+        peg$c163 = peg$classExpectation([">", "<", "~"], false, false),
+        peg$c164 = /^[%$]/,
+        peg$c165 = peg$classExpectation(["%", "$"], false, false),
+        peg$c166 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */},
+        peg$c167 = /^[{}|]/,
+        peg$c168 = peg$classExpectation(["{", "}", "|"], false, false),
+        peg$c169 = function(f) { return tu.other_delimiters1[f]; },
+        peg$c170 = function(f) { return tu.other_delimiters2[f]; },
+        peg$c171 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
              console.assert(Array.isArray(p) && p.length === 1);
              console.assert(p[0].constructor === ast.Tex.LITERAL);
              console.assert(p[0][0].constructor === ast.RenderT.TEX_ONLY);
              return p[0][0];
            },
-        peg$c175 = function(f) { return tu.fun_ar1nb[f]; },
-        peg$c176 = function(f) { return f; },
-        peg$c177 = function(f) { return tu.fun_ar1opt[f]; },
-        peg$c178 = "&",
-        peg$c179 = peg$literalExpectation("&", false),
-        peg$c180 = "\\\\",
-        peg$c181 = peg$literalExpectation("\\\\", false),
-        peg$c182 = "\\begin",
-        peg$c183 = peg$literalExpectation("\\begin", false),
-        peg$c184 = "\\end",
-        peg$c185 = peg$literalExpectation("\\end", false),
-        peg$c186 = "{matrix}",
-        peg$c187 = peg$literalExpectation("{matrix}", false),
-        peg$c188 = "{pmatrix}",
-        peg$c189 = peg$literalExpectation("{pmatrix}", false),
-        peg$c190 = "{bmatrix}",
-        peg$c191 = peg$literalExpectation("{bmatrix}", false),
-        peg$c192 = "{Bmatrix}",
-        peg$c193 = peg$literalExpectation("{Bmatrix}", false),
-        peg$c194 = "{vmatrix}",
-        peg$c195 = peg$literalExpectation("{vmatrix}", false),
-        peg$c196 = "{Vmatrix}",
-        peg$c197 = peg$literalExpectation("{Vmatrix}", false),
-        peg$c198 = "{array}",
-        peg$c199 = peg$literalExpectation("{array}", false),
-        peg$c200 = "{align}",
-        peg$c201 = peg$literalExpectation("{align}", false),
-        peg$c202 = "{aligned}",
-        peg$c203 = peg$literalExpectation("{aligned}", false),
-        peg$c204 = "{alignat}",
-        peg$c205 = peg$literalExpectation("{alignat}", false),
-        peg$c206 = "{alignedat}",
-        peg$c207 = peg$literalExpectation("{alignedat}", false),
-        peg$c208 = "{smallmatrix}",
-        peg$c209 = peg$literalExpectation("{smallmatrix}", false),
-        peg$c210 = "{cases}",
-        peg$c211 = peg$literalExpectation("{cases}", false),
-        peg$c212 = function(f) { return tu.big_literals[f]; },
-        peg$c213 = function(f) { return tu.fun_ar1[f]; },
-        peg$c214 = function(f) { return tu.other_fun_ar1[f]; },
-        peg$c215 = function(f) { return tu.fun_mhchem[f]; },
-        peg$c216 = function(f) { return tu.fun_ar2[f]; },
-        peg$c217 = function(f) { return tu.fun_infix[f]; },
-        peg$c218 = function(f) { return tu.declh_function[f]; },
-        peg$c219 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
-        peg$c220 = function(f) { return tu.fun_ar2nb[f]; },
-        peg$c221 = function(f) { return tu.left_function[f]; },
-        peg$c222 = function(f) { return tu.right_function[f]; },
-        peg$c223 = function(f) { return tu.hline_function[f]; },
-        peg$c224 = function(f) { return tu.color_function[f]; },
-        peg$c225 = function(f, cs) { return f + " " + cs; },
-        peg$c226 = function(f) { return tu.definecolor_function[f]; },
-        peg$c227 = "named",
-        peg$c228 = peg$literalExpectation("named", true),
-        peg$c229 = function(f, name, cs) { return "{named}" + cs; },
-        peg$c230 = "gray",
-        peg$c231 = peg$literalExpectation("gray", true),
-        peg$c232 = function(f, name, cs) { return "{gray}" + cs; },
-        peg$c233 = "rgb",
-        peg$c234 = peg$literalExpectation("rgb", false),
-        peg$c235 = function(f, name, cs) { return "{rgb}" + cs; },
-        peg$c236 = "RGB",
-        peg$c237 = peg$literalExpectation("RGB", false),
-        peg$c238 = "cmyk",
-        peg$c239 = peg$literalExpectation("cmyk", true),
-        peg$c240 = function(f, name, cs) { return "{cmyk}" + cs; },
-        peg$c241 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
-        peg$c242 = function(cs) { return "[named]" + cs; },
-        peg$c243 = function(cs) { return "[gray]" + cs; },
-        peg$c244 = function(cs) { return "[rgb]" + cs; },
-        peg$c245 = function(cs) { return "[cmyk]" + cs; },
-        peg$c246 = function(name) { return "{" + name.join('') + "}"; },
-        peg$c247 = function(k) { return "{"+k+"}"; },
-        peg$c248 = ",",
-        peg$c249 = peg$literalExpectation(",", false),
-        peg$c250 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
-        peg$c251 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
-        peg$c252 = "0",
-        peg$c253 = peg$literalExpectation("0", false),
-        peg$c254 = /^[1-9]/,
-        peg$c255 = peg$classExpectation([["1", "9"]], false, false),
-        peg$c256 = function(n) { return parseInt(n, 10) <= 255; },
-        peg$c257 = function(n) { return n / 255; },
-        peg$c258 = ".",
-        peg$c259 = peg$literalExpectation(".", false),
-        peg$c260 = function(n) { return n; },
-        peg$c261 = /^[01]/,
-        peg$c262 = peg$classExpectation(["0", "1"], false, false),
-        peg$c263 = function(f) { return tu.mhchem_single_macro[f]; },
-        peg$c264 = function(f) { return tu.mhchem_bond[f]; },
-        peg$c265 = function(f) { return tu.mhchem_macro_1p[f]; },
-        peg$c266 = function(f) { return tu.mhchem_macro_2p[f]; },
-        peg$c267 = function(f) { return tu.mhchem_macro_2pu[f]; },
-        peg$c268 = function(f) { return tu.mhchem_macro_2pc[f]; },
-        peg$c269 = /^[+-.*']/,
-        peg$c270 = peg$classExpectation([["+", "."], "*", "'"], false, false),
-        peg$c271 = "=",
-        peg$c272 = peg$literalExpectation("=", false),
-        peg$c273 = "#",
-        peg$c274 = peg$literalExpectation("#", false),
-        peg$c275 = "~--",
-        peg$c276 = peg$literalExpectation("~--", false),
-        peg$c277 = "~-",
-        peg$c278 = peg$literalExpectation("~-", false),
-        peg$c279 = "~=",
-        peg$c280 = peg$literalExpectation("~=", false),
-        peg$c281 = "~",
-        peg$c282 = peg$literalExpectation("~", false),
-        peg$c283 = "-~-",
-        peg$c284 = peg$literalExpectation("-~-", false),
-        peg$c285 = "....",
-        peg$c286 = peg$literalExpectation("....", false),
-        peg$c287 = "...",
-        peg$c288 = peg$literalExpectation("...", false),
-        peg$c289 = "<-",
-        peg$c290 = peg$literalExpectation("<-", false),
-        peg$c291 = "->",
-        peg$c292 = peg$literalExpectation("->", false),
-        peg$c293 = "1",
-        peg$c294 = peg$literalExpectation("1", false),
-        peg$c295 = "2",
-        peg$c296 = peg$literalExpectation("2", false),
-        peg$c297 = "3",
-        peg$c298 = peg$literalExpectation("3", false),
-        peg$c299 = "{math}",
-        peg$c300 = peg$literalExpectation("{math}", false),
-        peg$c301 = function(c) { return c; },
-        peg$c302 = "\\}",
-        peg$c303 = peg$literalExpectation("\\}", false),
-        peg$c304 = /^[+-=#().,;\/*<>|@&'[\]]/,
-        peg$c305 = peg$classExpectation([["+", "="], "#", "(", ")", ".", ",", ";", "/", "*", "<", ">", "|", "@", "&", "'", "[", "]"], false, false),
-        peg$c306 = function() { return "{}"; },
-        peg$c307 = function() { return false; },
-        peg$c308 = function() { return peg$currPos === input.length; },
+        peg$c172 = function(f) { return tu.fun_ar1nb[f]; },
+        peg$c173 = function(f) { return f; },
+        peg$c174 = function(f) { return tu.fun_ar1opt[f]; },
+        peg$c175 = "&",
+        peg$c176 = peg$literalExpectation("&", false),
+        peg$c177 = "\\\\",
+        peg$c178 = peg$literalExpectation("\\\\", false),
+        peg$c179 = "\\begin",
+        peg$c180 = peg$literalExpectation("\\begin", false),
+        peg$c181 = "\\end",
+        peg$c182 = peg$literalExpectation("\\end", false),
+        peg$c183 = "{matrix}",
+        peg$c184 = peg$literalExpectation("{matrix}", false),
+        peg$c185 = "{pmatrix}",
+        peg$c186 = peg$literalExpectation("{pmatrix}", false),
+        peg$c187 = "{bmatrix}",
+        peg$c188 = peg$literalExpectation("{bmatrix}", false),
+        peg$c189 = "{Bmatrix}",
+        peg$c190 = peg$literalExpectation("{Bmatrix}", false),
+        peg$c191 = "{vmatrix}",
+        peg$c192 = peg$literalExpectation("{vmatrix}", false),
+        peg$c193 = "{Vmatrix}",
+        peg$c194 = peg$literalExpectation("{Vmatrix}", false),
+        peg$c195 = "{array}",
+        peg$c196 = peg$literalExpectation("{array}", false),
+        peg$c197 = "{align}",
+        peg$c198 = peg$literalExpectation("{align}", false),
+        peg$c199 = "{aligned}",
+        peg$c200 = peg$literalExpectation("{aligned}", false),
+        peg$c201 = "{alignat}",
+        peg$c202 = peg$literalExpectation("{alignat}", false),
+        peg$c203 = "{alignedat}",
+        peg$c204 = peg$literalExpectation("{alignedat}", false),
+        peg$c205 = "{smallmatrix}",
+        peg$c206 = peg$literalExpectation("{smallmatrix}", false),
+        peg$c207 = "{cases}",
+        peg$c208 = peg$literalExpectation("{cases}", false),
+        peg$c209 = function(f) { return tu.big_literals[f]; },
+        peg$c210 = function(f) { return tu.fun_ar1[f]; },
+        peg$c211 = function(f) { return tu.other_fun_ar1[f]; },
+        peg$c212 = function(f) { return tu.fun_mhchem[f]; },
+        peg$c213 = function(f) { return tu.fun_ar2[f]; },
+        peg$c214 = function(f) { return tu.fun_infix[f]; },
+        peg$c215 = function(f) { return tu.declh_function[f]; },
+        peg$c216 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
+        peg$c217 = function(f) { return tu.fun_ar2nb[f]; },
+        peg$c218 = function(f) { return tu.left_function[f]; },
+        peg$c219 = function(f) { return tu.right_function[f]; },
+        peg$c220 = function(f) { return tu.hline_function[f]; },
+        peg$c221 = function(f) { return tu.color_function[f]; },
+        peg$c222 = function(f, cs) { return f + " " + cs; },
+        peg$c223 = function(f) { return tu.definecolor_function[f]; },
+        peg$c224 = "named",
+        peg$c225 = peg$literalExpectation("named", true),
+        peg$c226 = function(f, name, cs) { return "{named}" + cs; },
+        peg$c227 = "gray",
+        peg$c228 = peg$literalExpectation("gray", true),
+        peg$c229 = function(f, name, cs) { return "{gray}" + cs; },
+        peg$c230 = "rgb",
+        peg$c231 = peg$literalExpectation("rgb", false),
+        peg$c232 = function(f, name, cs) { return "{rgb}" + cs; },
+        peg$c233 = "RGB",
+        peg$c234 = peg$literalExpectation("RGB", false),
+        peg$c235 = "cmyk",
+        peg$c236 = peg$literalExpectation("cmyk", true),
+        peg$c237 = function(f, name, cs) { return "{cmyk}" + cs; },
+        peg$c238 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
+        peg$c239 = function(cs) { return "[named]" + cs; },
+        peg$c240 = function(cs) { return "[gray]" + cs; },
+        peg$c241 = function(cs) { return "[rgb]" + cs; },
+        peg$c242 = function(cs) { return "[cmyk]" + cs; },
+        peg$c243 = function(name) { return "{" + name.join('') + "}"; },
+        peg$c244 = function(k) { return "{"+k+"}"; },
+        peg$c245 = ",",
+        peg$c246 = peg$literalExpectation(",", false),
+        peg$c247 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
+        peg$c248 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
+        peg$c249 = "0",
+        peg$c250 = peg$literalExpectation("0", false),
+        peg$c251 = /^[1-9]/,
+        peg$c252 = peg$classExpectation([["1", "9"]], false, false),
+        peg$c253 = function(n) { return parseInt(n, 10) <= 255; },
+        peg$c254 = function(n) { return n / 255; },
+        peg$c255 = ".",
+        peg$c256 = peg$literalExpectation(".", false),
+        peg$c257 = function(n) { return n; },
+        peg$c258 = /^[01]/,
+        peg$c259 = peg$classExpectation(["0", "1"], false, false),
+        peg$c260 = function(f) { return tu.mhchem_single_macro[f]; },
+        peg$c261 = function(f) { return tu.mhchem_bond[f]; },
+        peg$c262 = function(f) { return tu.mhchem_macro_1p[f]; },
+        peg$c263 = function(f) { return tu.mhchem_macro_2p[f]; },
+        peg$c264 = function(f) { return tu.mhchem_macro_2pu[f]; },
+        peg$c265 = function(f) { return tu.mhchem_macro_2pc[f]; },
+        peg$c266 = /^[+-.*']/,
+        peg$c267 = peg$classExpectation([["+", "."], "*", "'"], false, false),
+        peg$c268 = "=",
+        peg$c269 = peg$literalExpectation("=", false),
+        peg$c270 = "#",
+        peg$c271 = peg$literalExpectation("#", false),
+        peg$c272 = "~--",
+        peg$c273 = peg$literalExpectation("~--", false),
+        peg$c274 = "~-",
+        peg$c275 = peg$literalExpectation("~-", false),
+        peg$c276 = "~=",
+        peg$c277 = peg$literalExpectation("~=", false),
+        peg$c278 = "~",
+        peg$c279 = peg$literalExpectation("~", false),
+        peg$c280 = "-~-",
+        peg$c281 = peg$literalExpectation("-~-", false),
+        peg$c282 = "....",
+        peg$c283 = peg$literalExpectation("....", false),
+        peg$c284 = "...",
+        peg$c285 = peg$literalExpectation("...", false),
+        peg$c286 = "<-",
+        peg$c287 = peg$literalExpectation("<-", false),
+        peg$c288 = "->",
+        peg$c289 = peg$literalExpectation("->", false),
+        peg$c290 = "1",
+        peg$c291 = peg$literalExpectation("1", false),
+        peg$c292 = "2",
+        peg$c293 = peg$literalExpectation("2", false),
+        peg$c294 = "3",
+        peg$c295 = peg$literalExpectation("3", false),
+        peg$c296 = "{math}",
+        peg$c297 = peg$literalExpectation("{math}", false),
+        peg$c298 = function(c) { return c; },
+        peg$c299 = "\\}",
+        peg$c300 = peg$literalExpectation("\\}", false),
+        peg$c301 = /^[+-=#().,;\/*<>|@&'[\]]/,
+        peg$c302 = peg$classExpectation([["+", "="], "#", "(", ")", ".", ",", ";", "/", "*", "<", ">", "|", "@", "&", "'", "[", "]"], false, false),
+        peg$c303 = function() { return "{}"; },
+        peg$c304 = function() { return false; },
+        peg$c305 = function() { return peg$currPos === input.length; },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -601,7 +598,7 @@ module.exports = /*
     function peg$parsestart() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 0,
+      var key    = peg$currPos * 125 + 0,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -635,7 +632,7 @@ module.exports = /*
     function peg$parse_() {
       var s0, s1;
 
-      var key    = peg$currPos * 124 + 1,
+      var key    = peg$currPos * 125 + 1,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -671,7 +668,7 @@ module.exports = /*
     function peg$parsetex_expr() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 124 + 2,
+      var key    = peg$currPos * 125 + 2,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -765,7 +762,7 @@ module.exports = /*
     function peg$parseexpr() {
       var s0, s1;
 
-      var key    = peg$currPos * 124 + 3,
+      var key    = peg$currPos * 125 + 3,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -793,7 +790,7 @@ module.exports = /*
     function peg$parsene_expr() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 4,
+      var key    = peg$currPos * 125 + 4,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -863,7 +860,7 @@ module.exports = /*
     function peg$parselitsq_aq() {
       var s0;
 
-      var key    = peg$currPos * 124 + 5,
+      var key    = peg$currPos * 125 + 5,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -891,7 +888,7 @@ module.exports = /*
     function peg$parselitsq_fq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 6,
+      var key    = peg$currPos * 125 + 6,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -955,7 +952,7 @@ module.exports = /*
     function peg$parselitsq_uq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 7,
+      var key    = peg$currPos * 125 + 7,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -995,7 +992,7 @@ module.exports = /*
     function peg$parselitsq_dq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 8,
+      var key    = peg$currPos * 125 + 8,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1035,7 +1032,7 @@ module.exports = /*
     function peg$parselitsq_zq() {
       var s0, s1;
 
-      var key    = peg$currPos * 124 + 9,
+      var key    = peg$currPos * 125 + 9,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1060,7 +1057,7 @@ module.exports = /*
     function peg$parseexpr_nosqc() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 10,
+      var key    = peg$currPos * 125 + 10,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1103,7 +1100,7 @@ module.exports = /*
     function peg$parselit_aq() {
       var s0;
 
-      var key    = peg$currPos * 124 + 11,
+      var key    = peg$currPos * 125 + 11,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1137,7 +1134,7 @@ module.exports = /*
     function peg$parselit_fq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 12,
+      var key    = peg$currPos * 125 + 12,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1225,7 +1222,7 @@ module.exports = /*
     function peg$parselit_uq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 13,
+      var key    = peg$currPos * 125 + 13,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1265,7 +1262,7 @@ module.exports = /*
     function peg$parselit_dq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 14,
+      var key    = peg$currPos * 125 + 14,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1305,7 +1302,7 @@ module.exports = /*
     function peg$parselit_uqn() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 15,
+      var key    = peg$currPos * 125 + 15,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1339,7 +1336,7 @@ module.exports = /*
     function peg$parselit_dqn() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 16,
+      var key    = peg$currPos * 125 + 16,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1373,7 +1370,7 @@ module.exports = /*
     function peg$parseleft() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 17,
+      var key    = peg$currPos * 125 + 17,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1425,7 +1422,7 @@ module.exports = /*
     function peg$parseright() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 18,
+      var key    = peg$currPos * 125 + 18,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1477,7 +1474,7 @@ module.exports = /*
     function peg$parselit() {
       var s0, s1, s2, s3, s4, s5;
 
-      var key    = peg$currPos * 124 + 19,
+      var key    = peg$currPos * 125 + 19,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2252,7 +2249,7 @@ module.exports = /*
     function peg$parsearray() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 20,
+      var key    = peg$currPos * 125 + 20,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2286,7 +2283,7 @@ module.exports = /*
     function peg$parsealignat() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 21,
+      var key    = peg$currPos * 125 + 21,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2320,7 +2317,7 @@ module.exports = /*
     function peg$parsematrix() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 124 + 22,
+      var key    = peg$currPos * 125 + 22,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2372,7 +2369,7 @@ module.exports = /*
     function peg$parseline_start() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 23,
+      var key    = peg$currPos * 125 + 23,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2409,7 +2406,7 @@ module.exports = /*
     function peg$parseline() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 124 + 24,
+      var key    = peg$currPos * 125 + 24,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2461,7 +2458,7 @@ module.exports = /*
     function peg$parsecolumn_spec() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 124 + 25,
+      var key    = peg$currPos * 125 + 25,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2516,7 +2513,7 @@ module.exports = /*
     function peg$parseone_col() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-      var key    = peg$currPos * 124 + 26,
+      var key    = peg$currPos * 125 + 26,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2795,7 +2792,7 @@ module.exports = /*
     function peg$parsealignat_spec() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 124 + 27,
+      var key    = peg$currPos * 125 + 27,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2868,7 +2865,7 @@ module.exports = /*
     function peg$parseopt_pos() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 124 + 28,
+      var key    = peg$currPos * 125 + 28,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2946,7 +2943,7 @@ module.exports = /*
     function peg$parsechem_lit() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 29,
+      var key    = peg$currPos * 125 + 29,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2986,7 +2983,7 @@ module.exports = /*
     function peg$parsechem_sentence() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 124 + 30,
+      var key    = peg$currPos * 125 + 30,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3062,7 +3059,7 @@ module.exports = /*
     function peg$parsechem_phrase() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 31,
+      var key    = peg$currPos * 125 + 31,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3144,7 +3141,7 @@ module.exports = /*
     function peg$parsechem_word() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 32,
+      var key    = peg$currPos * 125 + 32,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3202,7 +3199,7 @@ module.exports = /*
     function peg$parsechem_word_nt() {
       var s0, s1;
 
-      var key    = peg$currPos * 124 + 33,
+      var key    = peg$currPos * 125 + 33,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3236,7 +3233,7 @@ module.exports = /*
     function peg$parsechem_char() {
       var s0, s1;
 
-      var key    = peg$currPos * 124 + 34,
+      var key    = peg$currPos * 125 + 34,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3270,7 +3267,7 @@ module.exports = /*
     function peg$parsechem_char_nl() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 35,
+      var key    = peg$currPos * 125 + 35,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3339,7 +3336,7 @@ module.exports = /*
               s2 = peg$parsechem_bond();
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c102(s1, s2);
+                s1 = peg$c28(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3379,7 +3376,7 @@ module.exports = /*
     function peg$parsechem_bond() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 36,
+      var key    = peg$currPos * 125 + 36,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3396,7 +3393,7 @@ module.exports = /*
           s3 = peg$parseCURLY_CLOSE();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c103(s2);
+            s1 = peg$c102(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3419,7 +3416,7 @@ module.exports = /*
     function peg$parsechem_script() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 124 + 37,
+      var key    = peg$currPos * 125 + 37,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3434,7 +3431,7 @@ module.exports = /*
         s2 = peg$parseCHEM_SCRIPT_FOLLOW();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c104(s1, s2);
+          s1 = peg$c103(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3451,7 +3448,7 @@ module.exports = /*
           s2 = peg$parsechem_lit();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c105(s1, s2);
+            s1 = peg$c104(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3472,7 +3469,7 @@ module.exports = /*
                 s4 = peg$parseEND_MATH();
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c106(s1, s3);
+                  s1 = peg$c105(s1, s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3501,7 +3498,7 @@ module.exports = /*
     function peg$parsechem_macro() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 124 + 38,
+      var key    = peg$currPos * 125 + 38,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3516,17 +3513,17 @@ module.exports = /*
         s2 = peg$parsechem_lit();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 95) {
-            s3 = peg$c107;
+            s3 = peg$c106;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c108); }
+            if (peg$silentFails === 0) { peg$fail(peg$c107); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parsechem_lit();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c109(s1, s2, s4);
+              s1 = peg$c108(s1, s2, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3548,12 +3545,12 @@ module.exports = /*
         s0 = peg$currPos;
         s1 = peg$parseCHEM_MACRO_2PC();
         if (s1 !== peg$FAILED) {
-          s2 = peg$parseCOLOR_SPEC_NAMED();
+          s2 = peg$parseCHEM_COLOR();
           if (s2 !== peg$FAILED) {
             s3 = peg$parsechem_lit();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c110(s1, s2, s3);
+              s1 = peg$c31(s1, s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3576,7 +3573,7 @@ module.exports = /*
               s3 = peg$parsechem_lit();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c111(s1, s2, s3);
+                s1 = peg$c31(s1, s2, s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3597,7 +3594,7 @@ module.exports = /*
               s2 = peg$parsechem_lit();
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c112(s1, s2);
+                s1 = peg$c28(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3619,7 +3616,7 @@ module.exports = /*
     function peg$parsechem_text() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 39,
+      var key    = peg$currPos * 125 + 39,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3641,9 +3638,88 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c113(s1);
+        s1 = peg$c109(s1);
       }
       s0 = s1;
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseCHEM_COLOR() {
+      var s0, s1, s2, s3, s4, s5, s6;
+
+      var key    = peg$currPos * 125 + 40,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 123) {
+        s1 = peg$c110;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c111); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse_();
+        if (s2 !== peg$FAILED) {
+          s3 = [];
+          s4 = peg$parsealpha();
+          if (s4 !== peg$FAILED) {
+            while (s4 !== peg$FAILED) {
+              s3.push(s4);
+              s4 = peg$parsealpha();
+            }
+          } else {
+            s3 = peg$FAILED;
+          }
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parse_();
+            if (s4 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 125) {
+                s5 = peg$c49;
+                peg$currPos++;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c50); }
+              }
+              if (s5 !== peg$FAILED) {
+                s6 = peg$parse_();
+                if (s6 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c112(s3);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
@@ -3653,7 +3729,7 @@ module.exports = /*
     function peg$parsealpha() {
       var s0;
 
-      var key    = peg$currPos * 124 + 40,
+      var key    = peg$currPos * 125 + 41,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3662,12 +3738,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c114.test(input.charAt(peg$currPos))) {
+      if (peg$c113.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c114); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3678,7 +3754,7 @@ module.exports = /*
     function peg$parseliteral_id() {
       var s0;
 
-      var key    = peg$currPos * 124 + 41,
+      var key    = peg$currPos * 125 + 42,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3687,12 +3763,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c114.test(input.charAt(peg$currPos))) {
+      if (peg$c113.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c114); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3703,7 +3779,7 @@ module.exports = /*
     function peg$parseliteral_mn() {
       var s0;
 
-      var key    = peg$currPos * 124 + 42,
+      var key    = peg$currPos * 125 + 43,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3728,7 +3804,7 @@ module.exports = /*
     function peg$parseliteral_uf_lt() {
       var s0;
 
-      var key    = peg$currPos * 124 + 43,
+      var key    = peg$currPos * 125 + 44,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3737,12 +3813,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c116.test(input.charAt(peg$currPos))) {
+      if (peg$c115.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c117); }
+        if (peg$silentFails === 0) { peg$fail(peg$c116); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3753,7 +3829,7 @@ module.exports = /*
     function peg$parsedelimiter_uf_lt() {
       var s0;
 
-      var key    = peg$currPos * 124 + 44,
+      var key    = peg$currPos * 125 + 45,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3762,12 +3838,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c118.test(input.charAt(peg$currPos))) {
+      if (peg$c117.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c119); }
+        if (peg$silentFails === 0) { peg$fail(peg$c118); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3778,7 +3854,7 @@ module.exports = /*
     function peg$parseliteral_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 124 + 45,
+      var key    = peg$currPos * 125 + 46,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3787,12 +3863,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c120.test(input.charAt(peg$currPos))) {
+      if (peg$c119.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c121); }
+        if (peg$silentFails === 0) { peg$fail(peg$c120); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3803,7 +3879,7 @@ module.exports = /*
     function peg$parsedelimiter_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 124 + 46,
+      var key    = peg$currPos * 125 + 47,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3812,12 +3888,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c122.test(input.charAt(peg$currPos))) {
+      if (peg$c121.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c123); }
+        if (peg$silentFails === 0) { peg$fail(peg$c122); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3828,7 +3904,7 @@ module.exports = /*
     function peg$parseboxchars() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 47,
+      var key    = peg$currPos * 125 + 48,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3837,33 +3913,33 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c124.test(input.charAt(peg$currPos))) {
+      if (peg$c123.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c125); }
+        if (peg$silentFails === 0) { peg$fail(peg$c124); }
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (peg$c126.test(input.charAt(peg$currPos))) {
+        if (peg$c125.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c127); }
+          if (peg$silentFails === 0) { peg$fail(peg$c126); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c128.test(input.charAt(peg$currPos))) {
+          if (peg$c127.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c129); }
+            if (peg$silentFails === 0) { peg$fail(peg$c128); }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c130(s1, s2);
+            s1 = peg$c129(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3883,7 +3959,7 @@ module.exports = /*
     function peg$parseBOX() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
-      var key    = peg$currPos * 124 + 48,
+      var key    = peg$currPos * 125 + 49,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3896,7 +3972,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c131(s1);
+        s2 = peg$c130(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -3906,11 +3982,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c132;
+              s4 = peg$c110;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c133); }
+              if (peg$silentFails === 0) { peg$fail(peg$c111); }
             }
             if (s4 !== peg$FAILED) {
               s5 = [];
@@ -3935,7 +4011,7 @@ module.exports = /*
                   s7 = peg$parse_();
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c134(s1, s5);
+                    s1 = peg$c131(s1, s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3974,7 +4050,7 @@ module.exports = /*
     function peg$parseLITERAL() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-      var key    = peg$currPos * 124 + 49,
+      var key    = peg$currPos * 125 + 50,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3991,11 +4067,11 @@ module.exports = /*
           s1 = peg$parseliteral_uf_lt();
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 45) {
-              s1 = peg$c135;
+              s1 = peg$c132;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c136); }
+              if (peg$silentFails === 0) { peg$fail(peg$c133); }
             }
             if (s1 === peg$FAILED) {
               s1 = peg$parseliteral_uf_op();
@@ -4007,7 +4083,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c137(s1);
+          s1 = peg$c134(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4022,7 +4098,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c138(s1);
+          s2 = peg$c135(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -4032,11 +4108,11 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s4 = peg$c139;
+                s4 = peg$c136;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c140); }
+                if (peg$silentFails === 0) { peg$fail(peg$c137); }
               }
               if (s4 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 91) {
@@ -4047,19 +4123,19 @@ module.exports = /*
                   if (peg$silentFails === 0) { peg$fail(peg$c79); }
                 }
                 if (s4 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c141) {
-                    s4 = peg$c141;
+                  if (input.substr(peg$currPos, 2) === peg$c138) {
+                    s4 = peg$c138;
                     peg$currPos += 2;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c142); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c139); }
                   }
                   if (s4 === peg$FAILED) {
                     s4 = peg$currPos;
                     s5 = peg$c6;
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s4;
-                      s5 = peg$c143(s1);
+                      s5 = peg$c140(s1);
                     }
                     s4 = s5;
                   }
@@ -4069,7 +4145,7 @@ module.exports = /*
                 s5 = peg$parse_();
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c144(s1, s4);
+                  s1 = peg$c141(s1, s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4096,7 +4172,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c145(s1);
+            s2 = peg$c142(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -4106,11 +4182,11 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s4 = peg$c139;
+                  s4 = peg$c136;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c140); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c137); }
                 }
                 if (s4 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 91) {
@@ -4121,19 +4197,19 @@ module.exports = /*
                     if (peg$silentFails === 0) { peg$fail(peg$c79); }
                   }
                   if (s4 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 2) === peg$c141) {
-                      s4 = peg$c141;
+                    if (input.substr(peg$currPos, 2) === peg$c138) {
+                      s4 = peg$c138;
                       peg$currPos += 2;
                     } else {
                       s4 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c142); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c139); }
                     }
                     if (s4 === peg$FAILED) {
                       s4 = peg$currPos;
                       s5 = peg$c6;
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s4;
-                        s5 = peg$c143(s1);
+                        s5 = peg$c140(s1);
                       }
                       s4 = s5;
                     }
@@ -4143,7 +4219,7 @@ module.exports = /*
                   s5 = peg$parse_();
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c146(s1, s4);
+                    s1 = peg$c143(s1, s4);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4170,7 +4246,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c147(s1);
+              s2 = peg$c144(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -4180,7 +4256,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c148(s1);
+                  s1 = peg$c145(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4199,7 +4275,7 @@ module.exports = /*
               s1 = peg$parsegeneric_func();
               if (s1 !== peg$FAILED) {
                 peg$savedPos = peg$currPos;
-                s2 = peg$c149(s1);
+                s2 = peg$c146(s1);
                 if (s2) {
                   s2 = void 0;
                 } else {
@@ -4209,7 +4285,7 @@ module.exports = /*
                   s3 = peg$parse_();
                   if (s3 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c150(s1);
+                    s1 = peg$c147(s1);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4228,7 +4304,7 @@ module.exports = /*
                 s1 = peg$parsegeneric_func();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = peg$currPos;
-                  s2 = peg$c151(s1);
+                  s2 = peg$c148(s1);
                   if (s2) {
                     s2 = void 0;
                   } else {
@@ -4238,17 +4314,17 @@ module.exports = /*
                     s3 = peg$parse_();
                     if (s3 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 123) {
-                        s4 = peg$c132;
+                        s4 = peg$c110;
                         peg$currPos++;
                       } else {
                         s4 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c111); }
                       }
                       if (s4 !== peg$FAILED) {
                         s5 = peg$parsegeneric_func();
                         if (s5 !== peg$FAILED) {
                           peg$savedPos = peg$currPos;
-                          s6 = peg$c152(s1, s5);
+                          s6 = peg$c149(s1, s5);
                           if (s6) {
                             s6 = void 0;
                           } else {
@@ -4268,7 +4344,7 @@ module.exports = /*
                                 s9 = peg$parse_();
                                 if (s9 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c153(s1, s5);
+                                  s1 = peg$c150(s1, s5);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -4311,7 +4387,7 @@ module.exports = /*
                   s1 = peg$parsegeneric_func();
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = peg$currPos;
-                    s2 = peg$c154(s1);
+                    s2 = peg$c151(s1);
                     if (s2) {
                       s2 = void 0;
                     } else {
@@ -4321,7 +4397,7 @@ module.exports = /*
                       s3 = peg$parse_();
                       if (s3 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c155(s1);
+                        s1 = peg$c152(s1);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -4340,7 +4416,7 @@ module.exports = /*
                     s1 = peg$parsegeneric_func();
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = peg$currPos;
-                      s2 = peg$c156(s1);
+                      s2 = peg$c153(s1);
                       if (s2) {
                         s2 = void 0;
                       } else {
@@ -4350,17 +4426,17 @@ module.exports = /*
                         s3 = peg$parse_();
                         if (s3 !== peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 123) {
-                            s4 = peg$c132;
+                            s4 = peg$c110;
                             peg$currPos++;
                           } else {
                             s4 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c133); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c111); }
                           }
                           if (s4 !== peg$FAILED) {
                             s5 = peg$parsegeneric_func();
                             if (s5 !== peg$FAILED) {
                               peg$savedPos = peg$currPos;
-                              s6 = peg$c157(s1, s5);
+                              s6 = peg$c154(s1, s5);
                               if (s6) {
                                 s6 = void 0;
                               } else {
@@ -4380,7 +4456,7 @@ module.exports = /*
                                     s9 = peg$parse_();
                                     if (s9 !== peg$FAILED) {
                                       peg$savedPos = s0;
-                                      s1 = peg$c158(s1, s5);
+                                      s1 = peg$c155(s1, s5);
                                       s0 = s1;
                                     } else {
                                       peg$currPos = s0;
@@ -4426,31 +4502,31 @@ module.exports = /*
                       }
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c159(s1);
+                        s1 = peg$c156(s1);
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
                         if (input.charCodeAt(peg$currPos) === 92) {
-                          s1 = peg$c160;
+                          s1 = peg$c157;
                           peg$currPos++;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c161); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c158); }
                         }
                         if (s1 !== peg$FAILED) {
-                          if (peg$c162.test(input.charAt(peg$currPos))) {
+                          if (peg$c159.test(input.charAt(peg$currPos))) {
                             s2 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s2 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c163); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c160); }
                           }
                           if (s2 !== peg$FAILED) {
                             s3 = peg$parse_();
                             if (s3 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c164(s2);
+                              s1 = peg$c161(s2);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -4466,18 +4542,18 @@ module.exports = /*
                         }
                         if (s0 === peg$FAILED) {
                           s0 = peg$currPos;
-                          if (peg$c165.test(input.charAt(peg$currPos))) {
+                          if (peg$c162.test(input.charAt(peg$currPos))) {
                             s1 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c166); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c163); }
                           }
                           if (s1 !== peg$FAILED) {
                             s2 = peg$parse_();
                             if (s2 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c137(s1);
+                              s1 = peg$c134(s1);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -4489,18 +4565,18 @@ module.exports = /*
                           }
                           if (s0 === peg$FAILED) {
                             s0 = peg$currPos;
-                            if (peg$c167.test(input.charAt(peg$currPos))) {
+                            if (peg$c164.test(input.charAt(peg$currPos))) {
                               s1 = input.charAt(peg$currPos);
                               peg$currPos++;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c168); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c165); }
                             }
                             if (s1 !== peg$FAILED) {
                               s2 = peg$parse_();
                               if (s2 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c169(s1);
+                                s1 = peg$c166(s1);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -4530,7 +4606,7 @@ module.exports = /*
     function peg$parseDELIMITER() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 50,
+      var key    = peg$currPos * 125 + 51,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4557,7 +4633,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c137(s1);
+          s1 = peg$c134(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4570,25 +4646,25 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c160;
+          s1 = peg$c157;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c161); }
+          if (peg$silentFails === 0) { peg$fail(peg$c158); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c170.test(input.charAt(peg$currPos))) {
+          if (peg$c167.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c171); }
+            if (peg$silentFails === 0) { peg$fail(peg$c168); }
           }
           if (s2 !== peg$FAILED) {
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c164(s2);
+              s1 = peg$c161(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4607,7 +4683,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c172(s1);
+            s2 = peg$c169(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -4617,7 +4693,7 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c148(s1);
+                s1 = peg$c145(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4636,7 +4712,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c173(s1);
+              s2 = peg$c170(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -4646,7 +4722,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c174(s1);
+                  s1 = peg$c171(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4672,7 +4748,7 @@ module.exports = /*
     function peg$parseFUN_AR1nb() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 51,
+      var key    = peg$currPos * 125 + 52,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4685,7 +4761,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c175(s1);
+        s2 = peg$c172(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -4695,7 +4771,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c173(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4718,7 +4794,7 @@ module.exports = /*
     function peg$parseFUN_AR1opt() {
       var s0, s1, s2, s3, s4, s5;
 
-      var key    = peg$currPos * 124 + 52,
+      var key    = peg$currPos * 125 + 53,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4731,7 +4807,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c177(s1);
+        s2 = peg$c174(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -4751,7 +4827,7 @@ module.exports = /*
               s5 = peg$parse_();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c176(s1);
+                s1 = peg$c173(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4782,7 +4858,7 @@ module.exports = /*
     function peg$parseNEXT_CELL() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 53,
+      var key    = peg$currPos * 125 + 54,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4793,11 +4869,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 38) {
-        s1 = peg$c178;
+        s1 = peg$c175;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c179); }
+        if (peg$silentFails === 0) { peg$fail(peg$c176); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4821,7 +4897,7 @@ module.exports = /*
     function peg$parseNEXT_ROW() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 54,
+      var key    = peg$currPos * 125 + 55,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4831,12 +4907,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c180) {
-        s1 = peg$c180;
+      if (input.substr(peg$currPos, 2) === peg$c177) {
+        s1 = peg$c177;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c181); }
+        if (peg$silentFails === 0) { peg$fail(peg$c178); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4860,7 +4936,7 @@ module.exports = /*
     function peg$parseBEGIN() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 55,
+      var key    = peg$currPos * 125 + 56,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4870,12 +4946,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c182) {
-        s1 = peg$c182;
+      if (input.substr(peg$currPos, 6) === peg$c179) {
+        s1 = peg$c179;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c180); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4899,7 +4975,7 @@ module.exports = /*
     function peg$parseEND() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 56,
+      var key    = peg$currPos * 125 + 57,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4909,12 +4985,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c184) {
-        s1 = peg$c184;
+      if (input.substr(peg$currPos, 4) === peg$c181) {
+        s1 = peg$c181;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c185); }
+        if (peg$silentFails === 0) { peg$fail(peg$c182); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4938,7 +5014,7 @@ module.exports = /*
     function peg$parseBEGIN_MATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 57,
+      var key    = peg$currPos * 125 + 58,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4950,12 +5026,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c186) {
-          s2 = peg$c186;
+        if (input.substr(peg$currPos, 8) === peg$c183) {
+          s2 = peg$c183;
           peg$currPos += 8;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c187); }
+          if (peg$silentFails === 0) { peg$fail(peg$c184); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4983,7 +5059,7 @@ module.exports = /*
     function peg$parseEND_MATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 58,
+      var key    = peg$currPos * 125 + 59,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4995,12 +5071,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c186) {
-          s2 = peg$c186;
+        if (input.substr(peg$currPos, 8) === peg$c183) {
+          s2 = peg$c183;
           peg$currPos += 8;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c187); }
+          if (peg$silentFails === 0) { peg$fail(peg$c184); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5028,7 +5104,7 @@ module.exports = /*
     function peg$parseBEGIN_PMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 59,
+      var key    = peg$currPos * 125 + 60,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5040,12 +5116,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c188) {
-          s2 = peg$c188;
+        if (input.substr(peg$currPos, 9) === peg$c185) {
+          s2 = peg$c185;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c189); }
+          if (peg$silentFails === 0) { peg$fail(peg$c186); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5073,7 +5149,7 @@ module.exports = /*
     function peg$parseEND_PMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 60,
+      var key    = peg$currPos * 125 + 61,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5085,12 +5161,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c188) {
-          s2 = peg$c188;
+        if (input.substr(peg$currPos, 9) === peg$c185) {
+          s2 = peg$c185;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c189); }
+          if (peg$silentFails === 0) { peg$fail(peg$c186); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5118,7 +5194,7 @@ module.exports = /*
     function peg$parseBEGIN_BMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 61,
+      var key    = peg$currPos * 125 + 62,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5130,12 +5206,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c190) {
-          s2 = peg$c190;
+        if (input.substr(peg$currPos, 9) === peg$c187) {
+          s2 = peg$c187;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c191); }
+          if (peg$silentFails === 0) { peg$fail(peg$c188); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5163,7 +5239,7 @@ module.exports = /*
     function peg$parseEND_BMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 62,
+      var key    = peg$currPos * 125 + 63,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5175,12 +5251,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c190) {
-          s2 = peg$c190;
+        if (input.substr(peg$currPos, 9) === peg$c187) {
+          s2 = peg$c187;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c191); }
+          if (peg$silentFails === 0) { peg$fail(peg$c188); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5208,7 +5284,7 @@ module.exports = /*
     function peg$parseBEGIN_BBMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 63,
+      var key    = peg$currPos * 125 + 64,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5220,12 +5296,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c192) {
-          s2 = peg$c192;
+        if (input.substr(peg$currPos, 9) === peg$c189) {
+          s2 = peg$c189;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c193); }
+          if (peg$silentFails === 0) { peg$fail(peg$c190); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5253,7 +5329,7 @@ module.exports = /*
     function peg$parseEND_BBMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 64,
+      var key    = peg$currPos * 125 + 65,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5265,12 +5341,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c192) {
-          s2 = peg$c192;
+        if (input.substr(peg$currPos, 9) === peg$c189) {
+          s2 = peg$c189;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c193); }
+          if (peg$silentFails === 0) { peg$fail(peg$c190); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5298,7 +5374,7 @@ module.exports = /*
     function peg$parseBEGIN_VMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 65,
+      var key    = peg$currPos * 125 + 66,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5310,12 +5386,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c194) {
-          s2 = peg$c194;
+        if (input.substr(peg$currPos, 9) === peg$c191) {
+          s2 = peg$c191;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c195); }
+          if (peg$silentFails === 0) { peg$fail(peg$c192); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5343,7 +5419,7 @@ module.exports = /*
     function peg$parseEND_VMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 66,
+      var key    = peg$currPos * 125 + 67,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5355,12 +5431,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c194) {
-          s2 = peg$c194;
+        if (input.substr(peg$currPos, 9) === peg$c191) {
+          s2 = peg$c191;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c195); }
+          if (peg$silentFails === 0) { peg$fail(peg$c192); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5388,7 +5464,7 @@ module.exports = /*
     function peg$parseBEGIN_VVMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 67,
+      var key    = peg$currPos * 125 + 68,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5400,12 +5476,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c196) {
-          s2 = peg$c196;
+        if (input.substr(peg$currPos, 9) === peg$c193) {
+          s2 = peg$c193;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c197); }
+          if (peg$silentFails === 0) { peg$fail(peg$c194); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5433,7 +5509,7 @@ module.exports = /*
     function peg$parseEND_VVMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 68,
+      var key    = peg$currPos * 125 + 69,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5445,12 +5521,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c196) {
-          s2 = peg$c196;
+        if (input.substr(peg$currPos, 9) === peg$c193) {
+          s2 = peg$c193;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c197); }
+          if (peg$silentFails === 0) { peg$fail(peg$c194); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5478,7 +5554,7 @@ module.exports = /*
     function peg$parseBEGIN_ARRAY() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 69,
+      var key    = peg$currPos * 125 + 70,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5490,12 +5566,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c198) {
-          s2 = peg$c198;
+        if (input.substr(peg$currPos, 7) === peg$c195) {
+          s2 = peg$c195;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c199); }
+          if (peg$silentFails === 0) { peg$fail(peg$c196); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5523,7 +5599,7 @@ module.exports = /*
     function peg$parseEND_ARRAY() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 70,
+      var key    = peg$currPos * 125 + 71,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5535,12 +5611,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c198) {
-          s2 = peg$c198;
+        if (input.substr(peg$currPos, 7) === peg$c195) {
+          s2 = peg$c195;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c199); }
+          if (peg$silentFails === 0) { peg$fail(peg$c196); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5568,7 +5644,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGN() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 71,
+      var key    = peg$currPos * 125 + 72,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5580,12 +5656,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c200) {
-          s2 = peg$c200;
+        if (input.substr(peg$currPos, 7) === peg$c197) {
+          s2 = peg$c197;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c201); }
+          if (peg$silentFails === 0) { peg$fail(peg$c198); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5613,7 +5689,7 @@ module.exports = /*
     function peg$parseEND_ALIGN() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 72,
+      var key    = peg$currPos * 125 + 73,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5625,12 +5701,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c200) {
-          s2 = peg$c200;
+        if (input.substr(peg$currPos, 7) === peg$c197) {
+          s2 = peg$c197;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c201); }
+          if (peg$silentFails === 0) { peg$fail(peg$c198); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5658,7 +5734,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNED() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 73,
+      var key    = peg$currPos * 125 + 74,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5670,12 +5746,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c202) {
-          s2 = peg$c202;
+        if (input.substr(peg$currPos, 9) === peg$c199) {
+          s2 = peg$c199;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c203); }
+          if (peg$silentFails === 0) { peg$fail(peg$c200); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5703,7 +5779,7 @@ module.exports = /*
     function peg$parseEND_ALIGNED() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 74,
+      var key    = peg$currPos * 125 + 75,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5715,12 +5791,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c202) {
-          s2 = peg$c202;
+        if (input.substr(peg$currPos, 9) === peg$c199) {
+          s2 = peg$c199;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c203); }
+          if (peg$silentFails === 0) { peg$fail(peg$c200); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5748,7 +5824,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 75,
+      var key    = peg$currPos * 125 + 76,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5760,12 +5836,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c204) {
-          s2 = peg$c204;
+        if (input.substr(peg$currPos, 9) === peg$c201) {
+          s2 = peg$c201;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c205); }
+          if (peg$silentFails === 0) { peg$fail(peg$c202); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5793,7 +5869,7 @@ module.exports = /*
     function peg$parseEND_ALIGNAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 76,
+      var key    = peg$currPos * 125 + 77,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5805,12 +5881,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c204) {
-          s2 = peg$c204;
+        if (input.substr(peg$currPos, 9) === peg$c201) {
+          s2 = peg$c201;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c205); }
+          if (peg$silentFails === 0) { peg$fail(peg$c202); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5838,7 +5914,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNEDAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 77,
+      var key    = peg$currPos * 125 + 78,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5850,12 +5926,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c206) {
-          s2 = peg$c206;
+        if (input.substr(peg$currPos, 11) === peg$c203) {
+          s2 = peg$c203;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c207); }
+          if (peg$silentFails === 0) { peg$fail(peg$c204); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5883,7 +5959,7 @@ module.exports = /*
     function peg$parseEND_ALIGNEDAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 78,
+      var key    = peg$currPos * 125 + 79,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5895,12 +5971,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c206) {
-          s2 = peg$c206;
+        if (input.substr(peg$currPos, 11) === peg$c203) {
+          s2 = peg$c203;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c207); }
+          if (peg$silentFails === 0) { peg$fail(peg$c204); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5928,7 +6004,7 @@ module.exports = /*
     function peg$parseBEGIN_SMALLMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 79,
+      var key    = peg$currPos * 125 + 80,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5940,12 +6016,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c208) {
-          s2 = peg$c208;
+        if (input.substr(peg$currPos, 13) === peg$c205) {
+          s2 = peg$c205;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c209); }
+          if (peg$silentFails === 0) { peg$fail(peg$c206); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5973,7 +6049,7 @@ module.exports = /*
     function peg$parseEND_SMALLMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 80,
+      var key    = peg$currPos * 125 + 81,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5985,12 +6061,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c208) {
-          s2 = peg$c208;
+        if (input.substr(peg$currPos, 13) === peg$c205) {
+          s2 = peg$c205;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c209); }
+          if (peg$silentFails === 0) { peg$fail(peg$c206); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6018,7 +6094,7 @@ module.exports = /*
     function peg$parseBEGIN_CASES() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 81,
+      var key    = peg$currPos * 125 + 82,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6030,12 +6106,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c210) {
-          s2 = peg$c210;
+        if (input.substr(peg$currPos, 7) === peg$c207) {
+          s2 = peg$c207;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c211); }
+          if (peg$silentFails === 0) { peg$fail(peg$c208); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6063,7 +6139,7 @@ module.exports = /*
     function peg$parseEND_CASES() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 82,
+      var key    = peg$currPos * 125 + 83,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6075,12 +6151,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c210) {
-          s2 = peg$c210;
+        if (input.substr(peg$currPos, 7) === peg$c207) {
+          s2 = peg$c207;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c211); }
+          if (peg$silentFails === 0) { peg$fail(peg$c208); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6108,7 +6184,7 @@ module.exports = /*
     function peg$parseSQ_CLOSE() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 83,
+      var key    = peg$currPos * 125 + 84,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6147,7 +6223,7 @@ module.exports = /*
     function peg$parseCURLY_OPEN() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 84,
+      var key    = peg$currPos * 125 + 85,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6158,11 +6234,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c110;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c111); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6186,7 +6262,7 @@ module.exports = /*
     function peg$parseCURLY_CLOSE() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 85,
+      var key    = peg$currPos * 125 + 86,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6225,7 +6301,7 @@ module.exports = /*
     function peg$parseSUP() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 86,
+      var key    = peg$currPos * 125 + 87,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6264,7 +6340,7 @@ module.exports = /*
     function peg$parseSUB() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 87,
+      var key    = peg$currPos * 125 + 88,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6275,11 +6351,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 95) {
-        s1 = peg$c107;
+        s1 = peg$c106;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c108); }
+        if (peg$silentFails === 0) { peg$fail(peg$c107); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6303,7 +6379,7 @@ module.exports = /*
     function peg$parsegeneric_func() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 88,
+      var key    = peg$currPos * 125 + 89,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6314,11 +6390,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c160;
+        s1 = peg$c157;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c161); }
+        if (peg$silentFails === 0) { peg$fail(peg$c158); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -6352,7 +6428,7 @@ module.exports = /*
     function peg$parseBIG() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 89,
+      var key    = peg$currPos * 125 + 90,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6365,7 +6441,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c212(s1);
+        s2 = peg$c209(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6375,7 +6451,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c173(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6398,7 +6474,7 @@ module.exports = /*
     function peg$parseFUN_AR1() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 90,
+      var key    = peg$currPos * 125 + 91,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6411,7 +6487,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c213(s1);
+        s2 = peg$c210(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6421,7 +6497,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c173(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6440,7 +6516,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c214(s1);
+          s2 = peg$c211(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -6450,7 +6526,7 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c214(s1);
+              s1 = peg$c211(s1);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6474,7 +6550,7 @@ module.exports = /*
     function peg$parseFUN_MHCHEM() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 91,
+      var key    = peg$currPos * 125 + 92,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6487,7 +6563,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c215(s1);
+        s2 = peg$c212(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6497,7 +6573,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c173(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6520,7 +6596,7 @@ module.exports = /*
     function peg$parseFUN_AR2() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 92,
+      var key    = peg$currPos * 125 + 93,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6533,7 +6609,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c216(s1);
+        s2 = peg$c213(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6543,7 +6619,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c173(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6566,7 +6642,7 @@ module.exports = /*
     function peg$parseFUN_INFIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 93,
+      var key    = peg$currPos * 125 + 94,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6579,7 +6655,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c217(s1);
+        s2 = peg$c214(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6589,7 +6665,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c173(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6612,7 +6688,7 @@ module.exports = /*
     function peg$parseDECLh() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 94,
+      var key    = peg$currPos * 125 + 95,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6625,7 +6701,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c218(s1);
+        s2 = peg$c215(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6635,7 +6711,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c219(s1);
+            s1 = peg$c216(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6658,7 +6734,7 @@ module.exports = /*
     function peg$parseFUN_AR2nb() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 95,
+      var key    = peg$currPos * 125 + 96,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6671,7 +6747,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c220(s1);
+        s2 = peg$c217(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6681,7 +6757,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c173(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6704,7 +6780,7 @@ module.exports = /*
     function peg$parseLEFT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 96,
+      var key    = peg$currPos * 125 + 97,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6717,7 +6793,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c221(s1);
+        s2 = peg$c218(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6749,7 +6825,7 @@ module.exports = /*
     function peg$parseRIGHT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 97,
+      var key    = peg$currPos * 125 + 98,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6762,7 +6838,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c222(s1);
+        s2 = peg$c219(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6794,7 +6870,7 @@ module.exports = /*
     function peg$parseHLINE() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 98,
+      var key    = peg$currPos * 125 + 99,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6807,7 +6883,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c223(s1);
+        s2 = peg$c220(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6817,7 +6893,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c173(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6840,7 +6916,7 @@ module.exports = /*
     function peg$parseCOLOR() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 124 + 99,
+      var key    = peg$currPos * 125 + 100,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6853,7 +6929,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c224(s1);
+        s2 = peg$c221(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6865,7 +6941,7 @@ module.exports = /*
             s4 = peg$parseCOLOR_SPEC();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c225(s1, s4);
+              s1 = peg$c222(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6892,7 +6968,7 @@ module.exports = /*
     function peg$parseDEFINECOLOR() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17;
 
-      var key    = peg$currPos * 124 + 100,
+      var key    = peg$currPos * 125 + 101,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6905,7 +6981,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c226(s1);
+        s2 = peg$c223(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6915,11 +6991,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c132;
+              s4 = peg$c110;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c133); }
+              if (peg$silentFails === 0) { peg$fail(peg$c111); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -6948,22 +7024,22 @@ module.exports = /*
                       s9 = peg$parse_();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 123) {
-                          s10 = peg$c132;
+                          s10 = peg$c110;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c133); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c111); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             s12 = peg$currPos;
-                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c227) {
+                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c224) {
                               s13 = input.substr(peg$currPos, 5);
                               peg$currPos += 5;
                             } else {
                               s13 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c228); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c225); }
                             }
                             if (s13 !== peg$FAILED) {
                               s14 = peg$parse_();
@@ -6981,7 +7057,7 @@ module.exports = /*
                                     s17 = peg$parseCOLOR_SPEC_NAMED();
                                     if (s17 !== peg$FAILED) {
                                       peg$savedPos = s12;
-                                      s13 = peg$c229(s1, s6, s17);
+                                      s13 = peg$c226(s1, s6, s17);
                                       s12 = s13;
                                     } else {
                                       peg$currPos = s12;
@@ -7005,12 +7081,12 @@ module.exports = /*
                             }
                             if (s12 === peg$FAILED) {
                               s12 = peg$currPos;
-                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c230) {
+                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c227) {
                                 s13 = input.substr(peg$currPos, 4);
                                 peg$currPos += 4;
                               } else {
                                 s13 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c231); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c228); }
                               }
                               if (s13 !== peg$FAILED) {
                                 s14 = peg$parse_();
@@ -7028,7 +7104,7 @@ module.exports = /*
                                       s17 = peg$parseCOLOR_SPEC_GRAY();
                                       if (s17 !== peg$FAILED) {
                                         peg$savedPos = s12;
-                                        s13 = peg$c232(s1, s6, s17);
+                                        s13 = peg$c229(s1, s6, s17);
                                         s12 = s13;
                                       } else {
                                         peg$currPos = s12;
@@ -7052,12 +7128,12 @@ module.exports = /*
                               }
                               if (s12 === peg$FAILED) {
                                 s12 = peg$currPos;
-                                if (input.substr(peg$currPos, 3) === peg$c233) {
-                                  s13 = peg$c233;
+                                if (input.substr(peg$currPos, 3) === peg$c230) {
+                                  s13 = peg$c230;
                                   peg$currPos += 3;
                                 } else {
                                   s13 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c234); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c231); }
                                 }
                                 if (s13 !== peg$FAILED) {
                                   s14 = peg$parse_();
@@ -7075,7 +7151,7 @@ module.exports = /*
                                         s17 = peg$parseCOLOR_SPEC_rgb();
                                         if (s17 !== peg$FAILED) {
                                           peg$savedPos = s12;
-                                          s13 = peg$c235(s1, s6, s17);
+                                          s13 = peg$c232(s1, s6, s17);
                                           s12 = s13;
                                         } else {
                                           peg$currPos = s12;
@@ -7099,12 +7175,12 @@ module.exports = /*
                                 }
                                 if (s12 === peg$FAILED) {
                                   s12 = peg$currPos;
-                                  if (input.substr(peg$currPos, 3) === peg$c236) {
-                                    s13 = peg$c236;
+                                  if (input.substr(peg$currPos, 3) === peg$c233) {
+                                    s13 = peg$c233;
                                     peg$currPos += 3;
                                   } else {
                                     s13 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c237); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c234); }
                                   }
                                   if (s13 !== peg$FAILED) {
                                     s14 = peg$parse_();
@@ -7122,7 +7198,7 @@ module.exports = /*
                                           s17 = peg$parseCOLOR_SPEC_RGB();
                                           if (s17 !== peg$FAILED) {
                                             peg$savedPos = s12;
-                                            s13 = peg$c235(s1, s6, s17);
+                                            s13 = peg$c232(s1, s6, s17);
                                             s12 = s13;
                                           } else {
                                             peg$currPos = s12;
@@ -7146,12 +7222,12 @@ module.exports = /*
                                   }
                                   if (s12 === peg$FAILED) {
                                     s12 = peg$currPos;
-                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c238) {
+                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c235) {
                                       s13 = input.substr(peg$currPos, 4);
                                       peg$currPos += 4;
                                     } else {
                                       s13 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c239); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c236); }
                                     }
                                     if (s13 !== peg$FAILED) {
                                       s14 = peg$parse_();
@@ -7169,7 +7245,7 @@ module.exports = /*
                                             s17 = peg$parseCOLOR_SPEC_CMYK();
                                             if (s17 !== peg$FAILED) {
                                               peg$savedPos = s12;
-                                              s13 = peg$c240(s1, s6, s17);
+                                              s13 = peg$c237(s1, s6, s17);
                                               s12 = s13;
                                             } else {
                                               peg$currPos = s12;
@@ -7197,7 +7273,7 @@ module.exports = /*
                             }
                             if (s12 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c241(s1, s6, s12);
+                              s1 = peg$c238(s1, s6, s12);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -7256,7 +7332,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
-      var key    = peg$currPos * 124 + 101,
+      var key    = peg$currPos * 125 + 102,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7278,12 +7354,12 @@ module.exports = /*
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c227) {
+            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c224) {
               s3 = input.substr(peg$currPos, 5);
               peg$currPos += 5;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c228); }
+              if (peg$silentFails === 0) { peg$fail(peg$c225); }
             }
             if (s3 !== peg$FAILED) {
               s4 = peg$parse_();
@@ -7301,7 +7377,7 @@ module.exports = /*
                     s7 = peg$parseCOLOR_SPEC_NAMED();
                     if (s7 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c242(s7);
+                      s1 = peg$c239(s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -7343,12 +7419,12 @@ module.exports = /*
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c230) {
+              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c227) {
                 s3 = input.substr(peg$currPos, 4);
                 peg$currPos += 4;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c231); }
+                if (peg$silentFails === 0) { peg$fail(peg$c228); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -7366,7 +7442,7 @@ module.exports = /*
                       s7 = peg$parseCOLOR_SPEC_GRAY();
                       if (s7 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c243(s7);
+                        s1 = peg$c240(s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -7408,12 +7484,12 @@ module.exports = /*
             if (s1 !== peg$FAILED) {
               s2 = peg$parse_();
               if (s2 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 3) === peg$c233) {
-                  s3 = peg$c233;
+                if (input.substr(peg$currPos, 3) === peg$c230) {
+                  s3 = peg$c230;
                   peg$currPos += 3;
                 } else {
                   s3 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c234); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c231); }
                 }
                 if (s3 !== peg$FAILED) {
                   s4 = peg$parse_();
@@ -7431,7 +7507,7 @@ module.exports = /*
                         s7 = peg$parseCOLOR_SPEC_rgb();
                         if (s7 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c244(s7);
+                          s1 = peg$c241(s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -7473,12 +7549,12 @@ module.exports = /*
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse_();
                 if (s2 !== peg$FAILED) {
-                  if (input.substr(peg$currPos, 3) === peg$c236) {
-                    s3 = peg$c236;
+                  if (input.substr(peg$currPos, 3) === peg$c233) {
+                    s3 = peg$c233;
                     peg$currPos += 3;
                   } else {
                     s3 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c237); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c234); }
                   }
                   if (s3 !== peg$FAILED) {
                     s4 = peg$parse_();
@@ -7496,7 +7572,7 @@ module.exports = /*
                           s7 = peg$parseCOLOR_SPEC_RGB();
                           if (s7 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c244(s7);
+                            s1 = peg$c241(s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7538,12 +7614,12 @@ module.exports = /*
                 if (s1 !== peg$FAILED) {
                   s2 = peg$parse_();
                   if (s2 !== peg$FAILED) {
-                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c238) {
+                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c235) {
                       s3 = input.substr(peg$currPos, 4);
                       peg$currPos += 4;
                     } else {
                       s3 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c239); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c236); }
                     }
                     if (s3 !== peg$FAILED) {
                       s4 = peg$parse_();
@@ -7561,7 +7637,7 @@ module.exports = /*
                             s7 = peg$parseCOLOR_SPEC_CMYK();
                             if (s7 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c245(s7);
+                              s1 = peg$c242(s7);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -7605,7 +7681,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_NAMED() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 124 + 102,
+      var key    = peg$currPos * 125 + 103,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7616,11 +7692,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c110;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c111); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7649,7 +7725,7 @@ module.exports = /*
                 s6 = peg$parse_();
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c246(s3);
+                  s1 = peg$c243(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7684,7 +7760,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_GRAY() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 124 + 103,
+      var key    = peg$currPos * 125 + 104,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7695,11 +7771,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c110;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c111); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7724,7 +7800,7 @@ module.exports = /*
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c247(s3);
+              s1 = peg$c244(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7751,7 +7827,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_rgb() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-      var key    = peg$currPos * 124 + 104,
+      var key    = peg$currPos * 125 + 105,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7762,11 +7838,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c110;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c111); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7774,11 +7850,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c248;
+              s4 = peg$c245;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c249); }
+              if (peg$silentFails === 0) { peg$fail(peg$c246); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7786,11 +7862,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c248;
+                    s7 = peg$c245;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c249); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c246); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -7808,7 +7884,7 @@ module.exports = /*
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c250(s3, s6, s9);
+                            s1 = peg$c247(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7863,7 +7939,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_RGB() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-      var key    = peg$currPos * 124 + 105,
+      var key    = peg$currPos * 125 + 106,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7874,11 +7950,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c110;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c111); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7886,11 +7962,11 @@ module.exports = /*
           s3 = peg$parseCNUM255();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c248;
+              s4 = peg$c245;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c249); }
+              if (peg$silentFails === 0) { peg$fail(peg$c246); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7898,11 +7974,11 @@ module.exports = /*
                 s6 = peg$parseCNUM255();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c248;
+                    s7 = peg$c245;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c249); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c246); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -7920,7 +7996,7 @@ module.exports = /*
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c250(s3, s6, s9);
+                            s1 = peg$c247(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7975,7 +8051,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_CMYK() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14;
 
-      var key    = peg$currPos * 124 + 106,
+      var key    = peg$currPos * 125 + 107,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7986,11 +8062,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c132;
+        s1 = peg$c110;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c111); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7998,11 +8074,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c248;
+              s4 = peg$c245;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c249); }
+              if (peg$silentFails === 0) { peg$fail(peg$c246); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -8010,11 +8086,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c248;
+                    s7 = peg$c245;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c249); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c246); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -8022,11 +8098,11 @@ module.exports = /*
                       s9 = peg$parseCNUM();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 44) {
-                          s10 = peg$c248;
+                          s10 = peg$c245;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c249); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c246); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
@@ -8044,7 +8120,7 @@ module.exports = /*
                                 s14 = peg$parse_();
                                 if (s14 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c251(s3, s6, s9, s12);
+                                  s1 = peg$c248(s3, s6, s9, s12);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -8111,7 +8187,7 @@ module.exports = /*
     function peg$parseCNUM255() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 124 + 107,
+      var key    = peg$currPos * 125 + 108,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8123,20 +8199,20 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s2 = peg$c252;
+        s2 = peg$c249;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c253); }
+        if (peg$silentFails === 0) { peg$fail(peg$c250); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$currPos;
-        if (peg$c254.test(input.charAt(peg$currPos))) {
+        if (peg$c251.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c255); }
+          if (peg$silentFails === 0) { peg$fail(peg$c252); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -8191,7 +8267,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c256(s1);
+        s2 = peg$c253(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8201,7 +8277,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c257(s1);
+            s1 = peg$c254(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8224,7 +8300,7 @@ module.exports = /*
     function peg$parseCNUM() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 124 + 108,
+      var key    = peg$currPos * 125 + 109,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8237,22 +8313,22 @@ module.exports = /*
       s1 = peg$currPos;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s3 = peg$c252;
+        s3 = peg$c249;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c253); }
+        if (peg$silentFails === 0) { peg$fail(peg$c250); }
       }
       if (s3 === peg$FAILED) {
         s3 = null;
       }
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c258;
+          s4 = peg$c255;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c259); }
+          if (peg$silentFails === 0) { peg$fail(peg$c256); }
         }
         if (s4 !== peg$FAILED) {
           s5 = [];
@@ -8301,7 +8377,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c260(s1);
+          s1 = peg$c257(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8315,20 +8391,20 @@ module.exports = /*
         s0 = peg$currPos;
         s1 = peg$currPos;
         s2 = peg$currPos;
-        if (peg$c261.test(input.charAt(peg$currPos))) {
+        if (peg$c258.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c262); }
+          if (peg$silentFails === 0) { peg$fail(peg$c259); }
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c258;
+            s4 = peg$c255;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c259); }
+            if (peg$silentFails === 0) { peg$fail(peg$c256); }
           }
           if (s4 === peg$FAILED) {
             s4 = null;
@@ -8353,7 +8429,7 @@ module.exports = /*
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c260(s1);
+            s1 = peg$c257(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8373,7 +8449,7 @@ module.exports = /*
     function peg$parseCHEM_SINGLE_MACRO() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 109,
+      var key    = peg$currPos * 125 + 110,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8386,7 +8462,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c263(s1);
+        s2 = peg$c260(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8394,7 +8470,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c176(s1);
+          s1 = peg$c173(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8413,7 +8489,7 @@ module.exports = /*
     function peg$parseCHEM_BOND() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 110,
+      var key    = peg$currPos * 125 + 111,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8426,7 +8502,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c264(s1);
+        s2 = peg$c261(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8436,7 +8512,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c173(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8459,7 +8535,7 @@ module.exports = /*
     function peg$parseCHEM_MACRO_1P() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 111,
+      var key    = peg$currPos * 125 + 112,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8472,7 +8548,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c265(s1);
+        s2 = peg$c262(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8482,7 +8558,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c173(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8505,7 +8581,7 @@ module.exports = /*
     function peg$parseCHEM_MACRO_2P() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 112,
+      var key    = peg$currPos * 125 + 113,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8518,7 +8594,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c266(s1);
+        s2 = peg$c263(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8528,7 +8604,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c173(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8551,7 +8627,7 @@ module.exports = /*
     function peg$parseCHEM_MACRO_2PU() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 113,
+      var key    = peg$currPos * 125 + 114,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8564,7 +8640,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c267(s1);
+        s2 = peg$c264(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8574,7 +8650,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c173(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8597,7 +8673,7 @@ module.exports = /*
     function peg$parseCHEM_MACRO_2PC() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 114,
+      var key    = peg$currPos * 125 + 115,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8610,7 +8686,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c268(s1);
+        s2 = peg$c265(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8620,7 +8696,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1);
+            s1 = peg$c173(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8643,7 +8719,7 @@ module.exports = /*
     function peg$parseCHEM_SCRIPT_FOLLOW() {
       var s0;
 
-      var key    = peg$currPos * 124 + 115,
+      var key    = peg$currPos * 125 + 116,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8656,12 +8732,12 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$parseliteral_id();
         if (s0 === peg$FAILED) {
-          if (peg$c269.test(input.charAt(peg$currPos))) {
+          if (peg$c266.test(input.charAt(peg$currPos))) {
             s0 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c270); }
+            if (peg$silentFails === 0) { peg$fail(peg$c267); }
           }
         }
       }
@@ -8674,7 +8750,7 @@ module.exports = /*
     function peg$parseCHEM_SUPERSUB() {
       var s0;
 
-      var key    = peg$currPos * 124 + 116,
+      var key    = peg$currPos * 125 + 117,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8684,11 +8760,11 @@ module.exports = /*
       }
 
       if (input.charCodeAt(peg$currPos) === 95) {
-        s0 = peg$c107;
+        s0 = peg$c106;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c108); }
+        if (peg$silentFails === 0) { peg$fail(peg$c107); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 94) {
@@ -8708,7 +8784,7 @@ module.exports = /*
     function peg$parseCHEM_BOND_TYPE() {
       var s0;
 
-      var key    = peg$currPos * 124 + 117,
+      var key    = peg$currPos * 125 + 118,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8718,123 +8794,123 @@ module.exports = /*
       }
 
       if (input.charCodeAt(peg$currPos) === 61) {
-        s0 = peg$c271;
+        s0 = peg$c268;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c272); }
+        if (peg$silentFails === 0) { peg$fail(peg$c269); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 35) {
-          s0 = peg$c273;
+          s0 = peg$c270;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c274); }
+          if (peg$silentFails === 0) { peg$fail(peg$c271); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c275) {
-            s0 = peg$c275;
+          if (input.substr(peg$currPos, 3) === peg$c272) {
+            s0 = peg$c272;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c276); }
+            if (peg$silentFails === 0) { peg$fail(peg$c273); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c277) {
-              s0 = peg$c277;
+            if (input.substr(peg$currPos, 2) === peg$c274) {
+              s0 = peg$c274;
               peg$currPos += 2;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c278); }
+              if (peg$silentFails === 0) { peg$fail(peg$c275); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c279) {
-                s0 = peg$c279;
+              if (input.substr(peg$currPos, 2) === peg$c276) {
+                s0 = peg$c276;
                 peg$currPos += 2;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c280); }
+                if (peg$silentFails === 0) { peg$fail(peg$c277); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 126) {
-                  s0 = peg$c281;
+                  s0 = peg$c278;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c282); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c279); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 3) === peg$c283) {
-                    s0 = peg$c283;
+                  if (input.substr(peg$currPos, 3) === peg$c280) {
+                    s0 = peg$c280;
                     peg$currPos += 3;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c284); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c281); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 4) === peg$c285) {
-                      s0 = peg$c285;
+                    if (input.substr(peg$currPos, 4) === peg$c282) {
+                      s0 = peg$c282;
                       peg$currPos += 4;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c283); }
                     }
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 3) === peg$c287) {
-                        s0 = peg$c287;
+                      if (input.substr(peg$currPos, 3) === peg$c284) {
+                        s0 = peg$c284;
                         peg$currPos += 3;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c288); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c285); }
                       }
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 2) === peg$c289) {
-                          s0 = peg$c289;
+                        if (input.substr(peg$currPos, 2) === peg$c286) {
+                          s0 = peg$c286;
                           peg$currPos += 2;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c290); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c287); }
                         }
                         if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c291) {
-                            s0 = peg$c291;
+                          if (input.substr(peg$currPos, 2) === peg$c288) {
+                            s0 = peg$c288;
                             peg$currPos += 2;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c292); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c289); }
                           }
                           if (s0 === peg$FAILED) {
                             if (input.charCodeAt(peg$currPos) === 45) {
-                              s0 = peg$c135;
+                              s0 = peg$c132;
                               peg$currPos++;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c136); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c133); }
                             }
                             if (s0 === peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 49) {
-                                s0 = peg$c293;
+                                s0 = peg$c290;
                                 peg$currPos++;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c294); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c291); }
                               }
                               if (s0 === peg$FAILED) {
                                 if (input.charCodeAt(peg$currPos) === 50) {
-                                  s0 = peg$c295;
+                                  s0 = peg$c292;
                                   peg$currPos++;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c296); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c293); }
                                 }
                                 if (s0 === peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 51) {
-                                    s0 = peg$c297;
+                                    s0 = peg$c294;
                                     peg$currPos++;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c298); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c295); }
                                   }
                                 }
                               }
@@ -8859,7 +8935,7 @@ module.exports = /*
     function peg$parseBEGIN_MATH() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 118,
+      var key    = peg$currPos * 125 + 119,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8871,12 +8947,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c299) {
-          s2 = peg$c299;
+        if (input.substr(peg$currPos, 6) === peg$c296) {
+          s2 = peg$c296;
           peg$currPos += 6;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c300); }
+          if (peg$silentFails === 0) { peg$fail(peg$c297); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -8904,7 +8980,7 @@ module.exports = /*
     function peg$parseEND_MATH() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 124 + 119,
+      var key    = peg$currPos * 125 + 120,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8916,12 +8992,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c299) {
-          s2 = peg$c299;
+        if (input.substr(peg$currPos, 6) === peg$c296) {
+          s2 = peg$c296;
           peg$currPos += 6;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c300); }
+          if (peg$silentFails === 0) { peg$fail(peg$c297); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -8949,7 +9025,7 @@ module.exports = /*
     function peg$parseCHEM_LETTER() {
       var s0;
 
-      var key    = peg$currPos * 124 + 120,
+      var key    = peg$currPos * 125 + 121,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8958,12 +9034,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c114.test(input.charAt(peg$currPos))) {
+      if (peg$c113.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c114); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -8974,7 +9050,7 @@ module.exports = /*
     function peg$parseCHEM_NONLETTER() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 124 + 121,
+      var key    = peg$currPos * 125 + 122,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -8984,58 +9060,58 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c141) {
-        s1 = peg$c141;
+      if (input.substr(peg$currPos, 2) === peg$c138) {
+        s1 = peg$c138;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c142); }
+        if (peg$silentFails === 0) { peg$fail(peg$c139); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c301(s1);
+        s1 = peg$c298(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c302) {
-          s1 = peg$c302;
+        if (input.substr(peg$currPos, 2) === peg$c299) {
+          s1 = peg$c299;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c303); }
+          if (peg$silentFails === 0) { peg$fail(peg$c300); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c301(s1);
+          s1 = peg$c298(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c180) {
-            s1 = peg$c180;
+          if (input.substr(peg$currPos, 2) === peg$c177) {
+            s1 = peg$c177;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c181); }
+            if (peg$silentFails === 0) { peg$fail(peg$c178); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c301(s1);
+            s1 = peg$c298(s1);
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (peg$c304.test(input.charAt(peg$currPos))) {
+            if (peg$c301.test(input.charAt(peg$currPos))) {
               s1 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c305); }
+              if (peg$silentFails === 0) { peg$fail(peg$c302); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c301(s1);
+              s1 = peg$c298(s1);
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
@@ -9043,7 +9119,7 @@ module.exports = /*
               s1 = peg$parseliteral_mn();
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c301(s1);
+                s1 = peg$c298(s1);
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
@@ -9053,7 +9129,7 @@ module.exports = /*
                   s2 = peg$parseCURLY_CLOSE();
                   if (s2 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c306();
+                    s1 = peg$c303();
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9077,7 +9153,7 @@ module.exports = /*
     function peg$parseimpossible() {
       var s0;
 
-      var key    = peg$currPos * 124 + 122,
+      var key    = peg$currPos * 125 + 123,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -9087,7 +9163,7 @@ module.exports = /*
       }
 
       peg$savedPos = peg$currPos;
-      s0 = peg$c307();
+      s0 = peg$c304();
       if (s0) {
         s0 = void 0;
       } else {
@@ -9102,7 +9178,7 @@ module.exports = /*
     function peg$parseEOF() {
       var s0;
 
-      var key    = peg$currPos * 124 + 123,
+      var key    = peg$currPos * 125 + 124,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -9112,7 +9188,7 @@ module.exports = /*
       }
 
       peg$savedPos = peg$currPos;
-      s0 = peg$c308();
+      s0 = peg$c305();
       if (s0) {
         s0 = void 0;
       } else {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -229,173 +229,277 @@ module.exports = /*
         peg$c81 = peg$classExpectation(["t", "c", "b"], false, false),
         peg$c82 = "]",
         peg$c83 = peg$literalExpectation("]", false),
-        peg$c84 = function(p, s) { return ast.LList(p,s); },
-        peg$c85 = function(m) {
+        peg$c84 = " ",
+        peg$c85 = peg$literalExpectation(" ", false),
+        peg$c86 = function(p, s) { return ast.LList(p,s); },
+        peg$c87 = function(p) { return ast.LList(p,ast.LList.EMPTY); },
+        peg$c88 = function(m) { return ast.Tex.LITERAL(m); },
+        peg$c89 = function(m) { return ast.RenderT.TEX_ONLY(m); },
+        peg$c90 = function(m, n) { return ast.RenderT.TEX_ONLY(m + n); },
+        peg$c91 = "^",
+        peg$c92 = peg$literalExpectation("^", false),
+        peg$c93 = function(m) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); },
+        peg$c94 = "(^)",
+        peg$c95 = peg$literalExpectation("(^)", false),
+        peg$c96 = /^[a-zA-Z]/,
+        peg$c97 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
+        peg$c98 = function(m, n) { return ast.RenderT.TEX_ONLY("baz"); },
+        peg$c99 = function(m, n) { return ast.RenderT.TEX_ONLY("bar"); },
+        peg$c100 = function(m, n, o) { return ast.RenderT.TEX_ONLY("foo"); },
+        peg$c101 = function() { return ast.RenderT.TEX_ONLY(""); },
+        peg$c102 = function(m) { return m;},
+        peg$c103 = function(e) { return ast.RenderT.TEX_ONLY("{some text}"); },
+        peg$c104 = "$",
+        peg$c105 = peg$literalExpectation("$", false),
+        peg$c106 = function(b) { return ast.RenderT.TEX_ONLY("baz"); },
+        peg$c107 = "\\bond",
+        peg$c108 = peg$literalExpectation("\\bond", false),
+        peg$c109 = function() { return ast.RenderT.TEX_ONLY("\bond{some bond}");},
+        peg$c110 = function() { return ast.RenderT.TEX_ONLY("{}"); },
+        peg$c111 = "+",
+        peg$c112 = peg$literalExpectation("+", false),
+        peg$c113 = "-",
+        peg$c114 = peg$literalExpectation("-", false),
+        peg$c115 = "=",
+        peg$c116 = peg$literalExpectation("=", false),
+        peg$c117 = "#",
+        peg$c118 = peg$literalExpectation("#", false),
+        peg$c119 = "(",
+        peg$c120 = peg$literalExpectation("(", false),
+        peg$c121 = ")",
+        peg$c122 = peg$literalExpectation(")", false),
+        peg$c123 = "\\{",
+        peg$c124 = peg$literalExpectation("\\{", false),
+        peg$c125 = "\\}",
+        peg$c126 = peg$literalExpectation("\\}", false),
+        peg$c127 = ".",
+        peg$c128 = peg$literalExpectation(".", false),
+        peg$c129 = ",",
+        peg$c130 = peg$literalExpectation(",", false),
+        peg$c131 = ";",
+        peg$c132 = peg$literalExpectation(";", false),
+        peg$c133 = "/",
+        peg$c134 = peg$literalExpectation("/", false),
+        peg$c135 = "<",
+        peg$c136 = peg$literalExpectation("<", false),
+        peg$c137 = ">",
+        peg$c138 = peg$literalExpectation(">", false),
+        peg$c139 = "&",
+        peg$c140 = peg$literalExpectation("&", false),
+        peg$c141 = "\\",
+        peg$c142 = peg$literalExpectation("\\", false),
+        peg$c143 = function() { return ast.RenderT.TEX_ONLY("some char"); },
+        peg$c144 = function(a, b) { return ast.RenderT.TEX_ONLY("foo"); },
+        peg$c145 = function(a, b) { return ast.RenderT.TEX_ONLY("bar"); },
+        peg$c146 = function(a, b) { return ast.RenderT.TEX_ONLY("baz"); },
+        peg$c147 = "_",
+        peg$c148 = peg$literalExpectation("_", false),
+        peg$c149 = "~--",
+        peg$c150 = peg$literalExpectation("~--", false),
+        peg$c151 = "~-",
+        peg$c152 = peg$literalExpectation("~-", false),
+        peg$c153 = "~=",
+        peg$c154 = peg$literalExpectation("~=", false),
+        peg$c155 = "~",
+        peg$c156 = peg$literalExpectation("~", false),
+        peg$c157 = "-~-",
+        peg$c158 = peg$literalExpectation("-~-", false),
+        peg$c159 = "....",
+        peg$c160 = peg$literalExpectation("....", false),
+        peg$c161 = "...",
+        peg$c162 = peg$literalExpectation("...", false),
+        peg$c163 = "<-",
+        peg$c164 = peg$literalExpectation("<-", false),
+        peg$c165 = "->",
+        peg$c166 = peg$literalExpectation("->", false),
+        peg$c167 = "1",
+        peg$c168 = peg$literalExpectation("1", false),
+        peg$c169 = "2",
+        peg$c170 = peg$literalExpectation("2", false),
+        peg$c171 = "3",
+        peg$c172 = peg$literalExpectation("3", false),
+        peg$c173 = "\\alpha",
+        peg$c174 = peg$literalExpectation("\\alpha", false),
+        peg$c175 = "\\delta",
+        peg$c176 = peg$literalExpectation("\\delta", false),
+        peg$c177 = "\\mu",
+        peg$c178 = peg$literalExpectation("\\mu", false),
+        peg$c179 = "\\eta",
+        peg$c180 = peg$literalExpectation("\\eta", false),
+        peg$c181 = "\\gamma",
+        peg$c182 = peg$literalExpectation("\\gamma", false),
+        peg$c183 = "\\pm",
+        peg$c184 = peg$literalExpectation("\\pm", false),
+        peg$c185 = "\\approx",
+        peg$c186 = peg$literalExpectation("\\approx", false),
+        peg$c187 = "\\ca",
+        peg$c188 = peg$literalExpectation("\\ca", false),
+        peg$c189 = "ce",
+        peg$c190 = peg$literalExpectation("ce", false),
+        peg$c191 = "mathbf",
+        peg$c192 = peg$literalExpectation("mathbf", false),
+        peg$c193 = "\\frac",
+        peg$c194 = peg$literalExpectation("\\frac", false),
+        peg$c195 = function(name, l1, l2) { return ast.Tex.MHCHEM2(name, l1, l2); },
+        peg$c196 = "\\color",
+        peg$c197 = peg$literalExpectation("\\color", false),
+        peg$c198 = "\\overset",
+        peg$c199 = peg$literalExpectation("\\overset", false),
+        peg$c200 = "\\underset",
+        peg$c201 = peg$literalExpectation("\\underset", false),
+        peg$c202 = "\\underbrace",
+        peg$c203 = peg$literalExpectation("\\underbrace", false),
+        peg$c204 = function(name, l1, l2) { return ast.Tex.MHCHEM2ub(name, l1, l2); },
+        peg$c205 = "\\red",
+        peg$c206 = peg$literalExpectation("\\red", false),
+        peg$c207 = "red",
+        peg$c208 = peg$literalExpectation("red", false),
+        peg$c209 = function(m) {
                 var s = "";
                 for (var c in m)
                     s += m[c];
                 return ast.RenderT.TEX_ONLY(s);
             },
-        peg$c86 = /^[a-zA-Z]/,
-        peg$c87 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
-        peg$c88 = /^[,:;?!']/,
-        peg$c89 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
-        peg$c90 = /^[().]/,
-        peg$c91 = peg$classExpectation(["(", ")", "."], false, false),
-        peg$c92 = /^[\-+*=]/,
-        peg$c93 = peg$classExpectation(["-", "+", "*", "="], false, false),
-        peg$c94 = /^[\/|]/,
-        peg$c95 = peg$classExpectation(["/", "|"], false, false),
-        peg$c96 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
-        peg$c97 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
-        peg$c98 = /^[\uD800-\uDBFF]/,
-        peg$c99 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
-        peg$c100 = /^[\uDC00-\uDFFF]/,
-        peg$c101 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
-        peg$c102 = function(l, h) { return text(); },
-        peg$c103 = function(b) { return tu.box_functions[b]; },
-        peg$c104 = "{",
-        peg$c105 = peg$literalExpectation("{", false),
-        peg$c106 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
-        peg$c107 = "-",
-        peg$c108 = peg$literalExpectation("-", false),
-        peg$c109 = function(c) { return ast.RenderT.TEX_ONLY(c); },
-        peg$c110 = function(f) { return tu.latex_function_names[f]; },
-        peg$c111 = "(",
-        peg$c112 = peg$literalExpectation("(", false),
-        peg$c113 = "\\{",
-        peg$c114 = peg$literalExpectation("\\{", false),
-        peg$c115 = function(f) { return " ";},
-        peg$c116 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
-        peg$c117 = function(f) { return tu.mediawiki_function_names[f]; },
-        peg$c118 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
-        peg$c119 = function(f) { return tu.other_literals1[f]; },
-        peg$c120 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
-        peg$c121 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c122 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c123 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
-        peg$c124 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
-        peg$c125 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c126 = function(f) { return tu.other_literals2[f]; },
-        peg$c127 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c128 = function(mbox) { return mbox === "\\mbox"; },
-        peg$c129 = function(mbox, f) { return tu.other_literals2[f]; },
-        peg$c130 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c131 = function(f) { return ast.RenderT.TEX_ONLY(f); },
-        peg$c132 = "\\",
-        peg$c133 = peg$literalExpectation("\\", false),
-        peg$c134 = /^[, ;!_#%$&]/,
-        peg$c135 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
-        peg$c136 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
-        peg$c137 = /^[><~]/,
-        peg$c138 = peg$classExpectation([">", "<", "~"], false, false),
-        peg$c139 = /^[%$]/,
-        peg$c140 = peg$classExpectation(["%", "$"], false, false),
-        peg$c141 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */},
-        peg$c142 = /^[{}|]/,
-        peg$c143 = peg$classExpectation(["{", "}", "|"], false, false),
-        peg$c144 = function(f) { return tu.other_delimiters1[f]; },
-        peg$c145 = function(f) { return tu.other_delimiters2[f]; },
-        peg$c146 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
+        peg$c210 = /^[,:;?!']/,
+        peg$c211 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
+        peg$c212 = /^[().]/,
+        peg$c213 = peg$classExpectation(["(", ")", "."], false, false),
+        peg$c214 = /^[\-+*=]/,
+        peg$c215 = peg$classExpectation(["-", "+", "*", "="], false, false),
+        peg$c216 = /^[\/|]/,
+        peg$c217 = peg$classExpectation(["/", "|"], false, false),
+        peg$c218 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
+        peg$c219 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
+        peg$c220 = /^[\uD800-\uDBFF]/,
+        peg$c221 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
+        peg$c222 = /^[\uDC00-\uDFFF]/,
+        peg$c223 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
+        peg$c224 = function(l, h) { return text(); },
+        peg$c225 = function(b) { return tu.box_functions[b]; },
+        peg$c226 = "{",
+        peg$c227 = peg$literalExpectation("{", false),
+        peg$c228 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
+        peg$c229 = function(c) { return ast.RenderT.TEX_ONLY(c); },
+        peg$c230 = function(f) { return tu.latex_function_names[f]; },
+        peg$c231 = function(f) { return " ";},
+        peg$c232 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
+        peg$c233 = function(f) { return tu.mediawiki_function_names[f]; },
+        peg$c234 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
+        peg$c235 = function(f) { return tu.other_literals1[f]; },
+        peg$c236 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
+        peg$c237 = function(f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c238 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c239 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
+        peg$c240 = function(mathrm, f) { return options.usemathrm && tu.other_literals2[f]; },
+        peg$c241 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c242 = function(f) { return tu.other_literals2[f]; },
+        peg$c243 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c244 = function(mbox) { return mbox === "\\mbox"; },
+        peg$c245 = function(mbox, f) { return tu.other_literals2[f]; },
+        peg$c246 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c247 = function(f) { return ast.RenderT.TEX_ONLY(f); },
+        peg$c248 = /^[, ;!_#%$&]/,
+        peg$c249 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
+        peg$c250 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
+        peg$c251 = /^[><~]/,
+        peg$c252 = peg$classExpectation([">", "<", "~"], false, false),
+        peg$c253 = /^[%$]/,
+        peg$c254 = peg$classExpectation(["%", "$"], false, false),
+        peg$c255 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */},
+        peg$c256 = /^[{}|]/,
+        peg$c257 = peg$classExpectation(["{", "}", "|"], false, false),
+        peg$c258 = function(f) { return tu.other_delimiters1[f]; },
+        peg$c259 = function(f) { return tu.other_delimiters2[f]; },
+        peg$c260 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
              console.assert(Array.isArray(p) && p.length === 1);
              console.assert(p[0].constructor === ast.Tex.LITERAL);
              console.assert(p[0][0].constructor === ast.RenderT.TEX_ONLY);
              return p[0][0];
            },
-        peg$c147 = function(f) { return tu.fun_ar1nb[f]; },
-        peg$c148 = function(f) { return f; },
-        peg$c149 = function(f) { return tu.fun_ar1opt[f]; },
-        peg$c150 = "&",
-        peg$c151 = peg$literalExpectation("&", false),
-        peg$c152 = "\\\\",
-        peg$c153 = peg$literalExpectation("\\\\", false),
-        peg$c154 = "\\begin",
-        peg$c155 = peg$literalExpectation("\\begin", false),
-        peg$c156 = "\\end",
-        peg$c157 = peg$literalExpectation("\\end", false),
-        peg$c158 = "{matrix}",
-        peg$c159 = peg$literalExpectation("{matrix}", false),
-        peg$c160 = "{pmatrix}",
-        peg$c161 = peg$literalExpectation("{pmatrix}", false),
-        peg$c162 = "{bmatrix}",
-        peg$c163 = peg$literalExpectation("{bmatrix}", false),
-        peg$c164 = "{Bmatrix}",
-        peg$c165 = peg$literalExpectation("{Bmatrix}", false),
-        peg$c166 = "{vmatrix}",
-        peg$c167 = peg$literalExpectation("{vmatrix}", false),
-        peg$c168 = "{Vmatrix}",
-        peg$c169 = peg$literalExpectation("{Vmatrix}", false),
-        peg$c170 = "{array}",
-        peg$c171 = peg$literalExpectation("{array}", false),
-        peg$c172 = "{align}",
-        peg$c173 = peg$literalExpectation("{align}", false),
-        peg$c174 = "{aligned}",
-        peg$c175 = peg$literalExpectation("{aligned}", false),
-        peg$c176 = "{alignat}",
-        peg$c177 = peg$literalExpectation("{alignat}", false),
-        peg$c178 = "{alignedat}",
-        peg$c179 = peg$literalExpectation("{alignedat}", false),
-        peg$c180 = "{smallmatrix}",
-        peg$c181 = peg$literalExpectation("{smallmatrix}", false),
-        peg$c182 = "{cases}",
-        peg$c183 = peg$literalExpectation("{cases}", false),
-        peg$c184 = "^",
-        peg$c185 = peg$literalExpectation("^", false),
-        peg$c186 = "_",
-        peg$c187 = peg$literalExpectation("_", false),
-        peg$c188 = function(f) { return tu.big_literals[f]; },
-        peg$c189 = function(f) { return tu.fun_ar1[f]; },
-        peg$c190 = function(f) { return tu.other_fun_ar1[f]; },
-        peg$c191 = function(f) { return tu.fun_mhchem[f]; },
-        peg$c192 = function(f) { return tu.fun_ar2[f]; },
-        peg$c193 = function(f) { return tu.fun_infix[f]; },
-        peg$c194 = function(f) { return tu.declh_function[f]; },
-        peg$c195 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
-        peg$c196 = function(f) { return tu.fun_ar2nb[f]; },
-        peg$c197 = function(f) { return tu.left_function[f]; },
-        peg$c198 = function(f) { return tu.right_function[f]; },
-        peg$c199 = function(f) { return tu.hline_function[f]; },
-        peg$c200 = function(f) { return tu.color_function[f]; },
-        peg$c201 = function(f, cs) { return f + " " + cs; },
-        peg$c202 = function(f) { return tu.definecolor_function[f]; },
-        peg$c203 = "named",
-        peg$c204 = peg$literalExpectation("named", true),
-        peg$c205 = function(f, name, cs) { return "{named}" + cs; },
-        peg$c206 = "gray",
-        peg$c207 = peg$literalExpectation("gray", true),
-        peg$c208 = function(f, name, cs) { return "{gray}" + cs; },
-        peg$c209 = "rgb",
-        peg$c210 = peg$literalExpectation("rgb", false),
-        peg$c211 = function(f, name, cs) { return "{rgb}" + cs; },
-        peg$c212 = "RGB",
-        peg$c213 = peg$literalExpectation("RGB", false),
-        peg$c214 = "cmyk",
-        peg$c215 = peg$literalExpectation("cmyk", true),
-        peg$c216 = function(f, name, cs) { return "{cmyk}" + cs; },
-        peg$c217 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
-        peg$c218 = function(cs) { return "[named]" + cs; },
-        peg$c219 = function(cs) { return "[gray]" + cs; },
-        peg$c220 = function(cs) { return "[rgb]" + cs; },
-        peg$c221 = function(cs) { return "[cmyk]" + cs; },
-        peg$c222 = function(name) { return "{" + name.join('') + "}"; },
-        peg$c223 = function(k) { return "{"+k+"}"; },
-        peg$c224 = ",",
-        peg$c225 = peg$literalExpectation(",", false),
-        peg$c226 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
-        peg$c227 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
-        peg$c228 = "0",
-        peg$c229 = peg$literalExpectation("0", false),
-        peg$c230 = /^[1-9]/,
-        peg$c231 = peg$classExpectation([["1", "9"]], false, false),
-        peg$c232 = function(n) { return parseInt(n, 10) <= 255; },
-        peg$c233 = function(n) { return n / 255; },
-        peg$c234 = ".",
-        peg$c235 = peg$literalExpectation(".", false),
-        peg$c236 = function(n) { return n; },
-        peg$c237 = /^[01]/,
-        peg$c238 = peg$classExpectation(["0", "1"], false, false),
-        peg$c239 = function() { return false; },
-        peg$c240 = function() { return peg$currPos === input.length; },
+        peg$c261 = function(f) { return tu.fun_ar1nb[f]; },
+        peg$c262 = function(f) { return f; },
+        peg$c263 = function(f) { return tu.fun_ar1opt[f]; },
+        peg$c264 = "\\\\",
+        peg$c265 = peg$literalExpectation("\\\\", false),
+        peg$c266 = "\\begin",
+        peg$c267 = peg$literalExpectation("\\begin", false),
+        peg$c268 = "\\end",
+        peg$c269 = peg$literalExpectation("\\end", false),
+        peg$c270 = "{matrix}",
+        peg$c271 = peg$literalExpectation("{matrix}", false),
+        peg$c272 = "{pmatrix}",
+        peg$c273 = peg$literalExpectation("{pmatrix}", false),
+        peg$c274 = "{bmatrix}",
+        peg$c275 = peg$literalExpectation("{bmatrix}", false),
+        peg$c276 = "{Bmatrix}",
+        peg$c277 = peg$literalExpectation("{Bmatrix}", false),
+        peg$c278 = "{vmatrix}",
+        peg$c279 = peg$literalExpectation("{vmatrix}", false),
+        peg$c280 = "{Vmatrix}",
+        peg$c281 = peg$literalExpectation("{Vmatrix}", false),
+        peg$c282 = "{array}",
+        peg$c283 = peg$literalExpectation("{array}", false),
+        peg$c284 = "{align}",
+        peg$c285 = peg$literalExpectation("{align}", false),
+        peg$c286 = "{aligned}",
+        peg$c287 = peg$literalExpectation("{aligned}", false),
+        peg$c288 = "{alignat}",
+        peg$c289 = peg$literalExpectation("{alignat}", false),
+        peg$c290 = "{alignedat}",
+        peg$c291 = peg$literalExpectation("{alignedat}", false),
+        peg$c292 = "{smallmatrix}",
+        peg$c293 = peg$literalExpectation("{smallmatrix}", false),
+        peg$c294 = "{cases}",
+        peg$c295 = peg$literalExpectation("{cases}", false),
+        peg$c296 = function(f) { return tu.big_literals[f]; },
+        peg$c297 = function(f) { return tu.fun_ar1[f]; },
+        peg$c298 = function(f) { return tu.other_fun_ar1[f]; },
+        peg$c299 = function(f) { return tu.fun_mhchem[f]; },
+        peg$c300 = function(f) { return tu.fun_ar2[f]; },
+        peg$c301 = function(f) { return tu.fun_infix[f]; },
+        peg$c302 = function(f) { return tu.declh_function[f]; },
+        peg$c303 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
+        peg$c304 = function(f) { return tu.fun_ar2nb[f]; },
+        peg$c305 = function(f) { return tu.left_function[f]; },
+        peg$c306 = function(f) { return tu.right_function[f]; },
+        peg$c307 = function(f) { return tu.hline_function[f]; },
+        peg$c308 = function(f) { return tu.color_function[f]; },
+        peg$c309 = function(f, cs) { return f + " " + cs; },
+        peg$c310 = function(f) { return tu.definecolor_function[f]; },
+        peg$c311 = "named",
+        peg$c312 = peg$literalExpectation("named", true),
+        peg$c313 = function(f, name, cs) { return "{named}" + cs; },
+        peg$c314 = "gray",
+        peg$c315 = peg$literalExpectation("gray", true),
+        peg$c316 = function(f, name, cs) { return "{gray}" + cs; },
+        peg$c317 = "rgb",
+        peg$c318 = peg$literalExpectation("rgb", false),
+        peg$c319 = function(f, name, cs) { return "{rgb}" + cs; },
+        peg$c320 = "RGB",
+        peg$c321 = peg$literalExpectation("RGB", false),
+        peg$c322 = "cmyk",
+        peg$c323 = peg$literalExpectation("cmyk", true),
+        peg$c324 = function(f, name, cs) { return "{cmyk}" + cs; },
+        peg$c325 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
+        peg$c326 = function(cs) { return "[named]" + cs; },
+        peg$c327 = function(cs) { return "[gray]" + cs; },
+        peg$c328 = function(cs) { return "[rgb]" + cs; },
+        peg$c329 = function(cs) { return "[cmyk]" + cs; },
+        peg$c330 = function(name) { return "{" + name.join('') + "}"; },
+        peg$c331 = function(k) { return "{"+k+"}"; },
+        peg$c332 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
+        peg$c333 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
+        peg$c334 = "0",
+        peg$c335 = peg$literalExpectation("0", false),
+        peg$c336 = /^[1-9]/,
+        peg$c337 = peg$classExpectation([["1", "9"]], false, false),
+        peg$c338 = function(n) { return parseInt(n, 10) <= 255; },
+        peg$c339 = function(n) { return n / 255; },
+        peg$c340 = function(n) { return n; },
+        peg$c341 = /^[01]/,
+        peg$c342 = peg$classExpectation(["0", "1"], false, false),
+        peg$c343 = function() { return false; },
+        peg$c344 = function() { return peg$currPos === input.length; },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -538,7 +642,7 @@ module.exports = /*
     function peg$parsestart() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 0,
+      var key    = peg$currPos * 115 + 0,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -572,7 +676,7 @@ module.exports = /*
     function peg$parse_() {
       var s0, s1;
 
-      var key    = peg$currPos * 105 + 1,
+      var key    = peg$currPos * 115 + 1,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -608,7 +712,7 @@ module.exports = /*
     function peg$parsetex_expr() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 105 + 2,
+      var key    = peg$currPos * 115 + 2,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -702,7 +806,7 @@ module.exports = /*
     function peg$parseexpr() {
       var s0, s1;
 
-      var key    = peg$currPos * 105 + 3,
+      var key    = peg$currPos * 115 + 3,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -730,7 +834,7 @@ module.exports = /*
     function peg$parsene_expr() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 4,
+      var key    = peg$currPos * 115 + 4,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -800,7 +904,7 @@ module.exports = /*
     function peg$parselitsq_aq() {
       var s0;
 
-      var key    = peg$currPos * 105 + 5,
+      var key    = peg$currPos * 115 + 5,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -828,7 +932,7 @@ module.exports = /*
     function peg$parselitsq_fq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 6,
+      var key    = peg$currPos * 115 + 6,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -892,7 +996,7 @@ module.exports = /*
     function peg$parselitsq_uq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 7,
+      var key    = peg$currPos * 115 + 7,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -932,7 +1036,7 @@ module.exports = /*
     function peg$parselitsq_dq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 8,
+      var key    = peg$currPos * 115 + 8,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -972,7 +1076,7 @@ module.exports = /*
     function peg$parselitsq_zq() {
       var s0, s1;
 
-      var key    = peg$currPos * 105 + 9,
+      var key    = peg$currPos * 115 + 9,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -997,7 +1101,7 @@ module.exports = /*
     function peg$parseexpr_nosqc() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 10,
+      var key    = peg$currPos * 115 + 10,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1040,7 +1144,7 @@ module.exports = /*
     function peg$parselit_aq() {
       var s0;
 
-      var key    = peg$currPos * 105 + 11,
+      var key    = peg$currPos * 115 + 11,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1074,7 +1178,7 @@ module.exports = /*
     function peg$parselit_fq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 12,
+      var key    = peg$currPos * 115 + 12,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1162,7 +1266,7 @@ module.exports = /*
     function peg$parselit_uq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 13,
+      var key    = peg$currPos * 115 + 13,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1202,7 +1306,7 @@ module.exports = /*
     function peg$parselit_dq() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 14,
+      var key    = peg$currPos * 115 + 14,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1242,7 +1346,7 @@ module.exports = /*
     function peg$parselit_uqn() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 15,
+      var key    = peg$currPos * 115 + 15,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1276,7 +1380,7 @@ module.exports = /*
     function peg$parselit_dqn() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 16,
+      var key    = peg$currPos * 115 + 16,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1310,7 +1414,7 @@ module.exports = /*
     function peg$parseleft() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 17,
+      var key    = peg$currPos * 115 + 17,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1362,7 +1466,7 @@ module.exports = /*
     function peg$parseright() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 18,
+      var key    = peg$currPos * 115 + 18,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -1414,7 +1518,7 @@ module.exports = /*
     function peg$parselit() {
       var s0, s1, s2, s3, s4, s5;
 
-      var key    = peg$currPos * 105 + 19,
+      var key    = peg$currPos * 115 + 19,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2189,7 +2293,7 @@ module.exports = /*
     function peg$parsearray() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 20,
+      var key    = peg$currPos * 115 + 20,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2223,7 +2327,7 @@ module.exports = /*
     function peg$parsealignat() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 21,
+      var key    = peg$currPos * 115 + 21,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2257,7 +2361,7 @@ module.exports = /*
     function peg$parsematrix() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 105 + 22,
+      var key    = peg$currPos * 115 + 22,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2309,7 +2413,7 @@ module.exports = /*
     function peg$parseline_start() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 23,
+      var key    = peg$currPos * 115 + 23,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2346,7 +2450,7 @@ module.exports = /*
     function peg$parseline() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 105 + 24,
+      var key    = peg$currPos * 115 + 24,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2398,7 +2502,7 @@ module.exports = /*
     function peg$parsecolumn_spec() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 105 + 25,
+      var key    = peg$currPos * 115 + 25,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2453,7 +2557,7 @@ module.exports = /*
     function peg$parseone_col() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-      var key    = peg$currPos * 105 + 26,
+      var key    = peg$currPos * 115 + 26,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2732,7 +2836,7 @@ module.exports = /*
     function peg$parsealignat_spec() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 105 + 27,
+      var key    = peg$currPos * 115 + 27,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2805,7 +2909,7 @@ module.exports = /*
     function peg$parseopt_pos() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 105 + 28,
+      var key    = peg$currPos * 115 + 28,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2883,7 +2987,7 @@ module.exports = /*
     function peg$parsechem_lit() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 29,
+      var key    = peg$currPos * 115 + 29,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2921,37 +3025,9 @@ module.exports = /*
     }
 
     function peg$parsechem_sentence() {
-      var s0, s1;
+      var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 30,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      s0 = peg$parsechem_nt_sentence();
-      if (s0 === peg$FAILED) {
-        s0 = peg$currPos;
-        s1 = peg$c6;
-        if (s1 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c7();
-        }
-        s0 = s1;
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parsechem_nt_sentence() {
-      var s0, s1, s2;
-
-      var key    = peg$currPos * 105 + 31,
+      var key    = peg$currPos * 115 + 30,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2963,11 +3039,23 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parsechem_phrase();
       if (s1 !== peg$FAILED) {
-        s2 = peg$parsechem_sentence();
+        if (input.charCodeAt(peg$currPos) === 32) {
+          s2 = peg$c84;
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c85); }
+        }
         if (s2 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c84(s1, s2);
-          s0 = s1;
+          s3 = peg$parsechem_sentence();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c86(s1, s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -2976,6 +3064,24 @@ module.exports = /*
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parsechem_phrase();
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c87(s1);
+        }
+        s0 = s1;
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$c6;
+          if (s1 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c7();
+          }
+          s0 = s1;
+        }
+      }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
@@ -2983,9 +3089,9 @@ module.exports = /*
     }
 
     function peg$parsechem_phrase() {
-      var s0, s1;
+      var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 32,
+      var key    = peg$currPos * 115 + 31,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -2998,9 +3104,66 @@ module.exports = /*
       s1 = peg$parsechem_word();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c21(s1);
+        s1 = peg$c88(s1);
       }
       s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parsechem_single_macro();
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c89(s1);
+        }
+        s0 = s1;
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parsechem_word();
+          if (s1 !== peg$FAILED) {
+            s2 = peg$parsechem_single_macro();
+            if (s2 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c90(s1, s2);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            if (input.charCodeAt(peg$currPos) === 94) {
+              s1 = peg$c91;
+              peg$currPos++;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c92); }
+            }
+            if (s1 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c93(s1);
+            }
+            s0 = s1;
+            if (s0 === peg$FAILED) {
+              s0 = peg$currPos;
+              if (input.substr(peg$currPos, 3) === peg$c94) {
+                s1 = peg$c94;
+                peg$currPos += 3;
+              } else {
+                s1 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c95); }
+              }
+              if (s1 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c89(s1);
+              }
+              s0 = s1;
+            }
+          }
+        }
+      }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
@@ -3008,9 +3171,1210 @@ module.exports = /*
     }
 
     function peg$parsechem_word() {
+      var s0, s1, s2, s3;
+
+      var key    = peg$currPos * 115 + 32,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      if (peg$c96.test(input.charAt(peg$currPos))) {
+        s1 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c97); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsechem_word();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c98(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parsechem_nonletter();
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parsechem_word();
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c99(s1, s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parsechem_single_macro();
+          if (s1 !== peg$FAILED) {
+            s2 = peg$parsechem_nonletter();
+            if (s2 !== peg$FAILED) {
+              s3 = peg$parsechem_word();
+              if (s3 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c100(s1, s2, s3);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            s1 = peg$c6;
+            if (s1 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c101();
+            }
+            s0 = s1;
+          }
+        }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_nonletter() {
+      var s0, s1, s2, s3, s4;
+
+      var key    = peg$currPos * 115 + 33,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsechem_script();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c102(s1);
+      }
+      s0 = s1;
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseCURLY_OPEN();
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parsechem_text();
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parseCURLY_CLOSE();
+            if (s3 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c103(s2);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 36) {
+            s1 = peg$c104;
+            peg$currPos++;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c105); }
+          }
+          if (s1 !== peg$FAILED) {
+            s2 = peg$parsechem_latex();
+            if (s2 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 36) {
+                s3 = peg$c104;
+                peg$currPos++;
+              } else {
+                s3 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c105); }
+              }
+              if (s3 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c106(s2);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            if (input.substr(peg$currPos, 5) === peg$c107) {
+              s1 = peg$c107;
+              peg$currPos += 5;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c108); }
+            }
+            if (s1 !== peg$FAILED) {
+              s2 = peg$parseCURLY_OPEN();
+              if (s2 !== peg$FAILED) {
+                s3 = peg$parsechem_bond_type();
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$parseCURLY_CLOSE();
+                  if (s4 !== peg$FAILED) {
+                    peg$savedPos = s0;
+                    s1 = peg$c109();
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+            if (s0 === peg$FAILED) {
+              s0 = peg$currPos;
+              s1 = peg$parsechem_macro_1p();
+              if (s1 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c102(s1);
+              }
+              s0 = s1;
+              if (s0 === peg$FAILED) {
+                s0 = peg$currPos;
+                s1 = peg$parsechem_macro_2p();
+                if (s1 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c102(s1);
+                }
+                s0 = s1;
+                if (s0 === peg$FAILED) {
+                  s0 = peg$currPos;
+                  s1 = peg$parseCURLY_OPEN();
+                  if (s1 !== peg$FAILED) {
+                    s2 = peg$parseCURLY_CLOSE();
+                    if (s2 !== peg$FAILED) {
+                      peg$savedPos = s0;
+                      s1 = peg$c110();
+                      s0 = s1;
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$currPos;
+                    if (peg$c69.test(input.charAt(peg$currPos))) {
+                      s1 = input.charAt(peg$currPos);
+                      peg$currPos++;
+                    } else {
+                      s1 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c70); }
+                    }
+                    if (s1 !== peg$FAILED) {
+                      peg$savedPos = s0;
+                      s1 = peg$c89(s1);
+                    }
+                    s0 = s1;
+                    if (s0 === peg$FAILED) {
+                      if (input.charCodeAt(peg$currPos) === 43) {
+                        s0 = peg$c111;
+                        peg$currPos++;
+                      } else {
+                        s0 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c112); }
+                      }
+                      if (s0 === peg$FAILED) {
+                        if (input.charCodeAt(peg$currPos) === 45) {
+                          s0 = peg$c113;
+                          peg$currPos++;
+                        } else {
+                          s0 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                        }
+                        if (s0 === peg$FAILED) {
+                          if (input.charCodeAt(peg$currPos) === 61) {
+                            s0 = peg$c115;
+                            peg$currPos++;
+                          } else {
+                            s0 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$c116); }
+                          }
+                          if (s0 === peg$FAILED) {
+                            if (input.charCodeAt(peg$currPos) === 35) {
+                              s0 = peg$c117;
+                              peg$currPos++;
+                            } else {
+                              s0 = peg$FAILED;
+                              if (peg$silentFails === 0) { peg$fail(peg$c118); }
+                            }
+                            if (s0 === peg$FAILED) {
+                              if (input.charCodeAt(peg$currPos) === 40) {
+                                s0 = peg$c119;
+                                peg$currPos++;
+                              } else {
+                                s0 = peg$FAILED;
+                                if (peg$silentFails === 0) { peg$fail(peg$c120); }
+                              }
+                              if (s0 === peg$FAILED) {
+                                if (input.charCodeAt(peg$currPos) === 41) {
+                                  s0 = peg$c121;
+                                  peg$currPos++;
+                                } else {
+                                  s0 = peg$FAILED;
+                                  if (peg$silentFails === 0) { peg$fail(peg$c122); }
+                                }
+                                if (s0 === peg$FAILED) {
+                                  if (input.charCodeAt(peg$currPos) === 91) {
+                                    s0 = peg$c78;
+                                    peg$currPos++;
+                                  } else {
+                                    s0 = peg$FAILED;
+                                    if (peg$silentFails === 0) { peg$fail(peg$c79); }
+                                  }
+                                  if (s0 === peg$FAILED) {
+                                    if (input.charCodeAt(peg$currPos) === 93) {
+                                      s0 = peg$c82;
+                                      peg$currPos++;
+                                    } else {
+                                      s0 = peg$FAILED;
+                                      if (peg$silentFails === 0) { peg$fail(peg$c83); }
+                                    }
+                                    if (s0 === peg$FAILED) {
+                                      if (input.substr(peg$currPos, 2) === peg$c123) {
+                                        s0 = peg$c123;
+                                        peg$currPos += 2;
+                                      } else {
+                                        s0 = peg$FAILED;
+                                        if (peg$silentFails === 0) { peg$fail(peg$c124); }
+                                      }
+                                      if (s0 === peg$FAILED) {
+                                        if (input.substr(peg$currPos, 2) === peg$c125) {
+                                          s0 = peg$c125;
+                                          peg$currPos += 2;
+                                        } else {
+                                          s0 = peg$FAILED;
+                                          if (peg$silentFails === 0) { peg$fail(peg$c126); }
+                                        }
+                                        if (s0 === peg$FAILED) {
+                                          if (input.charCodeAt(peg$currPos) === 46) {
+                                            s0 = peg$c127;
+                                            peg$currPos++;
+                                          } else {
+                                            s0 = peg$FAILED;
+                                            if (peg$silentFails === 0) { peg$fail(peg$c128); }
+                                          }
+                                          if (s0 === peg$FAILED) {
+                                            if (input.charCodeAt(peg$currPos) === 44) {
+                                              s0 = peg$c129;
+                                              peg$currPos++;
+                                            } else {
+                                              s0 = peg$FAILED;
+                                              if (peg$silentFails === 0) { peg$fail(peg$c130); }
+                                            }
+                                            if (s0 === peg$FAILED) {
+                                              if (input.charCodeAt(peg$currPos) === 59) {
+                                                s0 = peg$c131;
+                                                peg$currPos++;
+                                              } else {
+                                                s0 = peg$FAILED;
+                                                if (peg$silentFails === 0) { peg$fail(peg$c132); }
+                                              }
+                                              if (s0 === peg$FAILED) {
+                                                if (input.charCodeAt(peg$currPos) === 47) {
+                                                  s0 = peg$c133;
+                                                  peg$currPos++;
+                                                } else {
+                                                  s0 = peg$FAILED;
+                                                  if (peg$silentFails === 0) { peg$fail(peg$c134); }
+                                                }
+                                                if (s0 === peg$FAILED) {
+                                                  if (input.charCodeAt(peg$currPos) === 42) {
+                                                    s0 = peg$c67;
+                                                    peg$currPos++;
+                                                  } else {
+                                                    s0 = peg$FAILED;
+                                                    if (peg$silentFails === 0) { peg$fail(peg$c68); }
+                                                  }
+                                                  if (s0 === peg$FAILED) {
+                                                    if (input.charCodeAt(peg$currPos) === 60) {
+                                                      s0 = peg$c135;
+                                                      peg$currPos++;
+                                                    } else {
+                                                      s0 = peg$FAILED;
+                                                      if (peg$silentFails === 0) { peg$fail(peg$c136); }
+                                                    }
+                                                    if (s0 === peg$FAILED) {
+                                                      if (input.charCodeAt(peg$currPos) === 62) {
+                                                        s0 = peg$c137;
+                                                        peg$currPos++;
+                                                      } else {
+                                                        s0 = peg$FAILED;
+                                                        if (peg$silentFails === 0) { peg$fail(peg$c138); }
+                                                      }
+                                                      if (s0 === peg$FAILED) {
+                                                        if (input.charCodeAt(peg$currPos) === 47) {
+                                                          s0 = peg$c133;
+                                                          peg$currPos++;
+                                                        } else {
+                                                          s0 = peg$FAILED;
+                                                          if (peg$silentFails === 0) { peg$fail(peg$c134); }
+                                                        }
+                                                        if (s0 === peg$FAILED) {
+                                                          if (input.charCodeAt(peg$currPos) === 64) {
+                                                            s0 = peg$c75;
+                                                            peg$currPos++;
+                                                          } else {
+                                                            s0 = peg$FAILED;
+                                                            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+                                                          }
+                                                          if (s0 === peg$FAILED) {
+                                                            if (input.charCodeAt(peg$currPos) === 38) {
+                                                              s0 = peg$c139;
+                                                              peg$currPos++;
+                                                            } else {
+                                                              s0 = peg$FAILED;
+                                                              if (peg$silentFails === 0) { peg$fail(peg$c140); }
+                                                            }
+                                                            if (s0 === peg$FAILED) {
+                                                              s0 = peg$currPos;
+                                                              if (input.charCodeAt(peg$currPos) === 92) {
+                                                                s1 = peg$c141;
+                                                                peg$currPos++;
+                                                              } else {
+                                                                s1 = peg$FAILED;
+                                                                if (peg$silentFails === 0) { peg$fail(peg$c142); }
+                                                              }
+                                                              if (s1 !== peg$FAILED) {
+                                                                peg$savedPos = s0;
+                                                                s1 = peg$c143();
+                                                              }
+                                                              s0 = s1;
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_script() {
+      var s0, s1, s2, s3, s4;
+
+      var key    = peg$currPos * 115 + 34,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = peg$parsechem_supersub();
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsechem_script_follow();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c144(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parsechem_supersub();
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parsechem_lit();
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c145(s1, s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = peg$parsechem_supersub();
+          if (s1 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 36) {
+              s2 = peg$c104;
+              peg$currPos++;
+            } else {
+              s2 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c105); }
+            }
+            if (s2 !== peg$FAILED) {
+              s3 = peg$parsechem_latex();
+              if (s3 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 36) {
+                  s4 = peg$c104;
+                  peg$currPos++;
+                } else {
+                  s4 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c105); }
+                }
+                if (s4 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c146(s1, s3);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_supersub() {
+      var s0, s1;
+
+      var key    = peg$currPos * 115 + 35,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (input.charCodeAt(peg$currPos) === 95) {
+        s0 = peg$c147;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 94) {
+          s1 = peg$c91;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c92); }
+        }
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c89(s1);
+        }
+        s0 = s1;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_script_follow() {
+      var s0, s1;
+
+      var key    = peg$currPos * 115 + 36,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (peg$c69.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c70); }
+      }
+      if (s0 === peg$FAILED) {
+        if (peg$c96.test(input.charAt(peg$currPos))) {
+          s0 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s0 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c97); }
+        }
+        if (s0 === peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 43) {
+            s0 = peg$c111;
+            peg$currPos++;
+          } else {
+            s0 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c112); }
+          }
+          if (s0 === peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 45) {
+              s0 = peg$c113;
+              peg$currPos++;
+            } else {
+              s0 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c114); }
+            }
+            if (s0 === peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 46) {
+                s0 = peg$c127;
+                peg$currPos++;
+              } else {
+                s0 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c128); }
+              }
+              if (s0 === peg$FAILED) {
+                s0 = peg$currPos;
+                if (input.charCodeAt(peg$currPos) === 42) {
+                  s1 = peg$c67;
+                  peg$currPos++;
+                } else {
+                  s1 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c68); }
+                }
+                if (s1 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c89(s1);
+                }
+                s0 = s1;
+              }
+            }
+          }
+        }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_bond_type() {
+      var s0, s1;
+
+      var key    = peg$currPos * 115 + 37,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (input.charCodeAt(peg$currPos) === 61) {
+        s0 = peg$c115;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c116); }
+      }
+      if (s0 === peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 35) {
+          s0 = peg$c117;
+          peg$currPos++;
+        } else {
+          s0 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c118); }
+        }
+        if (s0 === peg$FAILED) {
+          if (input.substr(peg$currPos, 3) === peg$c149) {
+            s0 = peg$c149;
+            peg$currPos += 3;
+          } else {
+            s0 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c150); }
+          }
+          if (s0 === peg$FAILED) {
+            if (input.substr(peg$currPos, 2) === peg$c151) {
+              s0 = peg$c151;
+              peg$currPos += 2;
+            } else {
+              s0 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c152); }
+            }
+            if (s0 === peg$FAILED) {
+              if (input.substr(peg$currPos, 2) === peg$c153) {
+                s0 = peg$c153;
+                peg$currPos += 2;
+              } else {
+                s0 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c154); }
+              }
+              if (s0 === peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 126) {
+                  s0 = peg$c155;
+                  peg$currPos++;
+                } else {
+                  s0 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c156); }
+                }
+                if (s0 === peg$FAILED) {
+                  if (input.substr(peg$currPos, 3) === peg$c157) {
+                    s0 = peg$c157;
+                    peg$currPos += 3;
+                  } else {
+                    s0 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c158); }
+                  }
+                  if (s0 === peg$FAILED) {
+                    if (input.charCodeAt(peg$currPos) === 45) {
+                      s0 = peg$c113;
+                      peg$currPos++;
+                    } else {
+                      s0 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                    }
+                    if (s0 === peg$FAILED) {
+                      if (input.substr(peg$currPos, 4) === peg$c159) {
+                        s0 = peg$c159;
+                        peg$currPos += 4;
+                      } else {
+                        s0 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c160); }
+                      }
+                      if (s0 === peg$FAILED) {
+                        if (input.substr(peg$currPos, 3) === peg$c161) {
+                          s0 = peg$c161;
+                          peg$currPos += 3;
+                        } else {
+                          s0 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c162); }
+                        }
+                        if (s0 === peg$FAILED) {
+                          if (input.substr(peg$currPos, 2) === peg$c163) {
+                            s0 = peg$c163;
+                            peg$currPos += 2;
+                          } else {
+                            s0 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$c164); }
+                          }
+                          if (s0 === peg$FAILED) {
+                            if (input.substr(peg$currPos, 2) === peg$c165) {
+                              s0 = peg$c165;
+                              peg$currPos += 2;
+                            } else {
+                              s0 = peg$FAILED;
+                              if (peg$silentFails === 0) { peg$fail(peg$c166); }
+                            }
+                            if (s0 === peg$FAILED) {
+                              if (input.charCodeAt(peg$currPos) === 49) {
+                                s0 = peg$c167;
+                                peg$currPos++;
+                              } else {
+                                s0 = peg$FAILED;
+                                if (peg$silentFails === 0) { peg$fail(peg$c168); }
+                              }
+                              if (s0 === peg$FAILED) {
+                                if (input.charCodeAt(peg$currPos) === 50) {
+                                  s0 = peg$c169;
+                                  peg$currPos++;
+                                } else {
+                                  s0 = peg$FAILED;
+                                  if (peg$silentFails === 0) { peg$fail(peg$c170); }
+                                }
+                                if (s0 === peg$FAILED) {
+                                  s0 = peg$currPos;
+                                  if (input.charCodeAt(peg$currPos) === 51) {
+                                    s1 = peg$c171;
+                                    peg$currPos++;
+                                  } else {
+                                    s1 = peg$FAILED;
+                                    if (peg$silentFails === 0) { peg$fail(peg$c172); }
+                                  }
+                                  if (s1 !== peg$FAILED) {
+                                    peg$savedPos = s0;
+                                    s1 = peg$c89(s1);
+                                  }
+                                  s0 = s1;
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_single_macro() {
+      var s0, s1;
+
+      var key    = peg$currPos * 115 + 38,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (input.substr(peg$currPos, 6) === peg$c173) {
+        s0 = peg$c173;
+        peg$currPos += 6;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c174); }
+      }
+      if (s0 === peg$FAILED) {
+        if (input.substr(peg$currPos, 6) === peg$c175) {
+          s0 = peg$c175;
+          peg$currPos += 6;
+        } else {
+          s0 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c176); }
+        }
+        if (s0 === peg$FAILED) {
+          if (input.substr(peg$currPos, 3) === peg$c177) {
+            s0 = peg$c177;
+            peg$currPos += 3;
+          } else {
+            s0 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c178); }
+          }
+          if (s0 === peg$FAILED) {
+            if (input.substr(peg$currPos, 4) === peg$c179) {
+              s0 = peg$c179;
+              peg$currPos += 4;
+            } else {
+              s0 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c180); }
+            }
+            if (s0 === peg$FAILED) {
+              if (input.substr(peg$currPos, 6) === peg$c181) {
+                s0 = peg$c181;
+                peg$currPos += 6;
+              } else {
+                s0 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c182); }
+              }
+              if (s0 === peg$FAILED) {
+                if (input.substr(peg$currPos, 3) === peg$c183) {
+                  s0 = peg$c183;
+                  peg$currPos += 3;
+                } else {
+                  s0 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c184); }
+                }
+                if (s0 === peg$FAILED) {
+                  if (input.substr(peg$currPos, 7) === peg$c185) {
+                    s0 = peg$c185;
+                    peg$currPos += 7;
+                  } else {
+                    s0 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c186); }
+                  }
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$currPos;
+                    if (input.substr(peg$currPos, 3) === peg$c187) {
+                      s1 = peg$c187;
+                      peg$currPos += 3;
+                    } else {
+                      s1 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c188); }
+                    }
+                    if (s1 !== peg$FAILED) {
+                      peg$savedPos = s0;
+                      s1 = peg$c89(s1);
+                    }
+                    s0 = s1;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_macro_1p() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 33,
+      var key    = peg$currPos * 115 + 39,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 2) === peg$c189) {
+        s1 = peg$c189;
+        peg$currPos += 2;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c190); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsechem_lit();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c30(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.substr(peg$currPos, 6) === peg$c191) {
+          s1 = peg$c191;
+          peg$currPos += 6;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c192); }
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parsechem_lit();
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c30(s1, s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_macro_2p() {
+      var s0, s1, s2, s3, s4;
+
+      var key    = peg$currPos * 115 + 40,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 5) === peg$c193) {
+        s1 = peg$c193;
+        peg$currPos += 5;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c194); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parsechem_lit();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parsechem_lit();
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c195(s1, s2, s3);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.substr(peg$currPos, 6) === peg$c196) {
+          s1 = peg$c196;
+          peg$currPos += 6;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c197); }
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parsechem_color();
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parsechem_lit();
+            if (s3 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c195(s1, s2, s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          if (input.substr(peg$currPos, 8) === peg$c198) {
+            s1 = peg$c198;
+            peg$currPos += 8;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c199); }
+          }
+          if (s1 !== peg$FAILED) {
+            s2 = peg$parsechem_lit();
+            if (s2 !== peg$FAILED) {
+              s3 = peg$parsechem_lit();
+              if (s3 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c195(s1, s2, s3);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            if (input.substr(peg$currPos, 9) === peg$c200) {
+              s1 = peg$c200;
+              peg$currPos += 9;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c201); }
+            }
+            if (s1 !== peg$FAILED) {
+              s2 = peg$parsechem_lit();
+              if (s2 !== peg$FAILED) {
+                s3 = peg$parsechem_lit();
+                if (s3 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c195(s1, s2, s3);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+            if (s0 === peg$FAILED) {
+              s0 = peg$currPos;
+              if (input.substr(peg$currPos, 11) === peg$c202) {
+                s1 = peg$c202;
+                peg$currPos += 11;
+              } else {
+                s1 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c203); }
+              }
+              if (s1 !== peg$FAILED) {
+                s2 = peg$parsechem_lit();
+                if (s2 !== peg$FAILED) {
+                  if (input.charCodeAt(peg$currPos) === 95) {
+                    s3 = peg$c147;
+                    peg$currPos++;
+                  } else {
+                    s3 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c148); }
+                  }
+                  if (s3 !== peg$FAILED) {
+                    s4 = peg$parsechem_lit();
+                    if (s4 !== peg$FAILED) {
+                      peg$savedPos = s0;
+                      s1 = peg$c204(s1, s2, s4);
+                      s0 = s1;
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            }
+          }
+        }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_color() {
+      var s0, s1;
+
+      var key    = peg$currPos * 115 + 41,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (input.substr(peg$currPos, 4) === peg$c205) {
+        s0 = peg$c205;
+        peg$currPos += 4;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c206); }
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.substr(peg$currPos, 3) === peg$c207) {
+          s1 = peg$c207;
+          peg$currPos += 3;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c208); }
+        }
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c89(s1);
+        }
+        s0 = s1;
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_latex() {
+      var s0, s1, s2;
+
+      var key    = peg$currPos * 115 + 42,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3032,7 +4396,41 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c85(s1);
+        s1 = peg$c209(s1);
+      }
+      s0 = s1;
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parsechem_text() {
+      var s0, s1, s2;
+
+      var key    = peg$currPos * 115 + 43,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      s0 = peg$currPos;
+      s1 = [];
+      s2 = peg$parseboxchars();
+      if (s2 !== peg$FAILED) {
+        while (s2 !== peg$FAILED) {
+          s1.push(s2);
+          s2 = peg$parseboxchars();
+        }
+      } else {
+        s1 = peg$FAILED;
+      }
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c209(s1);
       }
       s0 = s1;
 
@@ -3044,7 +4442,7 @@ module.exports = /*
     function peg$parsealpha() {
       var s0;
 
-      var key    = peg$currPos * 105 + 34,
+      var key    = peg$currPos * 115 + 44,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3053,12 +4451,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c86.test(input.charAt(peg$currPos))) {
+      if (peg$c96.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c87); }
+        if (peg$silentFails === 0) { peg$fail(peg$c97); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3069,7 +4467,7 @@ module.exports = /*
     function peg$parseliteral_id() {
       var s0;
 
-      var key    = peg$currPos * 105 + 35,
+      var key    = peg$currPos * 115 + 45,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3078,12 +4476,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c86.test(input.charAt(peg$currPos))) {
+      if (peg$c96.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c87); }
+        if (peg$silentFails === 0) { peg$fail(peg$c97); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3094,7 +4492,7 @@ module.exports = /*
     function peg$parseliteral_mn() {
       var s0;
 
-      var key    = peg$currPos * 105 + 36,
+      var key    = peg$currPos * 115 + 46,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3119,7 +4517,7 @@ module.exports = /*
     function peg$parseliteral_uf_lt() {
       var s0;
 
-      var key    = peg$currPos * 105 + 37,
+      var key    = peg$currPos * 115 + 47,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3128,12 +4526,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c88.test(input.charAt(peg$currPos))) {
+      if (peg$c210.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c89); }
+        if (peg$silentFails === 0) { peg$fail(peg$c211); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3144,7 +4542,7 @@ module.exports = /*
     function peg$parsedelimiter_uf_lt() {
       var s0;
 
-      var key    = peg$currPos * 105 + 38,
+      var key    = peg$currPos * 115 + 48,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3153,12 +4551,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c90.test(input.charAt(peg$currPos))) {
+      if (peg$c212.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c91); }
+        if (peg$silentFails === 0) { peg$fail(peg$c213); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3169,7 +4567,7 @@ module.exports = /*
     function peg$parseliteral_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 105 + 39,
+      var key    = peg$currPos * 115 + 49,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3178,12 +4576,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c92.test(input.charAt(peg$currPos))) {
+      if (peg$c214.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c93); }
+        if (peg$silentFails === 0) { peg$fail(peg$c215); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3194,7 +4592,7 @@ module.exports = /*
     function peg$parsedelimiter_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 105 + 40,
+      var key    = peg$currPos * 115 + 50,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3203,12 +4601,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c94.test(input.charAt(peg$currPos))) {
+      if (peg$c216.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c95); }
+        if (peg$silentFails === 0) { peg$fail(peg$c217); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3219,7 +4617,7 @@ module.exports = /*
     function peg$parseboxchars() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 41,
+      var key    = peg$currPos * 115 + 51,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3228,33 +4626,33 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c96.test(input.charAt(peg$currPos))) {
+      if (peg$c218.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c97); }
+        if (peg$silentFails === 0) { peg$fail(peg$c219); }
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (peg$c98.test(input.charAt(peg$currPos))) {
+        if (peg$c220.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c99); }
+          if (peg$silentFails === 0) { peg$fail(peg$c221); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c100.test(input.charAt(peg$currPos))) {
+          if (peg$c222.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c101); }
+            if (peg$silentFails === 0) { peg$fail(peg$c223); }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c102(s1, s2);
+            s1 = peg$c224(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3274,7 +4672,7 @@ module.exports = /*
     function peg$parseBOX() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
-      var key    = peg$currPos * 105 + 42,
+      var key    = peg$currPos * 115 + 52,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3287,7 +4685,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c103(s1);
+        s2 = peg$c225(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -3297,11 +4695,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c104;
+              s4 = peg$c226;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c105); }
+              if (peg$silentFails === 0) { peg$fail(peg$c227); }
             }
             if (s4 !== peg$FAILED) {
               s5 = [];
@@ -3326,7 +4724,7 @@ module.exports = /*
                   s7 = peg$parse_();
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c106(s1, s5);
+                    s1 = peg$c228(s1, s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3365,7 +4763,7 @@ module.exports = /*
     function peg$parseLITERAL() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-      var key    = peg$currPos * 105 + 43,
+      var key    = peg$currPos * 115 + 53,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3382,11 +4780,11 @@ module.exports = /*
           s1 = peg$parseliteral_uf_lt();
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 45) {
-              s1 = peg$c107;
+              s1 = peg$c113;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c108); }
+              if (peg$silentFails === 0) { peg$fail(peg$c114); }
             }
             if (s1 === peg$FAILED) {
               s1 = peg$parseliteral_uf_op();
@@ -3398,7 +4796,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c109(s1);
+          s1 = peg$c229(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3413,7 +4811,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c110(s1);
+          s2 = peg$c230(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -3423,11 +4821,11 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s4 = peg$c111;
+                s4 = peg$c119;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c112); }
+                if (peg$silentFails === 0) { peg$fail(peg$c120); }
               }
               if (s4 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 91) {
@@ -3438,19 +4836,19 @@ module.exports = /*
                   if (peg$silentFails === 0) { peg$fail(peg$c79); }
                 }
                 if (s4 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c113) {
-                    s4 = peg$c113;
+                  if (input.substr(peg$currPos, 2) === peg$c123) {
+                    s4 = peg$c123;
                     peg$currPos += 2;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c124); }
                   }
                   if (s4 === peg$FAILED) {
                     s4 = peg$currPos;
                     s5 = peg$c6;
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s4;
-                      s5 = peg$c115(s1);
+                      s5 = peg$c231(s1);
                     }
                     s4 = s5;
                   }
@@ -3460,7 +4858,7 @@ module.exports = /*
                 s5 = peg$parse_();
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c116(s1, s4);
+                  s1 = peg$c232(s1, s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3487,7 +4885,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c117(s1);
+            s2 = peg$c233(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -3497,11 +4895,11 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s4 = peg$c111;
+                  s4 = peg$c119;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c112); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c120); }
                 }
                 if (s4 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 91) {
@@ -3512,19 +4910,19 @@ module.exports = /*
                     if (peg$silentFails === 0) { peg$fail(peg$c79); }
                   }
                   if (s4 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 2) === peg$c113) {
-                      s4 = peg$c113;
+                    if (input.substr(peg$currPos, 2) === peg$c123) {
+                      s4 = peg$c123;
                       peg$currPos += 2;
                     } else {
                       s4 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c124); }
                     }
                     if (s4 === peg$FAILED) {
                       s4 = peg$currPos;
                       s5 = peg$c6;
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s4;
-                        s5 = peg$c115(s1);
+                        s5 = peg$c231(s1);
                       }
                       s4 = s5;
                     }
@@ -3534,7 +4932,7 @@ module.exports = /*
                   s5 = peg$parse_();
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c118(s1, s4);
+                    s1 = peg$c234(s1, s4);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3561,7 +4959,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c119(s1);
+              s2 = peg$c235(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -3571,7 +4969,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c120(s1);
+                  s1 = peg$c236(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3590,7 +4988,7 @@ module.exports = /*
               s1 = peg$parsegeneric_func();
               if (s1 !== peg$FAILED) {
                 peg$savedPos = peg$currPos;
-                s2 = peg$c121(s1);
+                s2 = peg$c237(s1);
                 if (s2) {
                   s2 = void 0;
                 } else {
@@ -3600,7 +4998,7 @@ module.exports = /*
                   s3 = peg$parse_();
                   if (s3 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c122(s1);
+                    s1 = peg$c238(s1);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -3619,7 +5017,7 @@ module.exports = /*
                 s1 = peg$parsegeneric_func();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = peg$currPos;
-                  s2 = peg$c123(s1);
+                  s2 = peg$c239(s1);
                   if (s2) {
                     s2 = void 0;
                   } else {
@@ -3629,17 +5027,17 @@ module.exports = /*
                     s3 = peg$parse_();
                     if (s3 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 123) {
-                        s4 = peg$c104;
+                        s4 = peg$c226;
                         peg$currPos++;
                       } else {
                         s4 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c105); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c227); }
                       }
                       if (s4 !== peg$FAILED) {
                         s5 = peg$parsegeneric_func();
                         if (s5 !== peg$FAILED) {
                           peg$savedPos = peg$currPos;
-                          s6 = peg$c124(s1, s5);
+                          s6 = peg$c240(s1, s5);
                           if (s6) {
                             s6 = void 0;
                           } else {
@@ -3659,7 +5057,7 @@ module.exports = /*
                                 s9 = peg$parse_();
                                 if (s9 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c125(s1, s5);
+                                  s1 = peg$c241(s1, s5);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -3702,7 +5100,7 @@ module.exports = /*
                   s1 = peg$parsegeneric_func();
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = peg$currPos;
-                    s2 = peg$c126(s1);
+                    s2 = peg$c242(s1);
                     if (s2) {
                       s2 = void 0;
                     } else {
@@ -3712,7 +5110,7 @@ module.exports = /*
                       s3 = peg$parse_();
                       if (s3 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c127(s1);
+                        s1 = peg$c243(s1);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3731,7 +5129,7 @@ module.exports = /*
                     s1 = peg$parsegeneric_func();
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = peg$currPos;
-                      s2 = peg$c128(s1);
+                      s2 = peg$c244(s1);
                       if (s2) {
                         s2 = void 0;
                       } else {
@@ -3741,17 +5139,17 @@ module.exports = /*
                         s3 = peg$parse_();
                         if (s3 !== peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 123) {
-                            s4 = peg$c104;
+                            s4 = peg$c226;
                             peg$currPos++;
                           } else {
                             s4 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c105); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c227); }
                           }
                           if (s4 !== peg$FAILED) {
                             s5 = peg$parsegeneric_func();
                             if (s5 !== peg$FAILED) {
                               peg$savedPos = peg$currPos;
-                              s6 = peg$c129(s1, s5);
+                              s6 = peg$c245(s1, s5);
                               if (s6) {
                                 s6 = void 0;
                               } else {
@@ -3771,7 +5169,7 @@ module.exports = /*
                                     s9 = peg$parse_();
                                     if (s9 !== peg$FAILED) {
                                       peg$savedPos = s0;
-                                      s1 = peg$c130(s1, s5);
+                                      s1 = peg$c246(s1, s5);
                                       s0 = s1;
                                     } else {
                                       peg$currPos = s0;
@@ -3817,31 +5215,31 @@ module.exports = /*
                       }
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c131(s1);
+                        s1 = peg$c247(s1);
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
                         if (input.charCodeAt(peg$currPos) === 92) {
-                          s1 = peg$c132;
+                          s1 = peg$c141;
                           peg$currPos++;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c133); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c142); }
                         }
                         if (s1 !== peg$FAILED) {
-                          if (peg$c134.test(input.charAt(peg$currPos))) {
+                          if (peg$c248.test(input.charAt(peg$currPos))) {
                             s2 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s2 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c135); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c249); }
                           }
                           if (s2 !== peg$FAILED) {
                             s3 = peg$parse_();
                             if (s3 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c136(s2);
+                              s1 = peg$c250(s2);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -3857,18 +5255,18 @@ module.exports = /*
                         }
                         if (s0 === peg$FAILED) {
                           s0 = peg$currPos;
-                          if (peg$c137.test(input.charAt(peg$currPos))) {
+                          if (peg$c251.test(input.charAt(peg$currPos))) {
                             s1 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c138); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c252); }
                           }
                           if (s1 !== peg$FAILED) {
                             s2 = peg$parse_();
                             if (s2 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c109(s1);
+                              s1 = peg$c229(s1);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -3880,18 +5278,18 @@ module.exports = /*
                           }
                           if (s0 === peg$FAILED) {
                             s0 = peg$currPos;
-                            if (peg$c139.test(input.charAt(peg$currPos))) {
+                            if (peg$c253.test(input.charAt(peg$currPos))) {
                               s1 = input.charAt(peg$currPos);
                               peg$currPos++;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c140); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c254); }
                             }
                             if (s1 !== peg$FAILED) {
                               s2 = peg$parse_();
                               if (s2 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c141(s1);
+                                s1 = peg$c255(s1);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -3921,7 +5319,7 @@ module.exports = /*
     function peg$parseDELIMITER() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 44,
+      var key    = peg$currPos * 115 + 54,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3948,7 +5346,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c109(s1);
+          s1 = peg$c229(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3961,25 +5359,25 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c132;
+          s1 = peg$c141;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c133); }
+          if (peg$silentFails === 0) { peg$fail(peg$c142); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c142.test(input.charAt(peg$currPos))) {
+          if (peg$c256.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c143); }
+            if (peg$silentFails === 0) { peg$fail(peg$c257); }
           }
           if (s2 !== peg$FAILED) {
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c136(s2);
+              s1 = peg$c250(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3998,7 +5396,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c144(s1);
+            s2 = peg$c258(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -4008,7 +5406,7 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c120(s1);
+                s1 = peg$c236(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4027,7 +5425,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c145(s1);
+              s2 = peg$c259(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -4037,7 +5435,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c146(s1);
+                  s1 = peg$c260(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4063,7 +5461,7 @@ module.exports = /*
     function peg$parseFUN_AR1nb() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 45,
+      var key    = peg$currPos * 115 + 55,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4076,7 +5474,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c147(s1);
+        s2 = peg$c261(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -4086,7 +5484,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c148(s1);
+            s1 = peg$c262(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4109,7 +5507,7 @@ module.exports = /*
     function peg$parseFUN_AR1opt() {
       var s0, s1, s2, s3, s4, s5;
 
-      var key    = peg$currPos * 105 + 46,
+      var key    = peg$currPos * 115 + 56,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4122,7 +5520,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c149(s1);
+        s2 = peg$c263(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -4142,7 +5540,7 @@ module.exports = /*
               s5 = peg$parse_();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c148(s1);
+                s1 = peg$c262(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4173,7 +5571,7 @@ module.exports = /*
     function peg$parseNEXT_CELL() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 47,
+      var key    = peg$currPos * 115 + 57,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4184,11 +5582,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 38) {
-        s1 = peg$c150;
+        s1 = peg$c139;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c151); }
+        if (peg$silentFails === 0) { peg$fail(peg$c140); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4212,7 +5610,7 @@ module.exports = /*
     function peg$parseNEXT_ROW() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 48,
+      var key    = peg$currPos * 115 + 58,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4222,12 +5620,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c152) {
-        s1 = peg$c152;
+      if (input.substr(peg$currPos, 2) === peg$c264) {
+        s1 = peg$c264;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c153); }
+        if (peg$silentFails === 0) { peg$fail(peg$c265); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4251,7 +5649,7 @@ module.exports = /*
     function peg$parseBEGIN() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 49,
+      var key    = peg$currPos * 115 + 59,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4261,12 +5659,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c154) {
-        s1 = peg$c154;
+      if (input.substr(peg$currPos, 6) === peg$c266) {
+        s1 = peg$c266;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c155); }
+        if (peg$silentFails === 0) { peg$fail(peg$c267); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4290,7 +5688,7 @@ module.exports = /*
     function peg$parseEND() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 50,
+      var key    = peg$currPos * 115 + 60,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4300,12 +5698,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c156) {
-        s1 = peg$c156;
+      if (input.substr(peg$currPos, 4) === peg$c268) {
+        s1 = peg$c268;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c157); }
+        if (peg$silentFails === 0) { peg$fail(peg$c269); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4329,7 +5727,7 @@ module.exports = /*
     function peg$parseBEGIN_MATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 51,
+      var key    = peg$currPos * 115 + 61,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4341,12 +5739,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c158) {
-          s2 = peg$c158;
+        if (input.substr(peg$currPos, 8) === peg$c270) {
+          s2 = peg$c270;
           peg$currPos += 8;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c159); }
+          if (peg$silentFails === 0) { peg$fail(peg$c271); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4374,7 +5772,7 @@ module.exports = /*
     function peg$parseEND_MATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 52,
+      var key    = peg$currPos * 115 + 62,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4386,12 +5784,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c158) {
-          s2 = peg$c158;
+        if (input.substr(peg$currPos, 8) === peg$c270) {
+          s2 = peg$c270;
           peg$currPos += 8;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c159); }
+          if (peg$silentFails === 0) { peg$fail(peg$c271); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4419,7 +5817,7 @@ module.exports = /*
     function peg$parseBEGIN_PMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 53,
+      var key    = peg$currPos * 115 + 63,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4431,12 +5829,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c160) {
-          s2 = peg$c160;
+        if (input.substr(peg$currPos, 9) === peg$c272) {
+          s2 = peg$c272;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c161); }
+          if (peg$silentFails === 0) { peg$fail(peg$c273); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4464,7 +5862,7 @@ module.exports = /*
     function peg$parseEND_PMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 54,
+      var key    = peg$currPos * 115 + 64,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4476,12 +5874,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c160) {
-          s2 = peg$c160;
+        if (input.substr(peg$currPos, 9) === peg$c272) {
+          s2 = peg$c272;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c161); }
+          if (peg$silentFails === 0) { peg$fail(peg$c273); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4509,7 +5907,7 @@ module.exports = /*
     function peg$parseBEGIN_BMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 55,
+      var key    = peg$currPos * 115 + 65,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4521,12 +5919,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c162) {
-          s2 = peg$c162;
+        if (input.substr(peg$currPos, 9) === peg$c274) {
+          s2 = peg$c274;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c163); }
+          if (peg$silentFails === 0) { peg$fail(peg$c275); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4554,7 +5952,7 @@ module.exports = /*
     function peg$parseEND_BMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 56,
+      var key    = peg$currPos * 115 + 66,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4566,12 +5964,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c162) {
-          s2 = peg$c162;
+        if (input.substr(peg$currPos, 9) === peg$c274) {
+          s2 = peg$c274;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c163); }
+          if (peg$silentFails === 0) { peg$fail(peg$c275); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4599,7 +5997,7 @@ module.exports = /*
     function peg$parseBEGIN_BBMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 57,
+      var key    = peg$currPos * 115 + 67,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4611,12 +6009,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c164) {
-          s2 = peg$c164;
+        if (input.substr(peg$currPos, 9) === peg$c276) {
+          s2 = peg$c276;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c165); }
+          if (peg$silentFails === 0) { peg$fail(peg$c277); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4644,7 +6042,7 @@ module.exports = /*
     function peg$parseEND_BBMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 58,
+      var key    = peg$currPos * 115 + 68,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4656,12 +6054,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c164) {
-          s2 = peg$c164;
+        if (input.substr(peg$currPos, 9) === peg$c276) {
+          s2 = peg$c276;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c165); }
+          if (peg$silentFails === 0) { peg$fail(peg$c277); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4689,7 +6087,7 @@ module.exports = /*
     function peg$parseBEGIN_VMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 59,
+      var key    = peg$currPos * 115 + 69,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4701,12 +6099,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c166) {
-          s2 = peg$c166;
+        if (input.substr(peg$currPos, 9) === peg$c278) {
+          s2 = peg$c278;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c167); }
+          if (peg$silentFails === 0) { peg$fail(peg$c279); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4734,7 +6132,7 @@ module.exports = /*
     function peg$parseEND_VMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 60,
+      var key    = peg$currPos * 115 + 70,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4746,12 +6144,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c166) {
-          s2 = peg$c166;
+        if (input.substr(peg$currPos, 9) === peg$c278) {
+          s2 = peg$c278;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c167); }
+          if (peg$silentFails === 0) { peg$fail(peg$c279); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4779,7 +6177,7 @@ module.exports = /*
     function peg$parseBEGIN_VVMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 61,
+      var key    = peg$currPos * 115 + 71,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4791,12 +6189,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c168) {
-          s2 = peg$c168;
+        if (input.substr(peg$currPos, 9) === peg$c280) {
+          s2 = peg$c280;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c169); }
+          if (peg$silentFails === 0) { peg$fail(peg$c281); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4824,7 +6222,7 @@ module.exports = /*
     function peg$parseEND_VVMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 62,
+      var key    = peg$currPos * 115 + 72,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4836,12 +6234,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c168) {
-          s2 = peg$c168;
+        if (input.substr(peg$currPos, 9) === peg$c280) {
+          s2 = peg$c280;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c169); }
+          if (peg$silentFails === 0) { peg$fail(peg$c281); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4869,7 +6267,7 @@ module.exports = /*
     function peg$parseBEGIN_ARRAY() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 63,
+      var key    = peg$currPos * 115 + 73,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4881,12 +6279,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c170) {
-          s2 = peg$c170;
+        if (input.substr(peg$currPos, 7) === peg$c282) {
+          s2 = peg$c282;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c171); }
+          if (peg$silentFails === 0) { peg$fail(peg$c283); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4914,7 +6312,7 @@ module.exports = /*
     function peg$parseEND_ARRAY() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 64,
+      var key    = peg$currPos * 115 + 74,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4926,12 +6324,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c170) {
-          s2 = peg$c170;
+        if (input.substr(peg$currPos, 7) === peg$c282) {
+          s2 = peg$c282;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c171); }
+          if (peg$silentFails === 0) { peg$fail(peg$c283); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -4959,7 +6357,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGN() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 65,
+      var key    = peg$currPos * 115 + 75,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -4971,12 +6369,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c172) {
-          s2 = peg$c172;
+        if (input.substr(peg$currPos, 7) === peg$c284) {
+          s2 = peg$c284;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c173); }
+          if (peg$silentFails === 0) { peg$fail(peg$c285); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5004,7 +6402,7 @@ module.exports = /*
     function peg$parseEND_ALIGN() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 66,
+      var key    = peg$currPos * 115 + 76,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5016,12 +6414,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c172) {
-          s2 = peg$c172;
+        if (input.substr(peg$currPos, 7) === peg$c284) {
+          s2 = peg$c284;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c173); }
+          if (peg$silentFails === 0) { peg$fail(peg$c285); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5049,7 +6447,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNED() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 67,
+      var key    = peg$currPos * 115 + 77,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5061,12 +6459,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c174) {
-          s2 = peg$c174;
+        if (input.substr(peg$currPos, 9) === peg$c286) {
+          s2 = peg$c286;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c175); }
+          if (peg$silentFails === 0) { peg$fail(peg$c287); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5094,7 +6492,7 @@ module.exports = /*
     function peg$parseEND_ALIGNED() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 68,
+      var key    = peg$currPos * 115 + 78,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5106,12 +6504,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c174) {
-          s2 = peg$c174;
+        if (input.substr(peg$currPos, 9) === peg$c286) {
+          s2 = peg$c286;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c175); }
+          if (peg$silentFails === 0) { peg$fail(peg$c287); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5139,7 +6537,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 69,
+      var key    = peg$currPos * 115 + 79,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5151,12 +6549,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c176) {
-          s2 = peg$c176;
+        if (input.substr(peg$currPos, 9) === peg$c288) {
+          s2 = peg$c288;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c177); }
+          if (peg$silentFails === 0) { peg$fail(peg$c289); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5184,7 +6582,7 @@ module.exports = /*
     function peg$parseEND_ALIGNAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 70,
+      var key    = peg$currPos * 115 + 80,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5196,12 +6594,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c176) {
-          s2 = peg$c176;
+        if (input.substr(peg$currPos, 9) === peg$c288) {
+          s2 = peg$c288;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c177); }
+          if (peg$silentFails === 0) { peg$fail(peg$c289); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5229,7 +6627,7 @@ module.exports = /*
     function peg$parseBEGIN_ALIGNEDAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 71,
+      var key    = peg$currPos * 115 + 81,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5241,12 +6639,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c178) {
-          s2 = peg$c178;
+        if (input.substr(peg$currPos, 11) === peg$c290) {
+          s2 = peg$c290;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c179); }
+          if (peg$silentFails === 0) { peg$fail(peg$c291); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5274,7 +6672,7 @@ module.exports = /*
     function peg$parseEND_ALIGNEDAT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 72,
+      var key    = peg$currPos * 115 + 82,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5286,12 +6684,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c178) {
-          s2 = peg$c178;
+        if (input.substr(peg$currPos, 11) === peg$c290) {
+          s2 = peg$c290;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c179); }
+          if (peg$silentFails === 0) { peg$fail(peg$c291); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5319,7 +6717,7 @@ module.exports = /*
     function peg$parseBEGIN_SMALLMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 73,
+      var key    = peg$currPos * 115 + 83,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5331,12 +6729,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c180) {
-          s2 = peg$c180;
+        if (input.substr(peg$currPos, 13) === peg$c292) {
+          s2 = peg$c292;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c181); }
+          if (peg$silentFails === 0) { peg$fail(peg$c293); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5364,7 +6762,7 @@ module.exports = /*
     function peg$parseEND_SMALLMATRIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 74,
+      var key    = peg$currPos * 115 + 84,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5376,12 +6774,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c180) {
-          s2 = peg$c180;
+        if (input.substr(peg$currPos, 13) === peg$c292) {
+          s2 = peg$c292;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c181); }
+          if (peg$silentFails === 0) { peg$fail(peg$c293); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5409,7 +6807,7 @@ module.exports = /*
     function peg$parseBEGIN_CASES() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 75,
+      var key    = peg$currPos * 115 + 85,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5421,12 +6819,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c182) {
-          s2 = peg$c182;
+        if (input.substr(peg$currPos, 7) === peg$c294) {
+          s2 = peg$c294;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c183); }
+          if (peg$silentFails === 0) { peg$fail(peg$c295); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5454,7 +6852,7 @@ module.exports = /*
     function peg$parseEND_CASES() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 76,
+      var key    = peg$currPos * 115 + 86,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5466,12 +6864,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c182) {
-          s2 = peg$c182;
+        if (input.substr(peg$currPos, 7) === peg$c294) {
+          s2 = peg$c294;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c183); }
+          if (peg$silentFails === 0) { peg$fail(peg$c295); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5499,7 +6897,7 @@ module.exports = /*
     function peg$parseSQ_CLOSE() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 77,
+      var key    = peg$currPos * 115 + 87,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5538,7 +6936,7 @@ module.exports = /*
     function peg$parseCURLY_OPEN() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 78,
+      var key    = peg$currPos * 115 + 88,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5549,11 +6947,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c104;
+        s1 = peg$c226;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c105); }
+        if (peg$silentFails === 0) { peg$fail(peg$c227); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -5577,7 +6975,7 @@ module.exports = /*
     function peg$parseCURLY_CLOSE() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 79,
+      var key    = peg$currPos * 115 + 89,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5616,7 +7014,7 @@ module.exports = /*
     function peg$parseSUP() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 80,
+      var key    = peg$currPos * 115 + 90,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5627,11 +7025,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 94) {
-        s1 = peg$c184;
+        s1 = peg$c91;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c185); }
+        if (peg$silentFails === 0) { peg$fail(peg$c92); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -5655,7 +7053,7 @@ module.exports = /*
     function peg$parseSUB() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 81,
+      var key    = peg$currPos * 115 + 91,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5666,11 +7064,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 95) {
-        s1 = peg$c186;
+        s1 = peg$c147;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c187); }
+        if (peg$silentFails === 0) { peg$fail(peg$c148); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -5694,7 +7092,7 @@ module.exports = /*
     function peg$parsegeneric_func() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 82,
+      var key    = peg$currPos * 115 + 92,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5705,11 +7103,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c132;
+        s1 = peg$c141;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c133); }
+        if (peg$silentFails === 0) { peg$fail(peg$c142); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -5743,7 +7141,7 @@ module.exports = /*
     function peg$parseBIG() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 83,
+      var key    = peg$currPos * 115 + 93,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5756,7 +7154,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c188(s1);
+        s2 = peg$c296(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -5766,7 +7164,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c148(s1);
+            s1 = peg$c262(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5789,7 +7187,7 @@ module.exports = /*
     function peg$parseFUN_AR1() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 84,
+      var key    = peg$currPos * 115 + 94,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5802,7 +7200,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c189(s1);
+        s2 = peg$c297(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -5812,7 +7210,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c148(s1);
+            s1 = peg$c262(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5831,7 +7229,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c190(s1);
+          s2 = peg$c298(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -5841,7 +7239,7 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c190(s1);
+              s1 = peg$c298(s1);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5865,7 +7263,7 @@ module.exports = /*
     function peg$parseFUN_MHCHEM() {
       var s0, s1, s2;
 
-      var key    = peg$currPos * 105 + 85,
+      var key    = peg$currPos * 115 + 95,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5878,7 +7276,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c191(s1);
+        s2 = peg$c299(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -5886,7 +7284,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c148(s1);
+          s1 = peg$c262(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5905,7 +7303,7 @@ module.exports = /*
     function peg$parseFUN_AR2() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 86,
+      var key    = peg$currPos * 115 + 96,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5918,7 +7316,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c192(s1);
+        s2 = peg$c300(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -5928,7 +7326,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c148(s1);
+            s1 = peg$c262(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5951,7 +7349,7 @@ module.exports = /*
     function peg$parseFUN_INFIX() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 87,
+      var key    = peg$currPos * 115 + 97,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -5964,7 +7362,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c193(s1);
+        s2 = peg$c301(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -5974,7 +7372,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c148(s1);
+            s1 = peg$c262(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5997,7 +7395,7 @@ module.exports = /*
     function peg$parseDECLh() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 88,
+      var key    = peg$currPos * 115 + 98,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6010,7 +7408,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c194(s1);
+        s2 = peg$c302(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6020,7 +7418,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c195(s1);
+            s1 = peg$c303(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6043,7 +7441,7 @@ module.exports = /*
     function peg$parseFUN_AR2nb() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 89,
+      var key    = peg$currPos * 115 + 99,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6056,7 +7454,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c196(s1);
+        s2 = peg$c304(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6066,7 +7464,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c148(s1);
+            s1 = peg$c262(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6089,7 +7487,7 @@ module.exports = /*
     function peg$parseLEFT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 90,
+      var key    = peg$currPos * 115 + 100,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6102,7 +7500,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c197(s1);
+        s2 = peg$c305(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6134,7 +7532,7 @@ module.exports = /*
     function peg$parseRIGHT() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 91,
+      var key    = peg$currPos * 115 + 101,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6147,7 +7545,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c198(s1);
+        s2 = peg$c306(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6179,7 +7577,7 @@ module.exports = /*
     function peg$parseHLINE() {
       var s0, s1, s2, s3;
 
-      var key    = peg$currPos * 105 + 92,
+      var key    = peg$currPos * 115 + 102,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6192,7 +7590,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c199(s1);
+        s2 = peg$c307(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6202,7 +7600,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c148(s1);
+            s1 = peg$c262(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6225,7 +7623,7 @@ module.exports = /*
     function peg$parseCOLOR() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 105 + 93,
+      var key    = peg$currPos * 115 + 103,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6238,7 +7636,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c200(s1);
+        s2 = peg$c308(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6250,7 +7648,7 @@ module.exports = /*
             s4 = peg$parseCOLOR_SPEC();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c201(s1, s4);
+              s1 = peg$c309(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6277,7 +7675,7 @@ module.exports = /*
     function peg$parseDEFINECOLOR() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17;
 
-      var key    = peg$currPos * 105 + 94,
+      var key    = peg$currPos * 115 + 104,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6290,7 +7688,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c202(s1);
+        s2 = peg$c310(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6300,11 +7698,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c104;
+              s4 = peg$c226;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c105); }
+              if (peg$silentFails === 0) { peg$fail(peg$c227); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -6333,22 +7731,22 @@ module.exports = /*
                       s9 = peg$parse_();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 123) {
-                          s10 = peg$c104;
+                          s10 = peg$c226;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c105); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c227); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             s12 = peg$currPos;
-                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c203) {
+                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c311) {
                               s13 = input.substr(peg$currPos, 5);
                               peg$currPos += 5;
                             } else {
                               s13 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c204); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c312); }
                             }
                             if (s13 !== peg$FAILED) {
                               s14 = peg$parse_();
@@ -6366,7 +7764,7 @@ module.exports = /*
                                     s17 = peg$parseCOLOR_SPEC_NAMED();
                                     if (s17 !== peg$FAILED) {
                                       peg$savedPos = s12;
-                                      s13 = peg$c205(s1, s6, s17);
+                                      s13 = peg$c313(s1, s6, s17);
                                       s12 = s13;
                                     } else {
                                       peg$currPos = s12;
@@ -6390,12 +7788,12 @@ module.exports = /*
                             }
                             if (s12 === peg$FAILED) {
                               s12 = peg$currPos;
-                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c206) {
+                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c314) {
                                 s13 = input.substr(peg$currPos, 4);
                                 peg$currPos += 4;
                               } else {
                                 s13 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c207); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c315); }
                               }
                               if (s13 !== peg$FAILED) {
                                 s14 = peg$parse_();
@@ -6413,7 +7811,7 @@ module.exports = /*
                                       s17 = peg$parseCOLOR_SPEC_GRAY();
                                       if (s17 !== peg$FAILED) {
                                         peg$savedPos = s12;
-                                        s13 = peg$c208(s1, s6, s17);
+                                        s13 = peg$c316(s1, s6, s17);
                                         s12 = s13;
                                       } else {
                                         peg$currPos = s12;
@@ -6437,12 +7835,12 @@ module.exports = /*
                               }
                               if (s12 === peg$FAILED) {
                                 s12 = peg$currPos;
-                                if (input.substr(peg$currPos, 3) === peg$c209) {
-                                  s13 = peg$c209;
+                                if (input.substr(peg$currPos, 3) === peg$c317) {
+                                  s13 = peg$c317;
                                   peg$currPos += 3;
                                 } else {
                                   s13 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c210); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c318); }
                                 }
                                 if (s13 !== peg$FAILED) {
                                   s14 = peg$parse_();
@@ -6460,7 +7858,7 @@ module.exports = /*
                                         s17 = peg$parseCOLOR_SPEC_rgb();
                                         if (s17 !== peg$FAILED) {
                                           peg$savedPos = s12;
-                                          s13 = peg$c211(s1, s6, s17);
+                                          s13 = peg$c319(s1, s6, s17);
                                           s12 = s13;
                                         } else {
                                           peg$currPos = s12;
@@ -6484,12 +7882,12 @@ module.exports = /*
                                 }
                                 if (s12 === peg$FAILED) {
                                   s12 = peg$currPos;
-                                  if (input.substr(peg$currPos, 3) === peg$c212) {
-                                    s13 = peg$c212;
+                                  if (input.substr(peg$currPos, 3) === peg$c320) {
+                                    s13 = peg$c320;
                                     peg$currPos += 3;
                                   } else {
                                     s13 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c213); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c321); }
                                   }
                                   if (s13 !== peg$FAILED) {
                                     s14 = peg$parse_();
@@ -6507,7 +7905,7 @@ module.exports = /*
                                           s17 = peg$parseCOLOR_SPEC_RGB();
                                           if (s17 !== peg$FAILED) {
                                             peg$savedPos = s12;
-                                            s13 = peg$c211(s1, s6, s17);
+                                            s13 = peg$c319(s1, s6, s17);
                                             s12 = s13;
                                           } else {
                                             peg$currPos = s12;
@@ -6531,12 +7929,12 @@ module.exports = /*
                                   }
                                   if (s12 === peg$FAILED) {
                                     s12 = peg$currPos;
-                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c214) {
+                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c322) {
                                       s13 = input.substr(peg$currPos, 4);
                                       peg$currPos += 4;
                                     } else {
                                       s13 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c215); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c323); }
                                     }
                                     if (s13 !== peg$FAILED) {
                                       s14 = peg$parse_();
@@ -6554,7 +7952,7 @@ module.exports = /*
                                             s17 = peg$parseCOLOR_SPEC_CMYK();
                                             if (s17 !== peg$FAILED) {
                                               peg$savedPos = s12;
-                                              s13 = peg$c216(s1, s6, s17);
+                                              s13 = peg$c324(s1, s6, s17);
                                               s12 = s13;
                                             } else {
                                               peg$currPos = s12;
@@ -6582,7 +7980,7 @@ module.exports = /*
                             }
                             if (s12 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c217(s1, s6, s12);
+                              s1 = peg$c325(s1, s6, s12);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -6641,7 +8039,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC() {
       var s0, s1, s2, s3, s4, s5, s6, s7;
 
-      var key    = peg$currPos * 105 + 95,
+      var key    = peg$currPos * 115 + 105,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -6663,12 +8061,12 @@ module.exports = /*
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c203) {
+            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c311) {
               s3 = input.substr(peg$currPos, 5);
               peg$currPos += 5;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c204); }
+              if (peg$silentFails === 0) { peg$fail(peg$c312); }
             }
             if (s3 !== peg$FAILED) {
               s4 = peg$parse_();
@@ -6686,7 +8084,7 @@ module.exports = /*
                     s7 = peg$parseCOLOR_SPEC_NAMED();
                     if (s7 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c218(s7);
+                      s1 = peg$c326(s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -6728,12 +8126,12 @@ module.exports = /*
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c206) {
+              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c314) {
                 s3 = input.substr(peg$currPos, 4);
                 peg$currPos += 4;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c207); }
+                if (peg$silentFails === 0) { peg$fail(peg$c315); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
@@ -6751,7 +8149,7 @@ module.exports = /*
                       s7 = peg$parseCOLOR_SPEC_GRAY();
                       if (s7 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c219(s7);
+                        s1 = peg$c327(s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -6793,12 +8191,12 @@ module.exports = /*
             if (s1 !== peg$FAILED) {
               s2 = peg$parse_();
               if (s2 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 3) === peg$c209) {
-                  s3 = peg$c209;
+                if (input.substr(peg$currPos, 3) === peg$c317) {
+                  s3 = peg$c317;
                   peg$currPos += 3;
                 } else {
                   s3 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c210); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c318); }
                 }
                 if (s3 !== peg$FAILED) {
                   s4 = peg$parse_();
@@ -6816,7 +8214,7 @@ module.exports = /*
                         s7 = peg$parseCOLOR_SPEC_rgb();
                         if (s7 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c220(s7);
+                          s1 = peg$c328(s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -6858,12 +8256,12 @@ module.exports = /*
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse_();
                 if (s2 !== peg$FAILED) {
-                  if (input.substr(peg$currPos, 3) === peg$c212) {
-                    s3 = peg$c212;
+                  if (input.substr(peg$currPos, 3) === peg$c320) {
+                    s3 = peg$c320;
                     peg$currPos += 3;
                   } else {
                     s3 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c213); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c321); }
                   }
                   if (s3 !== peg$FAILED) {
                     s4 = peg$parse_();
@@ -6881,7 +8279,7 @@ module.exports = /*
                           s7 = peg$parseCOLOR_SPEC_RGB();
                           if (s7 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c220(s7);
+                            s1 = peg$c328(s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -6923,12 +8321,12 @@ module.exports = /*
                 if (s1 !== peg$FAILED) {
                   s2 = peg$parse_();
                   if (s2 !== peg$FAILED) {
-                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c214) {
+                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c322) {
                       s3 = input.substr(peg$currPos, 4);
                       peg$currPos += 4;
                     } else {
                       s3 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c215); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c323); }
                     }
                     if (s3 !== peg$FAILED) {
                       s4 = peg$parse_();
@@ -6946,7 +8344,7 @@ module.exports = /*
                             s7 = peg$parseCOLOR_SPEC_CMYK();
                             if (s7 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c221(s7);
+                              s1 = peg$c329(s7);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -6990,7 +8388,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_NAMED() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 105 + 96,
+      var key    = peg$currPos * 115 + 106,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7001,11 +8399,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c104;
+        s1 = peg$c226;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c105); }
+        if (peg$silentFails === 0) { peg$fail(peg$c227); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7034,7 +8432,7 @@ module.exports = /*
                 s6 = peg$parse_();
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c222(s3);
+                  s1 = peg$c330(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7069,7 +8467,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_GRAY() {
       var s0, s1, s2, s3, s4;
 
-      var key    = peg$currPos * 105 + 97,
+      var key    = peg$currPos * 115 + 107,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7080,11 +8478,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c104;
+        s1 = peg$c226;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c105); }
+        if (peg$silentFails === 0) { peg$fail(peg$c227); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7109,7 +8507,7 @@ module.exports = /*
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c223(s3);
+              s1 = peg$c331(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7136,7 +8534,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_rgb() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-      var key    = peg$currPos * 105 + 98,
+      var key    = peg$currPos * 115 + 108,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7147,11 +8545,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c104;
+        s1 = peg$c226;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c105); }
+        if (peg$silentFails === 0) { peg$fail(peg$c227); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7159,11 +8557,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c224;
+              s4 = peg$c129;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c225); }
+              if (peg$silentFails === 0) { peg$fail(peg$c130); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7171,11 +8569,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c224;
+                    s7 = peg$c129;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c225); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c130); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -7193,7 +8591,7 @@ module.exports = /*
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c226(s3, s6, s9);
+                            s1 = peg$c332(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7248,7 +8646,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_RGB() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11;
 
-      var key    = peg$currPos * 105 + 99,
+      var key    = peg$currPos * 115 + 109,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7259,11 +8657,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c104;
+        s1 = peg$c226;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c105); }
+        if (peg$silentFails === 0) { peg$fail(peg$c227); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7271,11 +8669,11 @@ module.exports = /*
           s3 = peg$parseCNUM255();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c224;
+              s4 = peg$c129;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c225); }
+              if (peg$silentFails === 0) { peg$fail(peg$c130); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7283,11 +8681,11 @@ module.exports = /*
                 s6 = peg$parseCNUM255();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c224;
+                    s7 = peg$c129;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c225); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c130); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -7305,7 +8703,7 @@ module.exports = /*
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c226(s3, s6, s9);
+                            s1 = peg$c332(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7360,7 +8758,7 @@ module.exports = /*
     function peg$parseCOLOR_SPEC_CMYK() {
       var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14;
 
-      var key    = peg$currPos * 105 + 100,
+      var key    = peg$currPos * 115 + 110,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7371,11 +8769,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c104;
+        s1 = peg$c226;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c105); }
+        if (peg$silentFails === 0) { peg$fail(peg$c227); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7383,11 +8781,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c224;
+              s4 = peg$c129;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c225); }
+              if (peg$silentFails === 0) { peg$fail(peg$c130); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7395,11 +8793,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c224;
+                    s7 = peg$c129;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c225); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c130); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -7407,11 +8805,11 @@ module.exports = /*
                       s9 = peg$parseCNUM();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 44) {
-                          s10 = peg$c224;
+                          s10 = peg$c129;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c225); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c130); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
@@ -7429,7 +8827,7 @@ module.exports = /*
                                 s14 = peg$parse_();
                                 if (s14 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c227(s3, s6, s9, s12);
+                                  s1 = peg$c333(s3, s6, s9, s12);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -7496,7 +8894,7 @@ module.exports = /*
     function peg$parseCNUM255() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 105 + 101,
+      var key    = peg$currPos * 115 + 111,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7508,20 +8906,20 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s2 = peg$c228;
+        s2 = peg$c334;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c229); }
+        if (peg$silentFails === 0) { peg$fail(peg$c335); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$currPos;
-        if (peg$c230.test(input.charAt(peg$currPos))) {
+        if (peg$c336.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c231); }
+          if (peg$silentFails === 0) { peg$fail(peg$c337); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
@@ -7576,7 +8974,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c232(s1);
+        s2 = peg$c338(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -7586,7 +8984,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c233(s1);
+            s1 = peg$c339(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7609,7 +9007,7 @@ module.exports = /*
     function peg$parseCNUM() {
       var s0, s1, s2, s3, s4, s5, s6;
 
-      var key    = peg$currPos * 105 + 102,
+      var key    = peg$currPos * 115 + 112,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7622,22 +9020,22 @@ module.exports = /*
       s1 = peg$currPos;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s3 = peg$c228;
+        s3 = peg$c334;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c229); }
+        if (peg$silentFails === 0) { peg$fail(peg$c335); }
       }
       if (s3 === peg$FAILED) {
         s3 = null;
       }
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c234;
+          s4 = peg$c127;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c235); }
+          if (peg$silentFails === 0) { peg$fail(peg$c128); }
         }
         if (s4 !== peg$FAILED) {
           s5 = [];
@@ -7686,7 +9084,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c236(s1);
+          s1 = peg$c340(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -7700,20 +9098,20 @@ module.exports = /*
         s0 = peg$currPos;
         s1 = peg$currPos;
         s2 = peg$currPos;
-        if (peg$c237.test(input.charAt(peg$currPos))) {
+        if (peg$c341.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c238); }
+          if (peg$silentFails === 0) { peg$fail(peg$c342); }
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c234;
+            s4 = peg$c127;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c235); }
+            if (peg$silentFails === 0) { peg$fail(peg$c128); }
           }
           if (s4 === peg$FAILED) {
             s4 = null;
@@ -7738,7 +9136,7 @@ module.exports = /*
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c236(s1);
+            s1 = peg$c340(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -7758,7 +9156,7 @@ module.exports = /*
     function peg$parseimpossible() {
       var s0;
 
-      var key    = peg$currPos * 105 + 103,
+      var key    = peg$currPos * 115 + 113,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7768,7 +9166,7 @@ module.exports = /*
       }
 
       peg$savedPos = peg$currPos;
-      s0 = peg$c239();
+      s0 = peg$c343();
       if (s0) {
         s0 = void 0;
       } else {
@@ -7783,7 +9181,7 @@ module.exports = /*
     function peg$parseEOF() {
       var s0;
 
-      var key    = peg$currPos * 105 + 104,
+      var key    = peg$currPos * 115 + 114,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -7793,7 +9191,7 @@ module.exports = /*
       }
 
       peg$savedPos = peg$currPos;
-      s0 = peg$c240();
+      s0 = peg$c344();
       if (s0) {
         s0 = void 0;
       } else {

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -240,21 +240,22 @@ chem_phrase =
     m:CHEM_SINGLE_MACRO             { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); } /
     m:"^"                           { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); }
 
-// TODO second rule is iffy
 chem_word =
-    m:chem_char n:chem_word_nt                      { return ast.Tex.CHEM_WORD(m, n); }
-//    m:CHEM_SINGLE_MACRO n:chem_char o:chem_word_nt  { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(n)), ast.Tex.CHEM_WORD(n, o)); }
+    m:chem_char n:chem_word_nt                      { return ast.Tex.CHEM_WORD(m, n); } /
+    m:CHEM_SINGLE_MACRO n:chem_char_nl              { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)), n); }
 
 chem_word_nt = m:chem_word { return m; }/ "" { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("")); }
 
-// TODO find hooks in parser for math mode and text mode
-chem_char =
+chem_char_nl =
     m:chem_script                                   { return m;} /
     CURLY_OPEN c:chem_text CURLY_CLOSE              { return ast.Tex.CURLY([c]); } /
-    CHEM_DOLLAR c:chem_latex CHEM_DOLLAR            { return ast.Tex.DOLLAR([c]); } /
+    CHEM_DOLLAR c:chem_latex CHEM_DOLLAR            { return ast.Tex.DOLLAR(c.toArray()); } /
     name:CHEM_BOND l:chem_bond                      { return ast.Tex.CHEM_BOND(name, l); } /
     m:chem_macro                                    { return m; } /
-    c:CHEM_NONLETTER                                { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) } /
+    c:CHEM_NONLETTER                                { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) }
+
+chem_char =
+    m:chem_char_nl                                  { return m;} /
     c:CHEM_LETTER                                   { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) }
 
 chem_bond
@@ -274,8 +275,10 @@ chem_macro =
 
 chem_color = COLOR
 
+// TODO change from § to $
+chem_latex = e:expr { return e; } // cs:(boxchars / "_" / CURLY_OPEN / CURLY_CLOSE / "\\")+ { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); }
 
-chem_latex = cs:(boxchars / "_" / CURLY_OPEN / CURLY_CLOSE / "\\")+ { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); } //e:expr { return e; }
+
 chem_text = cs:boxchars+ { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); }
 
 /////////////////////////////////////////////////////////////
@@ -557,7 +560,7 @@ CHEM_SUPERSUB
 CHEM_BOND_TYPE
  = "=" / "#" / "~--" / "~-"  / "~=" / "~" / "-~-" / "...." / "..." / "<-" / "->" / "-" / "1" / "2" / "3"
 
-CHEM_DOLLAR = "$"
+CHEM_DOLLAR = "§"
 
 CHEM_BOND =
     f:generic_func &{ return tu.mhchem_bond[f]; } _ { return f; }

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -254,7 +254,7 @@ chem_char_nl =
     m:chem_script                                        { return m;} /
     CURLY_OPEN c:chem_text CURLY_CLOSE                   { return ast.Tex.CURLY([c]); } /
     BEGIN_MATH c:expr END_MATH                           { return ast.Tex.DOLLAR(c.toArray()); }/
-    name:CHEM_BOND l:chem_bond                           { return ast.Tex.CHEM_BOND(name, l); } /
+    name:CHEM_BOND l:chem_bond                           { return ast.Tex.FUN1(name, l); } /
     m:chem_macro                                         { return m; } /
     c:CHEM_NONLETTER                                     { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) }
 
@@ -268,12 +268,13 @@ chem_script =
 
 // TODO \color is a not documented feature of mhchem for MathJax, at the moment named colors are accepted
 chem_macro =
-    name:CHEM_MACRO_2PU l1:chem_lit "_" l2:chem_lit      { return ast.Tex.CHEM_FUN2u(name, l1, l2); }/
-    name:CHEM_MACRO_2PC l1:COLOR_SPEC_NAMED l2:chem_lit  { return ast.Tex.CHEM_FUN2c(l1, l2); } /
-    name:CHEM_MACRO_2P l1:chem_lit l2:chem_lit           { return ast.Tex.CHEM_FUN2(name, l1, l2); } /
-    name:CHEM_MACRO_1P l:chem_lit                        { return ast.Tex.CHEM_FUN1(name, l); }
+    name:CHEM_MACRO_2PU l1:chem_lit "_" l2:chem_lit      { return ast.Tex.CHEM_FUN2u(name, l1, l2); }/ //return ast.Tex.FUN1nb(name, l);
+    name:CHEM_MACRO_2PC l1:CHEM_COLOR l2:chem_lit        { return ast.Tex.FUN2(name, l1, l2); } /
+    name:CHEM_MACRO_2P l1:chem_lit l2:chem_lit           { return ast.Tex.FUN2(name, l1, l2); } /
+    name:CHEM_MACRO_1P l:chem_lit                        { return ast.Tex.FUN1(name, l); }
 
 chem_text = cs:boxchars+                                 { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); }
+CHEM_COLOR = "{" _ name:alpha+ _ "}" _                   { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(name.join(''))); }
 
 /////////////////////////////////////////////////////////////
 // LEXER
@@ -547,6 +548,9 @@ CHEM_SUPERSUB = "_" / "^"
 
 CHEM_BOND_TYPE = "=" / "#" / "~--" / "~-"  / "~=" / "~" / "-~-" / "...." / "..." / "<-" / "->" / "-" / "1" / "2" / "3"
 
+
+// As '$' cannot be used (dangerous char in math mode) to switch from chem mode to math mode
+// \begin{math} and \end{math} are introduced to do so
 BEGIN_MATH = BEGIN "{math}" _
 
 END_MATH = END "{math}" _

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -230,75 +230,57 @@ chem_lit
     { return ast.Tex.CURLY(e.toArray()); }
 
 chem_sentence = 
-    p:chem_phrase " " s:chem_sentence { return ast.LList(p,s); } /
-    p:chem_phrase { return ast.LList(p,ast.LList.EMPTY); } /
-    "" { return ast.LList.EMPTY; }
+//    _ p:chem_phrase " " s:chem_sentence { return ast.LList(p,ast.LList(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(" ")),s)); } /
+    _ p:chem_phrase _ { return ast.LList(p,ast.LList.EMPTY); }
 
 // TODO needs some work
-chem_phrase = 
-    m:chem_word                     { return ast.Tex.LITERAL(m); }/
-    m:chem_single_macro             { return ast.RenderT.TEX_ONLY(m); }/ 
-    m:chem_word n:chem_single_macro { return ast.RenderT.TEX_ONLY(m + n); } / 
-    m:"^"                           { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); }/ 
-    m:"(^)"                         { return ast.RenderT.TEX_ONLY(m); }
+chem_phrase =  
+//    m:"^"                           { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); }/
+//    m:"(^)"                         { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); }/
+//    m:chem_single_macro             { return ast.RenderT.TEX_ONLY(m); }/
+//    m:chem_word n:chem_single_macro { return ast.RenderT.TEX_ONLY(m + n); }/
+    m:chem_word                     { return m; }
     
 chem_word = 
-    m:[a-zA-Z] n:chem_word                            { return ast.RenderT.TEX_ONLY("baz"); }/
-    m:chem_nonletter n:chem_word                      { return ast.RenderT.TEX_ONLY("bar"); }/
-    m:chem_single_macro n:chem_nonletter o:chem_word  { return ast.RenderT.TEX_ONLY("foo"); } /
-    "" { return ast.RenderT.TEX_ONLY(""); }
+//    m:alpha n:chem_word_nt                               { return ast.LList(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)), n); }/
+    m:chem_nonletter n:chem_word_nt                      { return ast.LList(m, n); }
+//    m:chem_single_macro n:chem_nonletter o:chem_word_nt  { return ast.LList(n, o); }
 
-// TODO find char m:Apostrophe, move chars, write correct AST
+chem_word_nt = m:chem_word { return m; }/ "" { return ast.LList.EMPTY; }
+
+// TODO write correct AST
 chem_nonletter =
-    m:chem_script                                  { return m;} /
-    CURLY_OPEN e:chem_text CURLY_CLOSE             { return ast.RenderT.TEX_ONLY("{some text}"); } /
-    "$" b:chem_latex "$"                           { return ast.RenderT.TEX_ONLY("baz"); } /
-    "\\bond" CURLY_OPEN chem_bond_type CURLY_CLOSE { return ast.RenderT.TEX_ONLY("\bond{some bond}");}/
-    m:chem_macro_1p                                { return m;} /
-    m:chem_macro_2p                                { return m;} /
-    CURLY_OPEN CURLY_CLOSE                         { return ast.RenderT.TEX_ONLY("{}"); }/
-    m:[0-9]                                        { return ast.RenderT.TEX_ONLY(m); } /
-    "+" / "-" / "=" / "#" / "(" / ")" / "[" / "]" / "\\{" / "\\}" / "." / "," / ";" / "/" / "*" / "<" / ">" / "/" / "@" / "&" / "\\" // Apostrophe
-            { return ast.RenderT.TEX_ONLY("some char"); }
+//    m:chem_script                                   { return m;} /
+//    CURLY_OPEN e:chem_text CURLY_CLOSE              { return "{" + e + "}"; } /
+//    CHEM_DOLLAR b:chem_latex CHEM_DOLLAR            { return ast.RenderT.TEX_ONLY("$" + b + "$"); } /
+    name:CHEM_BOND l:chem_bond                      { return ast.Tex.CHEM_BOND(name, l);} //
+//    chem_macro /
+//    CHEM_NONLETTER
+
+chem_bond
+ = CURLY_OPEN e:CHEM_BOND_TYPE CURLY_CLOSE
+   { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(e))]); }
 
 chem_script = 
-    a:chem_supersub b:chem_script_follow  { return ast.RenderT.TEX_ONLY("foo"); } /
-    a:chem_supersub b:chem_lit            { return ast.RenderT.TEX_ONLY("bar"); } /
-    a:chem_supersub "$" b:chem_latex "$"  { return ast.RenderT.TEX_ONLY("baz"); }
-           
-chem_supersub = m:"_" / m:"^"
-    { return ast.RenderT.TEX_ONLY(m); }
-
-chem_script_follow = m:[0-9] / m:[a-zA-Z] / m:"+" / m:"-" / m:"." / m:"*" // TODO find char m:Apostrophe
-    { return ast.RenderT.TEX_ONLY(m); }
-
-chem_bond_type = m:"=" / m:"#" / m:"~--" / m:"~-"  / m:"~=" / m:"~" / m:"-~-" / m:"-" / m:"...." / m:"..." / m:"<-" / m:"->" / m:"1" / m:"2" / m:"3"
-    { return ast.RenderT.TEX_ONLY(m); }
+    a:CHEM_SUPERSUB b:CHEM_SCRIPT_FOLLOW  { return a + b; } /
+    a:CHEM_SUPERSUB b:chem_lit            { return a + b; } /
+    a:CHEM_SUPERSUB CHEM_DOLLAR b:chem_latex CHEM_DOLLAR  { return a + "$" + b + "$"; }
 
 // TODO Complete the list and move to file similarly to texutil.js
 chem_single_macro = m:"\\alpha" / m:"\\delta" / m:"\\mu" / m:"\\eta" / m:"\\gamma" / m:"\\pm" / m:"\\approx" / m:"\\ca"
-    { return ast.RenderT.TEX_ONLY(m); }
-    
-chem_macro_1p = 
-    name:'\ce' l:chem_lit { return ast.Tex.MHCHEM(name, l); } /
-    name:'\mathbf' l:chem_lit { return ast.Tex.MHCHEM(name, l); }
-  
-chem_macro_2p = 
-    name:"\\frac" l1:chem_lit l2:chem_lit { return ast.Tex.MHCHEM2(name, l1, l2); } /
-    name:"\\color" l1:chem_color l2:chem_lit { return ast.Tex.MHCHEM2(name, l1, l2); } /
-    name:"\\overset" l1:chem_lit l2:chem_lit { return ast.Tex.MHCHEM2(name, l1, l2); } /
-    name:"\\underset" l1:chem_lit l2:chem_lit { return ast.Tex.MHCHEM2(name, l1, l2); } /
-    name:"\\underbrace" l1:chem_lit "_" l2:chem_lit { return ast.Tex.MHCHEM2ub(name, l1, l2); }
+    { return m; }
+
+chem_macro = CHEM_MACRO_2PU chem_lit "_" chem_lit / CHEM_MACRO_2P chem_lit chem_lit / CHEM_MACRO_1P chem_lit
 
 // TODO extend to regular LaTeX treatment
-chem_color = m:"\\red" / m:"red" { return ast.RenderT.TEX_ONLY(m); }
+chem_color = m:"\\red" / m:"red" { return m; }
 
 chem_latex = m:boxchars+
     {
         var s = "";
         for (var c in m)
             s += m[c];
-        return ast.RenderT.TEX_ONLY(s);
+        return s;//ast.RenderT.TEX_ONLY(s);
     }
     
 chem_text = m:boxchars+
@@ -306,7 +288,7 @@ chem_text = m:boxchars+
         var s = "";
         for (var c in m)
             s += m[c];
-        return ast.RenderT.TEX_ONLY(s);
+        return s;//ast.RenderT.TEX_ONLY(s);
     }
 
 /////////////////////////////////////////////////////////////
@@ -570,3 +552,29 @@ impossible = & { return false; }
 
 // End of file
 EOF = & { return peg$currPos === input.length; }
+
+// MHCHEM
+
+CHEM_SCRIPT_FOLLOW = literal_mn / literal_id / [+-.*']
+
+CHEM_SUPERSUB
+ = "_" / "^"
+
+CHEM_BOND_TYPE
+ = "=" / "#" / "~--" / "~-"  / "~=" / "~" / "-~-" / "-" / "...." / "..." / "<-" / "->" / "1" / "2" / "3"
+
+CHEM_DOLLAR = "$"
+CHEM_BOND =
+    f:generic_func &{ return tu.mhchem_bond[f]; } { return f; }
+
+CHEM_NONLETTER = "\\{" / "\\}" / [+-=#().,;/*<>|@&\'\\\[\]] / literal_mn / CURLY_OPEN CURLY_CLOSE
+
+CHEM_MACRO_1P =
+    f:generic_func &{ return tu.mhchem_macro_1p[f]; } { return f; }
+
+CHEM_MACRO_2P =
+    f:generic_func &{ return tu.mhchem_macro_2p[f]; } { return f; }
+
+
+CHEM_MACRO_2PU =
+    f:generic_func &{ return tu.mhchem_macro_2pu[f]; } { return f; }

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -221,65 +221,59 @@ opt_pos
   / "" /* empty */
 
 /////////////////////////////////////////////////////////////
-// MHCHEM
+// MHCHEM grammar rules
 //----------------------------------------------------------
 
 
 chem_lit
-  = CURLY_OPEN e:chem_sentence CURLY_CLOSE
-    { return ast.Tex.CURLY(e.toArray()); }
+  = CURLY_OPEN e:chem_sentence CURLY_CLOSE               { return ast.Tex.CURLY(e.toArray()); }
 
 chem_sentence = 
-    _ p:chem_phrase " " s:chem_sentence { return ast.LList(p,ast.LList(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(" ")),s)); } /
-    _ p:chem_phrase _ { return ast.LList(p,ast.LList.EMPTY); }
+    _ p:chem_phrase " " s:chem_sentence                  { return ast.LList(p,ast.LList(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(" ")),s)); } /
+    _ p:chem_phrase _                                    { return ast.LList(p,ast.LList.EMPTY); }
 
 chem_phrase =
-    m:"(^)"                         { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); } /
-    m:chem_word n:CHEM_SINGLE_MACRO { return ast.Tex.CHEM_WORD(m, ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(n))); }/
-    m:chem_word                     { return m; } /
-    m:CHEM_SINGLE_MACRO             { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); } /
-    m:"^"                           { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); }
+    m:"(^)"                                              { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); } /
+    m:chem_word n:CHEM_SINGLE_MACRO                      { return ast.Tex.CHEM_WORD(m, ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(n))); }/
+    m:chem_word                                          { return m; } /
+    m:CHEM_SINGLE_MACRO                                  { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); } /
+    m:"^"                                                { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); }
 
 chem_word =
-    m:chem_char n:chem_word_nt                      { return ast.Tex.CHEM_WORD(m, n); } /
-    m:CHEM_SINGLE_MACRO n:chem_char_nl              { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)), n); }
+    m:chem_char n:chem_word_nt                           { return ast.Tex.CHEM_WORD(m, n); } /
+    m:CHEM_SINGLE_MACRO n:chem_char_nl o:chem_word_nt    { return ast.Tex.CHEM_WORD(ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)), n), o); }
 
-chem_word_nt = m:chem_word { return m; }/ "" { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("")); }
-
-chem_char_nl =
-    m:chem_script                                   { return m;} /
-    CURLY_OPEN c:chem_text CURLY_CLOSE              { return ast.Tex.CURLY([c]); } /
-    CHEM_DOLLAR c:chem_latex CHEM_DOLLAR            { return ast.Tex.DOLLAR(c.toArray()); } /
-    name:CHEM_BOND l:chem_bond                      { return ast.Tex.CHEM_BOND(name, l); } /
-    m:chem_macro                                    { return m; } /
-    c:CHEM_NONLETTER                                { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) }
+chem_word_nt = m:chem_word                               { return m; } /
+    ""                                                   { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("")); }
 
 chem_char =
-    m:chem_char_nl                                  { return m;} /
-    c:CHEM_LETTER                                   { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) }
+    m:chem_char_nl                                       { return m;} /
+    c:CHEM_LETTER                                        { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) }
+
+chem_char_nl =
+    m:chem_script                                        { return m;} /
+    CURLY_OPEN c:chem_text CURLY_CLOSE                   { return ast.Tex.CURLY([c]); } /
+    BEGIN_MATH c:expr END_MATH                           { return ast.Tex.DOLLAR(c.toArray()); }/
+    name:CHEM_BOND l:chem_bond                           { return ast.Tex.CHEM_BOND(name, l); } /
+    m:chem_macro                                         { return m; } /
+    c:CHEM_NONLETTER                                     { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) }
 
 chem_bond
- = CURLY_OPEN e:CHEM_BOND_TYPE CURLY_CLOSE
-   { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(e))]); }
+ = CURLY_OPEN e:CHEM_BOND_TYPE CURLY_CLOSE               { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(e))]); }
 
 chem_script = 
-    a:CHEM_SUPERSUB b:CHEM_SCRIPT_FOLLOW  { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(b))); } /
-    a:CHEM_SUPERSUB b:chem_lit            { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), b); } /
-    a:CHEM_SUPERSUB CHEM_DOLLAR b:chem_latex CHEM_DOLLAR  { return a + "$" + b + "$"; }
+    a:CHEM_SUPERSUB b:CHEM_SCRIPT_FOLLOW                 { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(b))); } /
+    a:CHEM_SUPERSUB b:chem_lit                           { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), b); } /
+    a:CHEM_SUPERSUB BEGIN_MATH b:expr END_MATH           { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.DOLLAR(b.toArray())); }
 
-// mhchem_macro_1p
+// TODO \color is a not documented feature of mhchem for MathJax, at the moment named colors are accepted
 chem_macro =
-    name:CHEM_MACRO_2PU l1:chem_lit "_" l2:chem_lit   { return ast.Tex.CHEM_FUN2u(name, l1, l2); }/
-    name:CHEM_MACRO_2P l1:chem_lit l2:chem_lit        { return ast.Tex.CHEM_FUN2(name, l1, l2); } /
-    name:CHEM_MACRO_1P l:chem_lit                     { return ast.Tex.CHEM_FUN1(name, l); }
+    name:CHEM_MACRO_2PU l1:chem_lit "_" l2:chem_lit      { return ast.Tex.CHEM_FUN2u(name, l1, l2); }/
+    name:CHEM_MACRO_2PC l1:COLOR_SPEC_NAMED l2:chem_lit  { return ast.Tex.CHEM_FUN2c(l1, l2); } /
+    name:CHEM_MACRO_2P l1:chem_lit l2:chem_lit           { return ast.Tex.CHEM_FUN2(name, l1, l2); } /
+    name:CHEM_MACRO_1P l:chem_lit                        { return ast.Tex.CHEM_FUN1(name, l); }
 
-chem_color = COLOR
-
-// TODO change from § to $
-chem_latex = e:expr { return e; } // cs:(boxchars / "_" / CURLY_OPEN / CURLY_CLOSE / "\\")+ { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); }
-
-
-chem_text = cs:boxchars+ { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); }
+chem_text = cs:boxchars+                                 { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); }
 
 /////////////////////////////////////////////////////////////
 // LEXER
@@ -533,6 +527,40 @@ CNUM
  / n:$( [01] "."? ) _
    { return n; }
 
+
+// MHCHEM LEXER RULES
+CHEM_SINGLE_MACRO = f:generic_func &{ return tu.mhchem_single_macro[f]; } { return f; }
+
+CHEM_BOND = f:generic_func &{ return tu.mhchem_bond[f]; } _ { return f; }
+
+CHEM_MACRO_1P = f:generic_func &{ return tu.mhchem_macro_1p[f]; } _   { return f; }
+
+CHEM_MACRO_2P = f:generic_func &{ return tu.mhchem_macro_2p[f]; } _   { return f; }
+
+CHEM_MACRO_2PU = f:generic_func &{ return tu.mhchem_macro_2pu[f]; } _ { return f; }
+
+CHEM_MACRO_2PC = f:generic_func &{ return tu.mhchem_macro_2pc[f]; } _ { return f; }
+
+CHEM_SCRIPT_FOLLOW = literal_mn / literal_id / [+-.*']
+
+CHEM_SUPERSUB = "_" / "^"
+
+CHEM_BOND_TYPE = "=" / "#" / "~--" / "~-"  / "~=" / "~" / "-~-" / "...." / "..." / "<-" / "->" / "-" / "1" / "2" / "3"
+
+BEGIN_MATH = BEGIN "{math}" _
+
+END_MATH = END "{math}" _
+
+CHEM_LETTER = [a-zA-Z]
+
+CHEM_NONLETTER =
+    c: "\\{" { return c; } /
+    c: "\\}" { return c; } /
+    c: "\\\\" { return c; } /
+    c:[+-=#().,;/*<>|@&\'\[\]] { return c; } /
+    c:literal_mn { return c; } /
+    CURLY_OPEN CURLY_CLOSE { return "{}"; }
+
 // Missing lexer tokens!
 FUN_INFIXh = impossible
 FUN_AR1hl = impossible
@@ -542,42 +570,3 @@ impossible = & { return false; }
 
 // End of file
 EOF = & { return peg$currPos === input.length; }
-
-// MHCHEM
-
-CHEM_LETTER = [a-zA-Z]
-
-// TODO Complete the list in texutil.js
-CHEM_SINGLE_MACRO =
-    f:generic_func &{ return tu.mhchem_single_macro[f]; } { return f; }
-
-
-CHEM_SCRIPT_FOLLOW = literal_mn / literal_id / [+-.*']
-
-CHEM_SUPERSUB
- = "_" / "^"
-
-CHEM_BOND_TYPE
- = "=" / "#" / "~--" / "~-"  / "~=" / "~" / "-~-" / "...." / "..." / "<-" / "->" / "-" / "1" / "2" / "3"
-
-CHEM_DOLLAR = "§"
-
-CHEM_BOND =
-    f:generic_func &{ return tu.mhchem_bond[f]; } _ { return f; }
-
-// TODO backslash???
-CHEM_NONLETTER =
-    c: "\\{" { return c; } /
-    c: "\\}" { return c; } /
-    c:[+-=#().,;/*<>|@&\'\[\]] { return c; } /
-    c:literal_mn { return c; } /
-    CURLY_OPEN CURLY_CLOSE { return "{}"; }
-
-CHEM_MACRO_1P =
-    f:generic_func &{ return tu.mhchem_macro_1p[f]; } _ { return f; }
-
-CHEM_MACRO_2P =
-    f:generic_func &{ return tu.mhchem_macro_2p[f]; } _ { return f; }
-
-CHEM_MACRO_2PU =
-    f:generic_func &{ return tu.mhchem_macro_2pu[f]; } _ { return f; }

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -250,12 +250,12 @@ chem_word_nt = m:chem_word { return m; }/ "" { return ast.Tex.LITERAL(ast.Render
 // TODO find hooks in parser for math mode and text mode
 chem_char =
     m:chem_script                                   { return m;} /
-    CURLY_OPEN c:chem_text CURLY_CLOSE              { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("{" + b + "}"));; } /
-    CHEM_DOLLAR c:chem_latex CHEM_DOLLAR            { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("$" + c + "$")); } /
-    name:CHEM_BOND l:chem_bond                      { return ast.Tex.CHEM_BOND(name, l);} /
+    CURLY_OPEN c:chem_text CURLY_CLOSE              { return ast.Tex.CURLY([c]); } /
+    CHEM_DOLLAR c:chem_latex CHEM_DOLLAR            { return ast.Tex.DOLLAR([c]); } /
+    name:CHEM_BOND l:chem_bond                      { return ast.Tex.CHEM_BOND(name, l); } /
     m:chem_macro                                    { return m; } /
-    c:CHEM_NONLETTER  {return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c))} /
-    c:CHEM_LETTER {return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c))}
+    c:CHEM_NONLETTER                                { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) } /
+    c:CHEM_LETTER                                   { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) }
 
 chem_bond
  = CURLY_OPEN e:CHEM_BOND_TYPE CURLY_CLOSE
@@ -274,21 +274,9 @@ chem_macro =
 
 chem_color = COLOR
 
-chem_latex = m:boxchars+
-    {
-        var s = "";
-        for (var c in m)
-            s += m[c];
-        return s;//ast.RenderT.TEX_ONLY(s);
-    }
-    
-chem_text = m:boxchars+
-    {
-        var s = "";
-        for (var c in m)
-            s += m[c];
-        return s;//ast.RenderT.TEX_ONLY(s);
-    }
+
+chem_latex = cs:(boxchars / "_" / CURLY_OPEN / CURLY_CLOSE / "\\")+ { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); } //e:expr { return e; }
+chem_text = cs:boxchars+ { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); }
 
 /////////////////////////////////////////////////////////////
 // LEXER
@@ -455,7 +443,7 @@ FUN_AR1
    { return tu.other_fun_ar1[f]; }
 
 FUN_MHCHEM
- = f:generic_func &{ return tu.fun_mhchem[f]; }
+ = f:generic_func &{ return tu.fun_mhchem[f]; } _
    { return f; }
 
 FUN_AR2
@@ -567,12 +555,12 @@ CHEM_SUPERSUB
  = "_" / "^"
 
 CHEM_BOND_TYPE
- = "=" / "#" / "~--" / "~-"  / "~=" / "~" / "-~-" / "-" / "...." / "..." / "<-" / "->" / "1" / "2" / "3"
+ = "=" / "#" / "~--" / "~-"  / "~=" / "~" / "-~-" / "...." / "..." / "<-" / "->" / "-" / "1" / "2" / "3"
 
 CHEM_DOLLAR = "$"
 
 CHEM_BOND =
-    f:generic_func &{ return tu.mhchem_bond[f]; } { return f; }
+    f:generic_func &{ return tu.mhchem_bond[f]; } _ { return f; }
 
 // TODO backslash???
 CHEM_NONLETTER =
@@ -583,10 +571,10 @@ CHEM_NONLETTER =
     CURLY_OPEN CURLY_CLOSE { return "{}"; }
 
 CHEM_MACRO_1P =
-    f:generic_func &{ return tu.mhchem_macro_1p[f]; } { return f; }
+    f:generic_func &{ return tu.mhchem_macro_1p[f]; } _ { return f; }
 
 CHEM_MACRO_2P =
-    f:generic_func &{ return tu.mhchem_macro_2p[f]; } { return f; }
+    f:generic_func &{ return tu.mhchem_macro_2p[f]; } _ { return f; }
 
 CHEM_MACRO_2PU =
-    f:generic_func &{ return tu.mhchem_macro_2pu[f]; } { return f; }
+    f:generic_func &{ return tu.mhchem_macro_2pu[f]; } _ { return f; }

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -230,50 +230,49 @@ chem_lit
     { return ast.Tex.CURLY(e.toArray()); }
 
 chem_sentence = 
-//    _ p:chem_phrase " " s:chem_sentence { return ast.LList(p,ast.LList(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(" ")),s)); } /
+    _ p:chem_phrase " " s:chem_sentence { return ast.LList(p,ast.LList(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(" ")),s)); } /
     _ p:chem_phrase _ { return ast.LList(p,ast.LList.EMPTY); }
 
-// TODO needs some work
-chem_phrase =  
-//    m:"^"                           { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); }/
-//    m:"(^)"                         { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); }/
-//    m:chem_single_macro             { return ast.RenderT.TEX_ONLY(m); }/
-//    m:chem_word n:chem_single_macro { return ast.RenderT.TEX_ONLY(m + n); }/
-    m:chem_word                     { return m; }
-    
-chem_word = 
-//    m:alpha n:chem_word_nt                               { return ast.LList(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)), n); }/
-    m:chem_nonletter n:chem_word_nt                      { return ast.LList(m, n); }
-//    m:chem_single_macro n:chem_nonletter o:chem_word_nt  { return ast.LList(n, o); }
+chem_phrase =
+    m:"(^)"                         { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); } /
+    m:chem_word n:CHEM_SINGLE_MACRO { return ast.Tex.CHEM_WORD(m, ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(n))); }/
+    m:chem_word                     { return m; } /
+    m:CHEM_SINGLE_MACRO             { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); } /
+    m:"^"                           { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); }
 
-chem_word_nt = m:chem_word { return m; }/ "" { return ast.LList.EMPTY; }
+// TODO second rule is iffy
+chem_word =
+    m:chem_char n:chem_word_nt                      { return ast.Tex.CHEM_WORD(m, n); }
+//    m:CHEM_SINGLE_MACRO n:chem_char o:chem_word_nt  { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(n)), ast.Tex.CHEM_WORD(n, o)); }
 
-// TODO write correct AST
-chem_nonletter =
-//    m:chem_script                                   { return m;} /
-//    CURLY_OPEN e:chem_text CURLY_CLOSE              { return "{" + e + "}"; } /
-//    CHEM_DOLLAR b:chem_latex CHEM_DOLLAR            { return ast.RenderT.TEX_ONLY("$" + b + "$"); } /
-    name:CHEM_BOND l:chem_bond                      { return ast.Tex.CHEM_BOND(name, l);} //
-//    chem_macro /
-//    CHEM_NONLETTER
+chem_word_nt = m:chem_word { return m; }/ "" { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("")); }
+
+// TODO find hooks in parser for math mode and text mode
+chem_char =
+    m:chem_script                                   { return m;} /
+    CURLY_OPEN c:chem_text CURLY_CLOSE              { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("{" + b + "}"));; } /
+    CHEM_DOLLAR c:chem_latex CHEM_DOLLAR            { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("$" + c + "$")); } /
+    name:CHEM_BOND l:chem_bond                      { return ast.Tex.CHEM_BOND(name, l);} /
+    m:chem_macro                                    { return m; } /
+    c:CHEM_NONLETTER  {return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c))} /
+    c:CHEM_LETTER {return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c))}
 
 chem_bond
  = CURLY_OPEN e:CHEM_BOND_TYPE CURLY_CLOSE
    { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(e))]); }
 
 chem_script = 
-    a:CHEM_SUPERSUB b:CHEM_SCRIPT_FOLLOW  { return a + b; } /
-    a:CHEM_SUPERSUB b:chem_lit            { return a + b; } /
+    a:CHEM_SUPERSUB b:CHEM_SCRIPT_FOLLOW  { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(b))); } /
+    a:CHEM_SUPERSUB b:chem_lit            { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), b); } /
     a:CHEM_SUPERSUB CHEM_DOLLAR b:chem_latex CHEM_DOLLAR  { return a + "$" + b + "$"; }
 
-// TODO Complete the list and move to file similarly to texutil.js
-chem_single_macro = m:"\\alpha" / m:"\\delta" / m:"\\mu" / m:"\\eta" / m:"\\gamma" / m:"\\pm" / m:"\\approx" / m:"\\ca"
-    { return m; }
+// mhchem_macro_1p
+chem_macro =
+    name:CHEM_MACRO_2PU l1:chem_lit "_" l2:chem_lit   { return ast.Tex.CHEM_FUN2u(name, l1, l2); }/
+    name:CHEM_MACRO_2P l1:chem_lit l2:chem_lit        { return ast.Tex.CHEM_FUN2(name, l1, l2); } /
+    name:CHEM_MACRO_1P l:chem_lit                     { return ast.Tex.CHEM_FUN1(name, l); }
 
-chem_macro = CHEM_MACRO_2PU chem_lit "_" chem_lit / CHEM_MACRO_2P chem_lit chem_lit / CHEM_MACRO_1P chem_lit
-
-// TODO extend to regular LaTeX treatment
-chem_color = m:"\\red" / m:"red" { return m; }
+chem_color = COLOR
 
 chem_latex = m:boxchars+
     {
@@ -555,6 +554,13 @@ EOF = & { return peg$currPos === input.length; }
 
 // MHCHEM
 
+CHEM_LETTER = [a-zA-Z]
+
+// TODO Complete the list in texutil.js
+CHEM_SINGLE_MACRO =
+    f:generic_func &{ return tu.mhchem_single_macro[f]; } { return f; }
+
+
 CHEM_SCRIPT_FOLLOW = literal_mn / literal_id / [+-.*']
 
 CHEM_SUPERSUB
@@ -564,17 +570,23 @@ CHEM_BOND_TYPE
  = "=" / "#" / "~--" / "~-"  / "~=" / "~" / "-~-" / "-" / "...." / "..." / "<-" / "->" / "1" / "2" / "3"
 
 CHEM_DOLLAR = "$"
+
 CHEM_BOND =
     f:generic_func &{ return tu.mhchem_bond[f]; } { return f; }
 
-CHEM_NONLETTER = "\\{" / "\\}" / [+-=#().,;/*<>|@&\'\\\[\]] / literal_mn / CURLY_OPEN CURLY_CLOSE
+// TODO backslash???
+CHEM_NONLETTER =
+    c: "\\{" { return c; } /
+    c: "\\}" { return c; } /
+    c:[+-=#().,;/*<>|@&\'\[\]] { return c; } /
+    c:literal_mn { return c; } /
+    CURLY_OPEN CURLY_CLOSE { return "{}"; }
 
 CHEM_MACRO_1P =
     f:generic_func &{ return tu.mhchem_macro_1p[f]; } { return f; }
 
 CHEM_MACRO_2P =
     f:generic_func &{ return tu.mhchem_macro_2p[f]; } { return f; }
-
 
 CHEM_MACRO_2PU =
     f:generic_func &{ return tu.mhchem_macro_2pu[f]; } { return f; }

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -133,6 +133,7 @@ lit
     { return ast.Tex.FUN2sq(name, ast.Tex.CURLY(e.toArray()), l); }
   / name:FUN_AR1 l:lit          { return ast.Tex.FUN1(name, l); }
   / name:FUN_AR1nb l:lit        { return ast.Tex.FUN1nb(name, l); }
+  / name:FUN_MHCHEM l:chem_lit  { return ast.Tex.MHCHEM(name, l); }
   / name:FUN_AR2 l1:lit l2:lit  { return ast.Tex.FUN2(name, l1, l2); }
   / name:FUN_AR2nb l1:lit l2:lit { return ast.Tex.FUN2nb(name, l1, l2); }
   / BOX
@@ -172,6 +173,7 @@ lit
     { throw new peg$SyntaxError("Illegal TeX function", [], text(), location()); }
   / f:generic_func &{ return !tu.all_functions[f]; }
     { throw new peg$SyntaxError("Illegal TeX function", [], f, location()); }
+
 
 // "array" requires mandatory column specification
 array
@@ -217,6 +219,32 @@ alignat_spec
 opt_pos
   = "[" _ [tcb] _ "]" _
   / "" /* empty */
+
+/////////////////////////////////////////////////////////////
+// MHCHEM
+//----------------------------------------------------------
+
+
+chem_lit
+  = CURLY_OPEN e:chem_sentence CURLY_CLOSE
+    { return ast.Tex.CURLY(e.toArray()); }
+
+chem_sentence = chem_nt_sentence / "" { return ast.LList.EMPTY; }
+ 
+chem_nt_sentence = p:chem_phrase s:chem_sentence
+    { return ast.LList(p,s); }
+
+chem_phrase = r:chem_word // r:chem_single_macro/ r:chem_word chem_single_macro  // r:"^" / r:"(^)" 
+    { return ast.Tex.LITERAL(r); }
+
+chem_word = m:alpha // m:chem_single_macro //w:alpha 
+    { return ast.RenderT.TEX_ONLY(m); }
+
+//chem_nonletter = m:literal_mn
+//    { return ast.RenderT.TEX_ONLY(m); }
+
+//chem_single_macro = m:"\alpha" / m:"\delta" / m:"\mu" / m:"\eta" / m:"\gamma" / m:"\pm" / m:"\approx" / m:"\ca"
+//    { return ast.RenderT.TEX_ONLY(m); }
 
 /////////////////////////////////////////////////////////////
 // LEXER
@@ -381,6 +409,10 @@ FUN_AR1
    { return f; }
  / f:generic_func &{ return tu.other_fun_ar1[f]; } _
    { return tu.other_fun_ar1[f]; }
+
+FUN_MHCHEM
+ = f:generic_func &{ return tu.fun_mhchem[f]; }
+   { return f; }
 
 FUN_AR2
  = f:generic_func &{ return tu.fun_ar2[f]; } _

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -237,8 +237,13 @@ chem_nt_sentence = p:chem_phrase s:chem_sentence
 chem_phrase = r:chem_word // r:chem_single_macro/ r:chem_word chem_single_macro  // r:"^" / r:"(^)" 
     { return ast.Tex.LITERAL(r); }
 
-chem_word = m:alpha // m:chem_single_macro //w:alpha 
-    { return ast.RenderT.TEX_ONLY(m); }
+chem_word = m:boxchars+ // m:chem_single_macro //w:alpha 
+    {
+        var s = "";
+        for (var c in m)
+            s += m[c];
+        return ast.RenderT.TEX_ONLY(s);
+    }
 
 //chem_nonletter = m:literal_mn
 //    { return ast.RenderT.TEX_ONLY(m); }

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -229,27 +229,85 @@ chem_lit
   = CURLY_OPEN e:chem_sentence CURLY_CLOSE
     { return ast.Tex.CURLY(e.toArray()); }
 
-chem_sentence = chem_nt_sentence / "" { return ast.LList.EMPTY; }
- 
-chem_nt_sentence = p:chem_phrase s:chem_sentence
-    { return ast.LList(p,s); }
+chem_sentence = 
+    p:chem_phrase " " s:chem_sentence { return ast.LList(p,s); } /
+    p:chem_phrase { return ast.LList(p,ast.LList.EMPTY); } /
+    "" { return ast.LList.EMPTY; }
 
-chem_phrase = r:chem_word // r:chem_single_macro/ r:chem_word chem_single_macro  // r:"^" / r:"(^)" 
-    { return ast.Tex.LITERAL(r); }
+// TODO needs some work
+chem_phrase = 
+    m:chem_word                     { return ast.Tex.LITERAL(m); }/
+    m:chem_single_macro             { return ast.RenderT.TEX_ONLY(m); }/ 
+    m:chem_word n:chem_single_macro { return ast.RenderT.TEX_ONLY(m + n); } / 
+    m:"^"                           { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); }/ 
+    m:"(^)"                         { return ast.RenderT.TEX_ONLY(m); }
+    
+chem_word = 
+    m:[a-zA-Z] n:chem_word                            { return ast.RenderT.TEX_ONLY("baz"); }/
+    m:chem_nonletter n:chem_word                      { return ast.RenderT.TEX_ONLY("bar"); }/
+    m:chem_single_macro n:chem_nonletter o:chem_word  { return ast.RenderT.TEX_ONLY("foo"); } /
+    "" { return ast.RenderT.TEX_ONLY(""); }
 
-chem_word = m:boxchars+ // m:chem_single_macro //w:alpha 
+// TODO find char m:Apostrophe, move chars, write correct AST
+chem_nonletter =
+    m:chem_script                                  { return m;} /
+    CURLY_OPEN e:chem_text CURLY_CLOSE             { return ast.RenderT.TEX_ONLY("{some text}"); } /
+    "$" b:chem_latex "$"                           { return ast.RenderT.TEX_ONLY("baz"); } /
+    "\\bond" CURLY_OPEN chem_bond_type CURLY_CLOSE { return ast.RenderT.TEX_ONLY("\bond{some bond}");}/
+    m:chem_macro_1p                                { return m;} /
+    m:chem_macro_2p                                { return m;} /
+    CURLY_OPEN CURLY_CLOSE                         { return ast.RenderT.TEX_ONLY("{}"); }/
+    m:[0-9]                                        { return ast.RenderT.TEX_ONLY(m); } /
+    "+" / "-" / "=" / "#" / "(" / ")" / "[" / "]" / "\\{" / "\\}" / "." / "," / ";" / "/" / "*" / "<" / ">" / "/" / "@" / "&" / "\\" // Apostrophe
+            { return ast.RenderT.TEX_ONLY("some char"); }
+
+chem_script = 
+    a:chem_supersub b:chem_script_follow  { return ast.RenderT.TEX_ONLY("foo"); } /
+    a:chem_supersub b:chem_lit            { return ast.RenderT.TEX_ONLY("bar"); } /
+    a:chem_supersub "$" b:chem_latex "$"  { return ast.RenderT.TEX_ONLY("baz"); }
+           
+chem_supersub = m:"_" / m:"^"
+    { return ast.RenderT.TEX_ONLY(m); }
+
+chem_script_follow = m:[0-9] / m:[a-zA-Z] / m:"+" / m:"-" / m:"." / m:"*" // TODO find char m:Apostrophe
+    { return ast.RenderT.TEX_ONLY(m); }
+
+chem_bond_type = m:"=" / m:"#" / m:"~--" / m:"~-"  / m:"~=" / m:"~" / m:"-~-" / m:"-" / m:"...." / m:"..." / m:"<-" / m:"->" / m:"1" / m:"2" / m:"3"
+    { return ast.RenderT.TEX_ONLY(m); }
+
+// TODO Complete the list and move to file similarly to texutil.js
+chem_single_macro = m:"\\alpha" / m:"\\delta" / m:"\\mu" / m:"\\eta" / m:"\\gamma" / m:"\\pm" / m:"\\approx" / m:"\\ca"
+    { return ast.RenderT.TEX_ONLY(m); }
+    
+chem_macro_1p = 
+    name:'\ce' l:chem_lit { return ast.Tex.MHCHEM(name, l); } /
+    name:'\mathbf' l:chem_lit { return ast.Tex.MHCHEM(name, l); }
+  
+chem_macro_2p = 
+    name:"\\frac" l1:chem_lit l2:chem_lit { return ast.Tex.MHCHEM2(name, l1, l2); } /
+    name:"\\color" l1:chem_color l2:chem_lit { return ast.Tex.MHCHEM2(name, l1, l2); } /
+    name:"\\overset" l1:chem_lit l2:chem_lit { return ast.Tex.MHCHEM2(name, l1, l2); } /
+    name:"\\underset" l1:chem_lit l2:chem_lit { return ast.Tex.MHCHEM2(name, l1, l2); } /
+    name:"\\underbrace" l1:chem_lit "_" l2:chem_lit { return ast.Tex.MHCHEM2ub(name, l1, l2); }
+
+// TODO extend to regular LaTeX treatment
+chem_color = m:"\\red" / m:"red" { return ast.RenderT.TEX_ONLY(m); }
+
+chem_latex = m:boxchars+
     {
         var s = "";
         for (var c in m)
             s += m[c];
         return ast.RenderT.TEX_ONLY(s);
     }
-
-//chem_nonletter = m:literal_mn
-//    { return ast.RenderT.TEX_ONLY(m); }
-
-//chem_single_macro = m:"\alpha" / m:"\delta" / m:"\mu" / m:"\eta" / m:"\gamma" / m:"\pm" / m:"\approx" / m:"\ca"
-//    { return ast.RenderT.TEX_ONLY(m); }
+    
+chem_text = m:boxchars+
+    {
+        var s = "";
+        for (var c in m)
+            s += m[c];
+        return ast.RenderT.TEX_ONLY(s);
+    }
 
 /////////////////////////////////////////////////////////////
 // LEXER

--- a/lib/render.js
+++ b/lib/render.js
@@ -77,6 +77,9 @@ ast.Tex.defineVisitor("render_tex", {
     FUN1: function(f, a) {
         return curlies(f + " " + curlies(a));
     },
+    MHCHEM: function(f, a) {
+        return curlies(f + " " + curlies(a));
+    },
     FUN1nb: function(f, a) {
         return f + " " + curlies(a) + " ";
     },

--- a/lib/render.js
+++ b/lib/render.js
@@ -97,23 +97,11 @@ ast.Tex.defineVisitor("render_tex", {
     MHCHEM: function(f, a) {
         return curlies(f + " " + curlies(a));
     },
-    CHEM_BOND: function(f, a) {
-        return f + " " + curlies(a);
-    },
     CHEM_WORD: function(l, w) {
         return l.render_tex() + w.render_tex();
     },
-    CHEM_FUN1: function(f, a) {
-        return curlies(f + " " + curlies(a));
-    },
-    CHEM_FUN2: function(f, a, b) {
-        return curlies(f + " " + curlies(a) + curlies(b));
-    },
-    CHEM_FUN2c: function(a, b) {
-    return curlies("\\color " + a + curlies(b));
-},
     CHEM_FUN2u: function(f, a, b) {
-        return curlies(f + " " + curlies(a) + "_" + curlies(b));
+        return f + curlies(a) + "_" + curlies(b);
     },
     FUN1nb: function(f, a) {
         return f + " " + curlies(a) + " ";

--- a/lib/render.js
+++ b/lib/render.js
@@ -52,11 +52,21 @@ var render_curlies = function(a) {
     return curlies(render(a));
 };
 
+var dollar = function(t) {
+    switch (t.constructor) {
+        case String:
+            break;
+        default:
+            t = t.render_tex();
+    }
+    return "$" + t + "$";
+};
+
 var render_dollar = function(a) {
     if (a.length === 1) {
-        return "$" + a[0].render_tex() + "$";
+        return dollar(a[0]);
     }
-    return "$" + a.render_tex() + "$";
+    return dollar(render(a));
 };
 
 ast.Tex.defineVisitor("render_tex", {
@@ -99,6 +109,9 @@ ast.Tex.defineVisitor("render_tex", {
     CHEM_FUN2: function(f, a, b) {
         return curlies(f + " " + curlies(a) + curlies(b));
     },
+    CHEM_FUN2c: function(a, b) {
+    return curlies("\\color " + a + curlies(b));
+},
     CHEM_FUN2u: function(f, a, b) {
         return curlies(f + " " + curlies(a) + "_" + curlies(b));
     },

--- a/lib/render.js
+++ b/lib/render.js
@@ -52,6 +52,13 @@ var render_curlies = function(a) {
     return curlies(render(a));
 };
 
+var render_dollar = function(a) {
+    if (a.length === 1) {
+        return "$" + a[0].render_tex() + "$";
+    }
+    return "$" + a.render_tex() + "$";
+};
+
 ast.Tex.defineVisitor("render_tex", {
     FQ: function(base, down, up) {
         return base.render_tex() + "_" + curlies(down) + "^" + curlies(up);
@@ -112,6 +119,9 @@ ast.Tex.defineVisitor("render_tex", {
     },
     CURLY: function(tl) {
         return render_curlies(tl);
+    },
+    DOLLAR: function(tl) {
+        return render_dollar(tl);
     },
     INFIX: function(s, ll, rl) {
         return curlies(render(ll) + " " + s + " " + render(rl));

--- a/lib/render.js
+++ b/lib/render.js
@@ -80,6 +80,9 @@ ast.Tex.defineVisitor("render_tex", {
     MHCHEM: function(f, a) {
         return curlies(f + " " + curlies(a));
     },
+    CHEM_BOND: function(f, a) {
+        return f + " " + curlies(a);
+    },
     FUN1nb: function(f, a) {
         return f + " " + curlies(a) + " ";
     },

--- a/lib/render.js
+++ b/lib/render.js
@@ -83,6 +83,18 @@ ast.Tex.defineVisitor("render_tex", {
     CHEM_BOND: function(f, a) {
         return f + " " + curlies(a);
     },
+    CHEM_WORD: function(l, w) {
+        return l.render_tex() + w.render_tex();
+    },
+    CHEM_FUN1: function(f, a) {
+        return curlies(f + " " + curlies(a));
+    },
+    CHEM_FUN2: function(f, a, b) {
+        return curlies(f + " " + curlies(a) + curlies(b));
+    },
+    CHEM_FUN2u: function(f, a, b) {
+        return curlies(f + " " + curlies(a) + "_" + curlies(b));
+    },
     FUN1nb: function(f, a) {
         return f + " " + curlies(a) + " ";
     },

--- a/lib/texutil.js
+++ b/lib/texutil.js
@@ -1098,6 +1098,7 @@ module.exports.mhchem_bond = arr2set([
 module.exports.mhchem_single_macro = arr2set([
     "\\alpha",
     "\\delta",
+    "\\Delta",
     "\\mu",
     "\\eta",
     "\\gamma",

--- a/lib/texutil.js
+++ b/lib/texutil.js
@@ -1091,11 +1091,6 @@ module.exports.mathoid_required = arr2set([
 
 // MHCHEM functions
 
-module.exports.mhchem_bond = arr2set([
-    "\\bond"
-]);
-
-// TODO complete this list
 module.exports.mhchem_single_macro = arr2set([
     "\\Alpha",
     "\\Beta",

--- a/lib/texutil.js
+++ b/lib/texutil.js
@@ -1095,13 +1095,61 @@ module.exports.mhchem_bond = arr2set([
     "\\bond"
 ]);
 
+// TODO complete this list
 module.exports.mhchem_single_macro = arr2set([
-    "\\alpha",
-    "\\delta",
+    "\\Alpha",
+    "\\Beta",
+    "\\Gamma",
     "\\Delta",
-    "\\mu",
-    "\\eta",
+    "\\Epsilon",
+    "\\Zeta",
+    "\\Eta",
+    "\\Theta",
+    "\\Iota",
+    "\\Kappa",
+    "\\Lambda",
+    "\\Mu",
+    "\\Nu",
+    "\\Omicron",
+    "\\Pi",
+    "\\Rho",
+    "\\Sigma",
+    "\\Tau",
+    "\\Upsilon",
+    "\\Phi",
+    "\\Chi",
+    "\\Psi",
+    "\\Omega",
+    "\\alpha",
+    "\\beta",
     "\\gamma",
+    "\\delta",
+    "\\epsilon",
+    "\\zeta",
+    "\\eta",
+    "\\theta",
+    "\\iota",
+    "\\kappa",
+    "\\lambda",
+    "\\mu",
+    "\\nu",
+    "\\omicron",
+    "\\pi",
+    "\\rho",
+    "\\sigma",
+    "\\tau",
+    "\\upsilon",
+    "\\phi",
+    "\\chi",
+    "\\psi",
+    "\\omega",
+    "\\varkappa",
+    "\\varepsilon",
+    "\\vartheta",
+    "\\varphi",
+    "\\varpi",
+    "\\varrho",
+    "\\varsigma",
     "\\pm",
     "\\approx",
     "\\ca"
@@ -1118,11 +1166,14 @@ module.exports.mhchem_macro_1p = arr2set([
 
 module.exports.mhchem_macro_2p = arr2set([
     "\\frac",
-    "\\color",
     "\\overset",
     "\\underset"
 ]);
 
 module.exports.mhchem_macro_2pu = arr2set([
     "\\underbrace"
+]);
+
+module.exports.mhchem_macro_2pc = arr2set([
+    "\\color"
 ]);

--- a/lib/texutil.js
+++ b/lib/texutil.js
@@ -1087,3 +1087,41 @@ module.exports.mathoid_required = arr2set([
     "\\ointctrclockwise",
     "\\varointclockwise",
 ]);
+
+
+// MHCHEM functions
+
+module.exports.mhchem_bond = arr2set([
+    "\\bond"
+]);
+
+module.exports.mhchem_single_macro = arr2set([
+    "\\alpha",
+    "\\delta",
+    "\\mu",
+    "\\eta",
+    "\\gamma",
+    "\\pm",
+    "\\approx",
+    "\\ca"
+]);
+
+module.exports.mhchem_bond = arr2set([
+    "\\bond"
+]);
+
+module.exports.mhchem_macro_1p = arr2set([
+    "\\ce",
+    "\\mathbf"
+]);
+
+module.exports.mhchem_macro_2p = arr2set([
+    "\\frac",
+    "\\color",
+    "\\overset",
+    "\\underset"
+]);
+
+module.exports.mhchem_macro_2pu = arr2set([
+    "\\underbrace"
+]);

--- a/lib/texutil.js
+++ b/lib/texutil.js
@@ -640,7 +640,7 @@ module.exports.fun_ar1 = arr2set([
     "\\boldsymbol",
     "\\breve",
     "\\cancel",
-    "\\ce",
+    //"\\ce",  // moved to fun_mhchem
     "\\check",
     "\\ddot",
     "\\dot",
@@ -682,6 +682,10 @@ module.exports.fun_ar1 = arr2set([
     "\\xcancel",
     "\\xleftarrow",
     "\\xrightarrow"
+]);
+
+module.exports.fun_mhchem = arr2set([
+    "\\ce"
 ]);
 
 module.exports.other_fun_ar1 = obj2map({

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "commander": "~2.9.0"
     },
     "devDependencies": {
+        "grunt-coveralls": "^1.0.1",
         "jshint": "~2.9.1",
         "mocha": "~3.1.2",
         "pegjs": "~0.10.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "main": "lib/index.js",
     "scripts": {
         "build": "node -e 'require(\"./lib/build-parser\")'",
-        "test": "node -e 'require(\"./lib/build-parser\")' && jshint . && mocha"
+        "test": "node -e 'require(\"./lib/build-parser\")' && jshint . && mocha",
+        "cover": "istanbul cover _mocha",
+        "report-coverage": "cat ./coverage/lcov.info | coveralls"
     },
     "repository": {
         "type": "git",
@@ -23,12 +25,14 @@
         "url": "https://phabricator.wikimedia.org/project/profile/1771/"
     },
     "dependencies": {
-        "commander": "~2.9.0"
+        "commander": "~2.11.0"
     },
     "devDependencies": {
-        "grunt-coveralls": "^1.0.1",
+        "coveralls": "^2.7.1",
+        "istanbul": "^0.4.5",
         "jshint": "~2.9.1",
-        "mocha": "~3.1.2",
+        "mocha": "~3.4.2",
+        "mocha-lcov-reporter": "^1.3.0",
         "pegjs": "~0.10.0"
     },
     "bin": {

--- a/test/en-wiki-formulae.js
+++ b/test/en-wiki-formulae.js
@@ -7,7 +7,7 @@ var path = require('path');
 
 // set this variable to the path to your texvccheck binary for additional
 // sanity-checking against the ocaml texvccheck.
-var TEXVCBINARY = "../../texvc/texvc"; // "../mediawiki/extensions/Math/texvccheck/texvccheck";
+var TEXVCBINARY = 0; //"../../texvc/texvc"; // "../mediawiki/extensions/Math/texvccheck/texvccheck";
 
 var getocaml = function(input, fixDoubleSpacing, done) {
     if (!TEXVCBINARY) { done( '-no texvcbinary') ; }
@@ -170,7 +170,7 @@ var normalize = function(s) {
 // run them in chunks in order to speed up reporting.
 var CHUNKSIZE = 1000;
 
-describe('All formulae from en-wiki:', function() {
+describe.skip('All formulae from en-wiki:', function() {
     this.timeout(0);
 
     // read test cases

--- a/test/en-wiki-formulae.js
+++ b/test/en-wiki-formulae.js
@@ -7,7 +7,7 @@ var path = require('path');
 
 // set this variable to the path to your texvccheck binary for additional
 // sanity-checking against the ocaml texvccheck.
-var TEXVCBINARY = 0; // "../mediawiki/extensions/Math/texvccheck/texvccheck";
+var TEXVCBINARY = "../../texvc/texvc"; // "../mediawiki/extensions/Math/texvccheck/texvccheck";
 
 var getocaml = function(input, fixDoubleSpacing, done) {
     if (!TEXVCBINARY) { done( '-no texvcbinary') ; }
@@ -170,7 +170,7 @@ var normalize = function(s) {
 // run them in chunks in order to speed up reporting.
 var CHUNKSIZE = 1000;
 
-describe.skip('All formulae from en-wiki:', function() {
+describe('All formulae from en-wiki:', function() {
     this.timeout(0);
 
     // read test cases

--- a/test/mathjax-texvc-mhchem.js
+++ b/test/mathjax-texvc-mhchem.js
@@ -1,0 +1,29 @@
+"use strict";
+var assert = require('assert');
+var texvcjs = require('../');
+
+var fs = require('fs');
+var path = require('path');
+
+
+describe('Run test for all mathjax-texvc commands:', function () {
+
+    require('../lib/build-parser');
+    this.timeout(0);
+    // read test cases
+    var formulae = require('./mathjax-texvc-mhchem.json');
+    // create a mocha test case for each chunk
+    formulae.forEach(function (testcase) {
+        if (testcase.ignore !== true) {
+            it(testcase.id+"$"+testcase.input+"$", function () {
+                var result = texvcjs.check(testcase.input,{usemathrm:true, usemhchem:true});
+                assert.equal(result.output, testcase.texvcjs,
+                    JSON.stringify({
+                        id: testcase.id,
+                        output: result.output,
+                        expected: testcase.texvcjs
+                    }, null, 2));
+            });
+        }
+    });
+});

--- a/test/mathjax-texvc-mhchem.json
+++ b/test/mathjax-texvc-mhchem.json
@@ -618,7 +618,7 @@
 	},
 	{
 		"id": 130,
-		"input": "\\ce{$n$H2O}",
+		"input": "\\ce{§n§H2O}",
 		"texvcjs": "{\\ce {$n$H2O}}"
 	},
 	{
@@ -673,8 +673,8 @@
 	},
 	{
 		"id": 141,
-		"input": "\\ce{NaOH(aq,$\\infty$)}",
-		"texvcjs": "{\\ce {NaOH(aq,$\\infty$)}}"
+		"input": "\\ce{NaOH(aq,§\\infty§)}",
+		"texvcjs": "{\\ce {NaOH(aq,$\\infty $)}}"
 	},
 	{
 		"id": 142,
@@ -700,14 +700,13 @@
 	},
 	{
 		"id": 146,
-		"input": "\\ce{NaOH(aq,$\\infty$)}",
-		"texvcjs": "{\\ce {NaOH(aq,$\\infty$)}}"
+		"input": "\\ce{NaOH(aq,§\\infty§)}",
+		"texvcjs": "{\\ce {NaOH(aq,$\\infty $)}}"
 	},
 	{
 		"id": 147,
-		"input": "\\ce{Fe(CN)_{$\\frac{6}{2}$}}",
-		"texvcjs": "",
-		"ignore": true
+		"input": "\\ce{Fe(CN)_{§\\frac{6}{2}§}}",
+		"texvcjs": "{\\ce {Fe(CN)_{${\\frac {6}{2}}$}}}"
 	},
 	{
 		"id": 148,
@@ -791,9 +790,8 @@
 	},
 	{
 		"id": 164,
-		"input": "\\ce{Hg^2+ ->[I-] $\\underset{\\mathrm{red}}{\\ce{HgI2}}$} ",
-		"texvcjs": "",
-		"ignore": true
+		"input": "\\ce{Hg^2+ ->[I-] §\\underset{\\mathrm{red}}{\\ce{HgI2}}§} ",
+		"texvcjs": "{\\ce {Hg^2+ ->[I-] ${\\underset {\\mathrm {red} }{{\\ce {HgI2}}}}$}}"
 	},
 	{
 		"id": 169,
@@ -817,13 +815,13 @@
 	},
 	{
 		"id": 173,
-		"input": "\\ce{A ->[$x$][$x_i$] B}",
-		"texvcjs": "{\\ce {A ->[$x$][$x_i$] B}}"
+		"input": "\\ce{A ->[§x§][§x_i§] B}",
+		"texvcjs": "{\\ce {A ->[$x$][$x_{i}$] B}}"
 	},
 	{
 		"id": 175,
-		"input": "\\ce{A ->[${x}$] B}",
-		"texvcjs": "{\\ce {A ->[${,x},$] B}}"
+		"input": "\\ce{A ->[§{x}§] B}",
+		"texvcjs": "{\\ce {A ->[${x}$] B}}"
 	},
 	{
 		"id": 177,
@@ -867,8 +865,8 @@
 	},
 	{
 		"id": 185,
-		"input": "$\\ce{NaOH(aq,$\\infty$)}$",
-		"texvcjs": "\\${\\ce {NaOH(aq,$\\infty$)}}\\$"
+		"input": "$\\ce{NaOH(aq,§\\infty§)}$",
+		"texvcjs": "\\${\\ce {NaOH(aq,$\\infty $)}}\\$"
 	},
 	{
 		"id": 186,
@@ -877,9 +875,8 @@
 	},
 	{
 		"id": 187,
-		"input": "$\\ce{Fe(CN)_{$\\frac{6}{2}$}}$",
-		"texvcjs": "",
-		"ignore": true
+		"input": "$\\ce{Fe(CN)_{§\\frac{6}{2}$}}§",
+		"texvcjs": ""
 	},
 	{
 		"id": 188,
@@ -894,21 +891,18 @@
 	},
 	{
 		"id": 190,
-		"input": "$\\ce{x Na(NH4)HPO4 ->[\\Delta] (NaPO3)_x + x NH3 ^ + x H2O}$",
-		"texvcjs": "",
-		"ignore": true
+		"input": "§\\ce{x Na(NH4)HPO4 ->[\\Delta] (NaPO3)_x + x NH3 ^ + x H2O}§",
+		"texvcjs": ""
 	},
 	{
 		"id": 191,
-		"input": "$\\ce{NO_$x$}$ \\sffamily\\bfseries \\ce{NO_$x$}",
-		"texvcjs": "",
-		"ignore": true
+		"input": "§\\ce{NO_$x$}§ \\bf\\ce{NO_$x$}",
+		"texvcjs": ""
 	},
 	{
 		"id": 192,
-		"input": "$\\ce{NO_${x}$}$ \\bf \\ce{NO_${x}$}",
-		"texvcjs": "",
-		"ignore": true
+		"input": "§\\ce{NO_§{x}§}§ \\bf \\ce{NO_§{x}§}",
+		"texvcjs": ""
 	},
 	{
 		"id": 193,

--- a/test/mathjax-texvc-mhchem.json
+++ b/test/mathjax-texvc-mhchem.json
@@ -562,6 +562,11 @@
 		"texvcjs": "{\\ce {A <--> B}}"
 	},
 	{
+		"id":113,
+		"input": "\\ce{H2O\\\\ CO2}",
+		"texvcjs": "{\\ce {H2O\\\\ CO2}}"
+	},
+	{
 		"id": 117,
 		"input": "\\ce{CrO4^2-}",
 		"texvcjs": "{\\ce {CrO4^2-}}"
@@ -618,7 +623,7 @@
 	},
 	{
 		"id": 130,
-		"input": "\\ce{§n§H2O}",
+		"input": "\\ce{\\begin{math}n\\end{math}H2O}",
 		"texvcjs": "{\\ce {$n$H2O}}"
 	},
 	{
@@ -673,7 +678,7 @@
 	},
 	{
 		"id": 141,
-		"input": "\\ce{NaOH(aq,§\\infty§)}",
+		"input": "\\ce{NaOH(aq,\\begin{math}\\infty\\end{math})}",
 		"texvcjs": "{\\ce {NaOH(aq,$\\infty $)}}"
 	},
 	{
@@ -689,28 +694,26 @@
 	{
 		"id": 144,
 		"input": "\\ce{\\mu-Cl}",
-		"texvcjs": "",
-		"ignore": true
+		"texvcjs": "{\\ce {\\mu-Cl}}"
 	},
 	{
 		"id": 145,
 		"input": "\\ce{[Pt(\\eta^2-C2H4)Cl3]-}",
-		"texvcjs": "",
-		"ignore": true
+		"texvcjs": "{\\ce {[Pt(\\eta^2-C2H4)Cl3]-}}"
 	},
 	{
 		"id": 146,
-		"input": "\\ce{NaOH(aq,§\\infty§)}",
+		"input": "\\ce{NaOH(aq,\\begin{math}\\infty\\end{math})}",
 		"texvcjs": "{\\ce {NaOH(aq,$\\infty $)}}"
 	},
 	{
 		"id": 147,
-		"input": "\\ce{Fe(CN)_{§\\frac{6}{2}§}}",
+		"input": "\\ce{Fe(CN)_{\\begin{math}\\frac{6}{2}\\end{math}}}",
 		"texvcjs": "{\\ce {Fe(CN)_{${\\frac {6}{2}}$}}}"
 	},
 	{
 		"id": 148,
-		"input": "\\ce{$cis${-}[PtCl2(NH3)2]}",
+		"input": "\\ce{\\begin{math}cis\\end{math}{-}[PtCl2(NH3)2]}",
 		"texvcjs": "{\\ce {$cis${-}[PtCl2(NH3)2]}}"
 	},
 	{
@@ -785,12 +788,12 @@
 	},
 	{
 		"id": 163,
-		"input": "$\\underset{\\mathrm{red}}{\\ce{[Hg^{II}I4]^2-}}$",
-		"texvcjs": "\\${\\underset {\\mathrm {red} }{{\\ce {[Hg^{II}I4]^2-}}}}\\$"
+		"input": "\\underset{\\mathrm{red}}{\\ce{[Hg^{II}I4]^2-}}",
+		"texvcjs": "{\\underset {\\mathrm {red} }{{\\ce {[Hg^{II}I4]^2-}}}}"
 	},
 	{
 		"id": 164,
-		"input": "\\ce{Hg^2+ ->[I-] §\\underset{\\mathrm{red}}{\\ce{HgI2}}§} ",
+		"input": "\\ce{Hg^2+ ->[I-] \\begin{math}\\underset{\\mathrm{red}}{\\ce{HgI2}}\\end{math}} ",
 		"texvcjs": "{\\ce {Hg^2+ ->[I-] ${\\underset {\\mathrm {red} }{{\\ce {HgI2}}}}$}}"
 	},
 	{
@@ -815,12 +818,12 @@
 	},
 	{
 		"id": 173,
-		"input": "\\ce{A ->[§x§][§x_i§] B}",
+		"input": "\\ce{A ->[\\begin{math}x\\end{math}][\\begin{math}x_i\\end{math}] B}",
 		"texvcjs": "{\\ce {A ->[$x$][$x_{i}$] B}}"
 	},
 	{
 		"id": 175,
-		"input": "\\ce{A ->[§{x}§] B}",
+		"input": "\\ce{A ->[\\begin{math}{x}\\end{math}] B}",
 		"texvcjs": "{\\ce {A ->[${x}$] B}}"
 	},
 	{
@@ -865,68 +868,73 @@
 	},
 	{
 		"id": 185,
-		"input": "$\\ce{NaOH(aq,§\\infty§)}$",
-		"texvcjs": "\\${\\ce {NaOH(aq,$\\infty $)}}\\$"
+		"input": "\\ce{NaOH(aq,\\begin{math}\\infty\\end{math})}",
+		"texvcjs": "{\\ce {NaOH(aq,$\\infty $)}}"
 	},
 	{
 		"id": 186,
-		"input": "$\\ce{H2O}$",
-		"texvcjs": "\\${\\ce {H2O}}\\$"
+		"input": "\\ce{H2O}",
+		"texvcjs": "{\\ce {H2O}}"
 	},
 	{
 		"id": 187,
-		"input": "$\\ce{Fe(CN)_{§\\frac{6}{2}$}}§",
-		"texvcjs": ""
+		"input": "\\ce{Fe(CN)_{\\begin{math}\\frac{6}{2}\\end{math}}}",
+		"texvcjs": "{\\ce {Fe(CN)_{${\\frac {6}{2}}$}}}"
 	},
 	{
 		"id": 188,
-		"input": "$\\ce{NO_x}$ \\bf \\ce{NO_x}",
-		"texvcjs": "\\${\\ce {NO_x}}\\${\\bf {{\\ce {NO_x}}}}"
+		"input": "\\ce{NO_x}",
+		"texvcjs": "{\\ce {NO_x}}"
 	},
 	{
 		"id": 189,
-		"input": "$\\ce{Fe^n+}$ \\bf \\ce{Fe^n+}",
-		"texvcjs": "\\${\\ce {Fe^n+}}\\${\\bf {{\\ce {Fe^n+}}}}"
+		"input": "\\ce{Fe^n+}",
+		"texvcjs": "{\\ce {Fe^n+}}"
 
 	},
 	{
 		"id": 190,
-		"input": "§\\ce{x Na(NH4)HPO4 ->[\\Delta] (NaPO3)_x + x NH3 ^ + x H2O}§",
-		"texvcjs": ""
+		"input": "\\ce{x Na(NH4)HPO4 ->[\\Delta] (NaPO3)_x + x NH3 ^ + x H2O}",
+		"texvcjs": "{\\ce {x Na(NH4)HPO4 ->[\\Delta] (NaPO3)_x + x NH3 ^ + x H2O}}"
 	},
 	{
 		"id": 191,
-		"input": "§\\ce{NO_$x$}§ \\bf\\ce{NO_$x$}",
-		"texvcjs": ""
+		"input": "\\ce{NO_\\begin{math}x\\end{math}}",
+		"texvcjs": "{\\ce {NO_$x$}}"
 	},
 	{
 		"id": 192,
-		"input": "§\\ce{NO_§{x}§}§ \\bf \\ce{NO_§{x}§}",
-		"texvcjs": ""
+		"input": "\\ce{NO_\\begin{math}{x}\\end{math}}",
+		"texvcjs": "{\\ce {NO_${x}$}}"
 	},
 	{
 		"id": 193,
-		"input": "$\\ce{$cis${-}[PtCl2(NH3)2]}$",
-		"texvcjs": "\\${\\ce {$cis${-}[PtCl2(NH3)2]}}\\$"
+		"input": "\\ce{NO_{\\begin{math}x\\end{math}}}",
+		"texvcjs": "{\\ce {NO_{$x$}}}"
 	},
 	{
 		"id": 194,
-		"input": "$\\underset{\\text{amphoteres Hydroxid}}{\\ce{Zn(OH)2 v}}$",
-		"texvcjs": "\\${\\underset {\\text{amphoteres Hydroxid}}{{\\ce {Zn(OH)2 v}}}}\\$"
+		"input": "$\\ce{\\begin{math}cis\\end{math}{-}[PtCl2(NH3)2]}$",
+		"texvcjs": "\\${\\ce {$cis${-}[PtCl2(NH3)2]}}\\$"
 	},
 	{
 		"id": 195,
-		"input": "$\\underset{\\text{Hydroxozikat}}{\\ce{[Zn(OH)4]^2-}}$",
-		"texvcjs": "\\${\\underset {\\text{Hydroxozikat}}{{\\ce {[Zn(OH)4]^2-}}}}\\$"
+		"input": "\\underset{\\text{amphoteres Hydroxid}}{\\ce{Zn(OH)2 v}}",
+		"texvcjs": "{\\underset {\\text{amphoteres Hydroxid}}{{\\ce {Zn(OH)2 v}}}}"
 	},
 	{
 		"id": 196,
-		"input": "$K = \\frac{[\\ce{Hg^2+}][\\ce{Hg}]}{[\\ce{Hg2^2+}]}$",
-		"texvcjs": "\\$K={\\frac {[{\\ce {Hg^2+}}][{\\ce {Hg}}]}{[{\\ce {Hg2^2+}}]}}\\$"
+		"input": "\\underset{\\text{Hydroxozikat}}{\\ce{[Zn(OH)4]^2-}}",
+		"texvcjs": "{\\underset {\\text{Hydroxozikat}}{{\\ce {[Zn(OH)4]^2-}}}}"
 	},
 	{
 		"id": 197,
-		"input": "$K = \\ce{\\frac{[Hg^2+][Hg]}{[Hg2^2+]}}$",
-		"texvcjs": "\\$K={\\ce {{\\frac {[Hg^2+][Hg]}{[Hg2^2+]}}}}\\$"
+		"input": "K = \\frac{[\\ce{Hg^2+}][\\ce{Hg}]}{[\\ce{Hg2^2+}]}",
+		"texvcjs": "K={\\frac {[{\\ce {Hg^2+}}][{\\ce {Hg}}]}{[{\\ce {Hg2^2+}}]}}"
+	},
+	{
+		"id": 198,
+		"input": "K = \\ce{\\frac{[Hg^2+][Hg]}{[Hg2^2+]}}",
+		"texvcjs": "K={\\ce {{\\frac {[Hg^2+][Hg]}{[Hg2^2+]}}}}"
 	}
 ]

--- a/test/mathjax-texvc-mhchem.json
+++ b/test/mathjax-texvc-mhchem.json
@@ -1,0 +1,519 @@
+[
+	{
+		"id": 1,
+		"input": "\\thetasym",
+		"texvcjs": "\\vartheta "
+	},
+	{
+		"id": 2,
+		"input": "\\koppa",
+		"texvcjs": "\\mathrm {\\koppa} "
+	},
+	{
+		"id": 3,
+		"input": "\\stigma",
+		"texvcjs": "\\mathrm {\\stigma} "
+	},
+	{
+		"id": 4,
+		"input": "\\coppa",
+		"texvcjs": "\\mathrm {\\coppa} "
+	},
+	{
+		"id": 5,
+		"input": "\\C",
+		"texvcjs": "\\mathbb {C} "
+	},
+	{
+		"id": 6,
+		"input": "\\cnums",
+		"texvcjs": "\\mathbb {C} "
+	},
+	{
+		"id": 7,
+		"input": "\\Complex",
+		"texvcjs": "\\mathbb {C} "
+	},
+	{
+		"id": 8,
+		"input": "\\H",
+		"texvcjs": "\\mathbb {H} "
+	},
+	{
+		"id": 9,
+		"input": "\\N",
+		"texvcjs": "\\mathbb {N} "
+	},
+	{
+		"id": 10,
+		"input": "\\natnums",
+		"texvcjs": "\\mathbb {N} "
+	},
+	{
+		"id": 11,
+		"input": "\\Q",
+		"texvcjs": "\\mathbb {Q} "
+	},
+	{
+		"id": 12,
+		"input": "\\R",
+		"texvcjs": "\\mathbb {R} "
+	},
+	{
+		"id": 13,
+		"input": "\\reals",
+		"texvcjs": "\\mathbb {R} "
+	},
+	{
+		"id": 14,
+		"input": "\\Reals",
+		"texvcjs": "\\mathbb {R} "
+	},
+	{
+		"id": 15,
+		"input": "\\Z",
+		"texvcjs": "\\mathbb {Z} "
+	},
+	{
+		"id": 16,
+		"input": "\\sect",
+		"texvcjs": "\\S "
+	},
+	{
+		"id": 17,
+		"input": "\\P",
+		"texvcjs": "\\P "
+	},
+	{
+		"id": 18,
+		"input": "\\AA",
+		"texvcjs": "\\mathrm {\\AA} "
+	},
+	{
+		"id": 19,
+		"input": "\\alef",
+		"texvcjs": "\\aleph "
+	},
+	{
+		"id": 20,
+		"input": "\\alefsym",
+		"texvcjs": "\\aleph "
+	},
+	{
+		"id": 21,
+		"input": "\\weierp",
+		"texvcjs": "\\wp "
+	},
+	{
+		"id": 22,
+		"input": "\\real",
+		"texvcjs": "\\Re "
+	},
+	{
+		"id": 23,
+		"input": "\\part",
+		"texvcjs": "\\partial "
+	},
+	{
+		"id": 24,
+		"input": "\\infin",
+		"texvcjs": "\\infty "
+	},
+	{
+		"id": 25,
+		"input": "\\empty",
+		"texvcjs": "\\emptyset "
+	},
+	{
+		"id": 26,
+		"input": "\\O",
+		"texvcjs": "\\emptyset "
+	},
+	{
+		"id": 27,
+		"input": "\\ang",
+		"texvcjs": "\\angle "
+	},
+	{
+		"id": 28,
+		"input": "\\exist",
+		"texvcjs": "\\exists "
+	},
+	{
+		"id": 29,
+		"input": "\\clubs",
+		"texvcjs": "\\clubsuit "
+	},
+	{
+		"id": 30,
+		"input": "\\diamonds",
+		"texvcjs": "\\diamondsuit "
+	},
+	{
+		"id": 31,
+		"input": "\\hearts",
+		"texvcjs": "\\heartsuit "
+	},
+	{
+		"id": 32,
+		"input": "\\spades",
+		"texvcjs": "\\spadesuit "
+	},
+	{
+		"id": 33,
+		"input": "\\textvisiblespace",
+		"texvcjs": "\\mathrm {\\textvisiblespace} "
+	},
+	{
+		"id": 34,
+		"input": "\\and",
+		"texvcjs": "\\land "
+	},
+	{
+		"id": 35,
+		"input": "\\or",
+		"texvcjs": "\\lor "
+	},
+	{
+		"id": 36,
+		"input": "\\bull",
+		"texvcjs": "\\bullet "
+	},
+	{
+		"id": 37,
+		"input": "\\plusmn",
+		"texvcjs": "\\pm "
+	},
+	{
+		"id": 38,
+		"input": "\\sdot",
+		"texvcjs": "\\cdot "
+	},
+	{
+		"id": 39,
+		"input": "\\sup",
+		"texvcjs": "\\sup "
+	},
+	{
+		"id": 40,
+		"input": "\\sub",
+		"texvcjs": "\\subset "
+	},
+	{
+		"id": 41,
+		"input": "\\supe",
+		"texvcjs": "\\supseteq "
+	},
+	{
+		"id": 42,
+		"input": "\\sube",
+		"texvcjs": "\\subseteq "
+	},
+	{
+		"id": 43,
+		"input": "\\isin",
+		"texvcjs": "\\in "
+	},
+	{
+		"id": 44,
+		"input": "\\hArr",
+		"texvcjs": "\\Leftrightarrow "
+	},
+	{
+		"id": 45,
+		"input": "\\harr",
+		"texvcjs": "\\leftrightarrow "
+	},
+	{
+		"id": 46,
+		"input": "\\Harr",
+		"texvcjs": "\\Leftrightarrow "
+	},
+	{
+		"id": 47,
+		"input": "\\Lrarr",
+		"texvcjs": "\\Leftrightarrow "
+	},
+	{
+		"id": 48,
+		"input": "\\lrArr",
+		"texvcjs": "\\Leftrightarrow "
+	},
+	{
+		"id": 49,
+		"input": "\\lArr",
+		"texvcjs": "\\Leftarrow "
+	},
+	{
+		"id": 50,
+		"input": "\\Larr",
+		"texvcjs": "\\Leftarrow "
+	},
+	{
+		"id": 51,
+		"input": "\\rArr",
+		"texvcjs": "\\Rightarrow "
+	},
+	{
+		"id": 52,
+		"input": "\\Rarr",
+		"texvcjs": "\\Rightarrow "
+	},
+	{
+		"id": 53,
+		"input": "\\harr",
+		"texvcjs": "\\leftrightarrow "
+	},
+	{
+		"id": 54,
+		"input": "\\lrarr",
+		"texvcjs": "\\leftrightarrow "
+	},
+	{
+		"id": 55,
+		"input": "\\larr",
+		"texvcjs": "\\leftarrow "
+	},
+	{
+		"id": 56,
+		"input": "\\gets",
+		"texvcjs": "\\gets "
+	},
+	{
+		"id": 57,
+		"input": "\\rarr",
+		"texvcjs": "\\rightarrow "
+	},
+	{
+		"id": 58,
+		"input": "\\oiint",
+		"texvcjs": "\\oiint "
+	},
+	{
+		"id": 59,
+		"input": "\\oiiint",
+		"texvcjs": "\\oiiint "
+	},
+	{
+		"id": 60,
+		"input": "\\Alpha",
+		"texvcjs": "\\mathrm {A} "
+	},
+	{
+		"id": 61,
+		"input": "\\Beta",
+		"texvcjs": "\\mathrm {B} "
+	},
+	{
+		"id": 62,
+		"input": "\\Epsilon",
+		"texvcjs": "\\mathrm {E} "
+	},
+	{
+		"id": 63,
+		"input": "\\Zeta",
+		"texvcjs": "\\mathrm {Z} "
+	},
+	{
+		"id": 64,
+		"input": "\\Eta",
+		"texvcjs": "\\mathrm {H} "
+	},
+	{
+		"id": 65,
+		"input": "\\Iota",
+		"texvcjs": "\\mathrm {I} "
+	},
+	{
+		"id": 66,
+		"input": "\\Kappa",
+		"texvcjs": "\\mathrm {K} "
+	},
+	{
+		"id": 67,
+		"input": "\\Mu",
+		"texvcjs": "\\mathrm {M} "
+	},
+	{
+		"id": 68,
+		"input": "\\Nu",
+		"texvcjs": "\\mathrm {N} "
+	},
+	{
+		"id": 69,
+		"input": "\\Omicron",
+		"texvcjs": "\\mathrm {O} "
+	},
+	{
+		"id": 70,
+		"input": "\\Rho",
+		"texvcjs": "\\mathrm {P} "
+	},
+	{
+		"id": 71,
+		"input": "\\Tau",
+		"texvcjs": "\\mathrm {T} "
+	},
+	{
+		"id": 72,
+		"input": "\\Chi",
+		"texvcjs": "\\mathrm {X} "
+	},
+	{
+		"id": 73,
+		"input": "\\Koppa",
+		"texvcjs": "\\mathrm {\\Koppa} "
+	},
+	{
+		"id": 74,
+		"input": "\\Stigma",
+		"texvcjs": "\\mathrm {\\Stigma} "
+	},
+	{
+		"id": 75,
+		"input": "\\Coppa",
+		"texvcjs": "\\mathrm {\\Coppa} "
+	},
+	{
+		"id": 76,
+		"input": "\\uarr",
+		"texvcjs": "\\uparrow "
+	},
+	{
+		"id": 77,
+		"input": "\\darr",
+		"texvcjs": "\\downarrow "
+	},
+	{
+		"id": 78,
+		"input": "\\Uarr",
+		"texvcjs": "\\Uparrow "
+	},
+	{
+		"id": 79,
+		"input": "\\uArr",
+		"texvcjs": "\\Uparrow "
+	},
+	{
+		"id": 80,
+		"input": "\\Darr",
+		"texvcjs": "\\Downarrow "
+	},
+	{
+		"id": 81,
+		"input": "\\dArr",
+		"texvcjs": "\\Downarrow "
+	},
+	{
+		"id": 82,
+		"input": "\\rang",
+		"texvcjs": "\\rangle "
+	},
+	{
+		"id": 83,
+		"input": "\\lang",
+		"texvcjs": "\\langle "
+	},
+	{
+		"id": 84,
+		"input": "\\arccot",
+		"texvcjs": "\\operatorname {arccot} "
+	},
+	{
+		"id": 85,
+		"input": "\\arcsec",
+		"texvcjs": "\\operatorname {arcsec} "
+	},
+	{
+		"id": 86,
+		"input": "\\arccsc",
+		"texvcjs": "\\operatorname {arccsc} "
+	},
+	{
+		"id": 87,
+		"input": "\\bold{x}",
+		"texvcjs": "{\\mathbf {x}}"
+	},
+	{
+		"id": 88,
+		"input": "\\href",
+		"ignore": true,
+		"comment": "Considered as dangerous MathJax command."
+	},
+	{
+		"id": 89,
+		"input": "\\style",
+		"ignore": true,
+		"comment": "Considered as dangerous MathJax command."
+	},
+	{
+		"id": 90,
+		"input": "\\pagecolor{red}x",
+		"texvcjs": "\\pagecolor {red}x"
+	},
+	{
+		"id": 91,
+		"input": "\\vline",
+		"texvcjs": "\\vline "
+	},
+	{
+		"id": 92,
+		"input": "\\image",
+		"texvcjs": "\\Im "
+	},
+	{
+		"id": 93,
+		"input": "\\ointctrclockwise",
+		"texvcjs": "\\ointctrclockwise "
+	},
+	{
+		"id": 94,
+		"input": "\\varointclockwise",
+		"texvcjs": "\\varointclockwise "
+	},
+	{
+		"id": 95,
+		"input": "\\text{[h]}",
+		"texvcjs": "{\\text{[h]}}"
+	},
+	{
+		"id": 96,
+		"input": "\\ce{H2O2}",
+		"texvcjs": "{\\ce {H2O2}}"
+	},
+	{
+		"id": 97,
+		"input": "\\ce{H H H}",
+		"texvcjs": "{\\ce {H H H}}"
+	},
+	{
+		"id": 98,
+		"input": "\\ce{H   H   H}",
+		"texvcjs": "{\\ce {H H H}}"
+	},
+	{
+		"id": 99,
+		"input": "\\ce{H_2HHHHH\\bond{...}H}",
+		"texvcjs": "{\\ce {H_2HHHHH\\bond{...}H}}"
+	},
+	{
+		"id": 100,
+		"input": "\\ce{^}",
+		"texvcjs": "{\\ce {^}}"
+	},
+	{
+		"id": 101,
+		"input": "\\ce{CO2 + C -> 2 CO}",
+		"texvcjs": "{\\ce {CO2 + C -> 2 CO}}"
+	},
+	{
+		"id": 101,
+		"input": "\\ce{CO_2 + C -> 2 CO}",
+		"texvcjs": "{\\ce {CO_2 + C -> 2 CO}}"
+	},
+	{
+		"id": 102,
+		"input": "\\ce{\\underbrace{O2}_{oxygen molecule} -> 2O}",
+		"texvcjs": "{\\ce {\\underbrace{O2}_{oxygen molecule} -> 2O}}"
+	}
+]

--- a/test/mathjax-texvc-mhchem.json
+++ b/test/mathjax-texvc-mhchem.json
@@ -520,5 +520,419 @@
 		"id": 104,
 		"input": "\\ce{^{227}_{90}Th+}",
 		"texvcjs": "{\\ce {^{227}_{90}Th+}}"
+	},
+	{
+		"id": 105,
+		"input": "\\ce{CO2 + C -> 2 CO}",
+		"texvcjs": "{\\ce {CO2 + C -> 2 CO}}"
+	},
+	{
+		"id": 106,
+		"input": "\\ce{Hg^2+ ->[I-] HgI2}",
+		"texvcjs": "{\\ce {Hg^2+ ->[I-] HgI2}}"
+	},
+	{
+		"id": 107,
+		"input": "\\ce{H2O}",
+		"texvcjs": "{\\ce {H2O}}"
+	},
+	{
+		"id": 108,
+		"input": "\\ce{Sb2O3}",
+		"texvcjs": "{\\ce {Sb2O3}}"
+	},
+	{
+		"id": 109,
+		"input": "\\ce{N2}",
+		"texvcjs": "{\\ce {N2}}"
+	},
+	{
+		"id": 110,
+		"input": "\\ce{O2}",
+		"texvcjs": "{\\ce {O2}}"
+	},
+	{
+		"id": 111,
+		"input": "\\ce{CO2}",
+		"texvcjs": "{\\ce {CO2}}"
+	},
+	{
+		"id": 112,
+		"input": "\\ce{A <--> B}",
+		"texvcjs": "{\\ce {A <--> B}}"
+	},
+	{
+		"id": 117,
+		"input": "\\ce{CrO4^2-}",
+		"texvcjs": "{\\ce {CrO4^2-}}"
+	},
+	{
+		"id": 119,
+		"input": "\\ce{H+}",
+		"texvcjs": "{\\ce {H+}}"
+	},
+	{
+		"id": 121,
+		"input": "\\ce{[AgCl2]-}",
+		"texvcjs": "{\\ce {[AgCl2]-}}"
+	},
+	{
+		"id": 122,
+		"input": "\\ce{Y^99+}",
+		"texvcjs": "{\\ce {Y^99+}}"
+	},
+	{
+		"id": 123,
+		"input": "\\ce{Y^{99+}}",
+		"texvcjs": "{\\ce {Y^{99+}}}"
+	},
+	{
+		"id": 124,
+		"input": "\\ce{Fe^{II}Fe^{III}2O4}",
+		"texvcjs": "{\\ce {Fe^{II}Fe^{III}2O4}}"
+	},
+	{
+		"id": 125,
+		"input": "\\ce{2H2O}",
+		"texvcjs": "{\\ce {2H2O}}"
+	},
+	{
+		"id": 126,
+		"input": "\\ce{2 H2O}",
+		"texvcjs": "{\\ce {2 H2O}}"
+	},
+	{
+		"id": 127,
+		"input": "\\ce{0.5H2O}",
+		"texvcjs": "{\\ce {0.5H2O}}"
+	},
+	{
+		"id": 128,
+		"input": "\\ce{1/2H2O}",
+		"texvcjs": "{\\ce {1/2H2O}}"
+	},
+	{
+		"id": 129,
+		"input": "\\ce{(1/2)H2O}",
+		"texvcjs": "{\\ce {(1/2)H2O}}"
+	},
+	{
+		"id": 130,
+		"input": "\\ce{$n$H2O}",
+		"texvcjs": "{\\ce {$n$H2O}}"
+	},
+	{
+		"id": 131,
+		"input": "\\ce{^{227}_{90}Th+}",
+		"texvcjs": "{\\ce {^{227}_{90}Th+}}"
+	},
+	{
+		"id": 132,
+		"input": "\\ce{^227_90Th+}",
+		"texvcjs": "{\\ce {^227_90Th+}}"
+	},
+	{
+		"id": 133,
+		"input": "\\ce{^{0}_{-1}n^{-}}",
+		"texvcjs": "{\\ce {^{0}_{-1}n^{-}}}"
+	},
+	{
+		"id": 134,
+		"input": "\\ce{^0_-1n-}",
+		"texvcjs": "{\\ce {^0_-1n-}}"
+	},
+	{
+		"id": 135,
+		"input": "\\ce{H{}^3HO}",
+		"texvcjs": "{\\ce {H{}^3HO}}"
+	},
+	{
+		"id": 136,
+		"input": "\\ce{H^3HO}",
+		"texvcjs": "{\\ce {H^3HO}}"
+	},
+	{
+		"id": 137,
+		"input": "\\ce{(NH4)2S}",
+		"texvcjs": "{\\ce {(NH4)2S}}"
+	},
+	{
+		"id": 138,
+		"input": "\\ce{[\\{(X2)3\\}2]^3+}",
+		"texvcjs": "{\\ce {[\\{(X2)3\\}2]^3+}}"
+	},
+	{
+		"id": 139,
+		"input": "\\ce{H2(aq)}",
+		"texvcjs": "{\\ce {H2(aq)}}"
+	},
+	{
+		"id": 140,
+		"input": "\\ce{CO3^2-{}_{(aq)}}",
+		"texvcjs": "{\\ce {CO3^2-{}_{(aq)}}}"
+	},
+	{
+		"id": 141,
+		"input": "\\ce{NaOH(aq,$\\infty$)}",
+		"texvcjs": "{\\ce {NaOH(aq,$\\infty$)}}"
+	},
+	{
+		"id": 142,
+		"input": "\\ce{OCO^{.-}}",
+		"texvcjs": "{\\ce {OCO^{.-}}}"
+	},
+	{
+		"id": 143,
+		"input": "\\ce{NO^{(2.)-}}",
+		"texvcjs": "{\\ce {NO^{(2.)-}}}"
+	},
+	{
+		"id": 144,
+		"input": "\\ce{\\mu-Cl}",
+		"texvcjs": "",
+		"ignore": true
+	},
+	{
+		"id": 145,
+		"input": "\\ce{[Pt(\\eta^2-C2H4)Cl3]-}",
+		"texvcjs": "",
+		"ignore": true
+	},
+	{
+		"id": 146,
+		"input": "\\ce{NaOH(aq,$\\infty$)}",
+		"texvcjs": "{\\ce {NaOH(aq,$\\infty$)}}"
+	},
+	{
+		"id": 147,
+		"input": "\\ce{Fe(CN)_{$\\frac{6}{2}$}}",
+		"texvcjs": "",
+		"ignore": true
+	},
+	{
+		"id": 148,
+		"input": "\\ce{$cis${-}[PtCl2(NH3)2]}",
+		"texvcjs": "{\\ce {$cis${-}[PtCl2(NH3)2]}}"
+	},
+	{
+		"id": 149,
+		"input": "\\ce{{(+)}_589{-}[Co(en)3]Cl3}",
+		"texvcjs": "{\\ce {{(+)}_589{-}[Co(en)3]Cl3}}"
+	},
+	{
+		"id": 150,
+		"input": "\\ce{{(+)}_589{-}[Co(en)3]Cl3}",
+		"texvcjs": "{\\ce {{(+)}_589{-}[Co(en)3]Cl3}}"
+	},
+	{
+		"id": 151,
+		"input": "\\ce{KCr(SO4)2*12H2O}",
+		"texvcjs": "{\\ce {KCr(SO4)2*12H2O}}"
+	},
+	{
+		"id": 152,
+		"input": "\\ce{KCr(SO4)2.12H2O}",
+		"texvcjs": "{\\ce {KCr(SO4)2.12H2O}}"
+	},
+	{
+		"id": 153,
+		"input": "\\ce{KCr(SO4)2 * 12 H2O}",
+		"texvcjs": "{\\ce {KCr(SO4)2 * 12 H2O}}"
+	},
+	{
+		"id": 154,
+		"input": "\\ce{C6H5-CHO}",
+		"texvcjs": "{\\ce {C6H5-CHO}}"
+	},
+	{
+		"id": 155,
+		"input": "\\ce{A-B=C#D}",
+		"texvcjs": "{\\ce {A-B=C#D}}"
+	},
+	{
+		"id": 156,
+		"input": "\\ce{A-B=C#D}",
+		"texvcjs": "{\\ce {A-B=C#D}}"
+	},
+	{
+		"id": 157,
+		"input": "\\ce{A\\bond{-}B\\bond{=}C\\bond{#}D}",
+		"texvcjs": "{\\ce {A\\bond {-}B\\bond {=}C\\bond {#}D}}"
+	},
+	{
+		"id": 158,
+		"input": "\\ce{A\\bond{1}B\\bond{2}C\\bond{3}D}",
+		"texvcjs": "{\\ce {A\\bond {1}B\\bond {2}C\\bond {3}D}}"
+	},
+	{
+		"id": 159,
+		"input": "\\ce{A\\bond{~}B\\bond{~-}C}",
+		"texvcjs": "{\\ce {A\\bond {~}B\\bond {~-}C}}"
+	},
+	{
+		"id": 160,
+		"input": "\\ce{A\\bond{~--}B\\bond{~=}C\\bond{-~-}D}",
+		"texvcjs": "{\\ce {A\\bond {~--}B\\bond {~=}C\\bond {-~-}D}}"
+	},
+	{
+		"id": 161,
+		"input": "\\ce{A\\bond{...}B\\bond{....}C}",
+		"texvcjs": "{\\ce {A\\bond {...}B\\bond {....}C}}"
+	},
+	{
+		"id": 162,
+		"input": "\\ce{A\\bond{->}B\\bond{<-}C}",
+		"texvcjs": "{\\ce {A\\bond {->}B\\bond {<-}C}}"
+	},
+	{
+		"id": 163,
+		"input": "$\\underset{\\mathrm{red}}{\\ce{[Hg^{II}I4]^2-}}$",
+		"texvcjs": "\\${\\underset {\\mathrm {red} }{{\\ce {[Hg^{II}I4]^2-}}}}\\$"
+	},
+	{
+		"id": 164,
+		"input": "\\ce{Hg^2+ ->[I-] $\\underset{\\mathrm{red}}{\\ce{HgI2}}$} ",
+		"texvcjs": "",
+		"ignore": true
+	},
+	{
+		"id": 169,
+		"input": "\\ce{A ->[H2O] B}",
+		"texvcjs": "{\\ce {A ->[H2O] B}}"
+	},
+	{
+		"id": 170,
+		"input": "\\ce{A ->[H2O] B}",
+		"texvcjs": "{\\ce {A ->[H2O] B}}"
+	},
+	{
+		"id": 171,
+		"input": "\\ce{A ->[{text above}][{text below}] B}",
+		"texvcjs": "{\\ce {A ->[{text above}][{text below}] B}}"
+	},
+	{
+		"id": 172,
+		"input": "\\ce{A ->[{text above}][{text below}] B}",
+		"texvcjs": "{\\ce {A ->[{text above}][{text below}] B}}"
+	},
+	{
+		"id": 173,
+		"input": "\\ce{A ->[$x$][$x_i$] B}",
+		"texvcjs": "{\\ce {A ->[$x$][$x_i$] B}}"
+	},
+	{
+		"id": 175,
+		"input": "\\ce{A ->[${x}$] B}",
+		"texvcjs": "{\\ce {A ->[${,x},$] B}}"
+	},
+	{
+		"id": 177,
+		"input": "\\ce{A + B}",
+		"texvcjs": "{\\ce {A + B}}"
+	},
+	{
+		"id": 178,
+		"input": "\\ce{A - B}",
+		"texvcjs": "{\\ce {A - B}}"
+	},
+	{
+		"id": 179,
+		"input": "\\ce{A = B}",
+		"texvcjs": "{\\ce {A = B}}"
+	},
+	{
+		"id": 180,
+		"input": "\\ce{A \\pm B}",
+		"texvcjs": "{\\ce {A \\pm B}}"
+	},
+	{
+		"id": 181,
+		"input": "\\ce{SO4^2- + Ba^2+ -> BaSO4 v}",
+		"texvcjs": "{\\ce {SO4^2- + Ba^2+ -> BaSO4 v}}"
+	},
+	{
+		"id": 182,
+		"input": "\\ce{A v B (v) -> B ^ B (^)}",
+		"texvcjs": "{\\ce {A v B (v) -> B ^ B (^)}}"
+	},
+	{
+		"id": 183,
+		"input": "\\ce{Zn^2+}",
+		"texvcjs": "{\\ce {Zn^2+}}"
+	},
+	{
+		"id": 184,
+		"input": "\\ce{RNO2 &<=>[+e] RNO2^{-.}}",
+		"texvcjs": "{\\ce {RNO2 &<=>[+e] RNO2^{-.}}}"
+	},
+	{
+		"id": 185,
+		"input": "$\\ce{NaOH(aq,$\\infty$)}$",
+		"texvcjs": "\\${\\ce {NaOH(aq,$\\infty$)}}\\$"
+	},
+	{
+		"id": 186,
+		"input": "$\\ce{H2O}$",
+		"texvcjs": "\\${\\ce {H2O}}\\$"
+	},
+	{
+		"id": 187,
+		"input": "$\\ce{Fe(CN)_{$\\frac{6}{2}$}}$",
+		"texvcjs": "",
+		"ignore": true
+	},
+	{
+		"id": 188,
+		"input": "$\\ce{NO_x}$ \\bf \\ce{NO_x}",
+		"texvcjs": "\\${\\ce {NO_x}}\\${\\bf {{\\ce {NO_x}}}}"
+	},
+	{
+		"id": 189,
+		"input": "$\\ce{Fe^n+}$ \\bf \\ce{Fe^n+}",
+		"texvcjs": "\\${\\ce {Fe^n+}}\\${\\bf {{\\ce {Fe^n+}}}}"
+
+	},
+	{
+		"id": 190,
+		"input": "$\\ce{x Na(NH4)HPO4 ->[\\Delta] (NaPO3)_x + x NH3 ^ + x H2O}$",
+		"texvcjs": "",
+		"ignore": true
+	},
+	{
+		"id": 191,
+		"input": "$\\ce{NO_$x$}$ \\sffamily\\bfseries \\ce{NO_$x$}",
+		"texvcjs": "",
+		"ignore": true
+	},
+	{
+		"id": 192,
+		"input": "$\\ce{NO_${x}$}$ \\bf \\ce{NO_${x}$}",
+		"texvcjs": "",
+		"ignore": true
+	},
+	{
+		"id": 193,
+		"input": "$\\ce{$cis${-}[PtCl2(NH3)2]}$",
+		"texvcjs": "\\${\\ce {$cis${-}[PtCl2(NH3)2]}}\\$"
+	},
+	{
+		"id": 194,
+		"input": "$\\underset{\\text{amphoteres Hydroxid}}{\\ce{Zn(OH)2 v}}$",
+		"texvcjs": "\\${\\underset {\\text{amphoteres Hydroxid}}{{\\ce {Zn(OH)2 v}}}}\\$"
+	},
+	{
+		"id": 195,
+		"input": "$\\underset{\\text{Hydroxozikat}}{\\ce{[Zn(OH)4]^2-}}$",
+		"texvcjs": "\\${\\underset {\\text{Hydroxozikat}}{{\\ce {[Zn(OH)4]^2-}}}}\\$"
+	},
+	{
+		"id": 196,
+		"input": "$K = \\frac{[\\ce{Hg^2+}][\\ce{Hg}]}{[\\ce{Hg2^2+}]}$",
+		"texvcjs": "\\$K={\\frac {[{\\ce {Hg^2+}}][{\\ce {Hg}}]}{[{\\ce {Hg2^2+}}]}}\\$"
+	},
+	{
+		"id": 197,
+		"input": "$K = \\ce{\\frac{[Hg^2+][Hg]}{[Hg2^2+]}}$",
+		"texvcjs": "\\$K={\\ce {{\\frac {[Hg^2+][Hg]}{[Hg2^2+]}}}}\\$"
 	}
 ]

--- a/test/mathjax-texvc-mhchem.json
+++ b/test/mathjax-texvc-mhchem.json
@@ -494,7 +494,7 @@
 	{
 		"id": 99,
 		"input": "\\ce{H_2HHHHH\\bond{...}H}",
-		"texvcjs": "{\\ce {H_2HHHHH\\bond{...}H}}"
+		"texvcjs": "{\\ce {H_2HHHHH\\bond {...}H}}"
 	},
 	{
 		"id": 100,
@@ -507,13 +507,18 @@
 		"texvcjs": "{\\ce {CO2 + C -> 2 CO}}"
 	},
 	{
-		"id": 101,
+		"id": 102,
 		"input": "\\ce{CO_2 + C -> 2 CO}",
 		"texvcjs": "{\\ce {CO_2 + C -> 2 CO}}"
 	},
 	{
-		"id": 102,
+		"id": 103,
 		"input": "\\ce{\\underbrace{O2}_{oxygen molecule} -> 2O}",
-		"texvcjs": "{\\ce {\\underbrace{O2}_{oxygen molecule} -> 2O}}"
+		"texvcjs": "{\\ce {{\\underbrace {O2}_{oxygen molecule}}-> 2O}}"
+	},
+	{
+		"id": 104,
+		"input": "\\ce{^{227}_{90}Th+}",
+		"texvcjs": "{\\ce {^{227}_{90}Th+}}"
 	}
 ]

--- a/test/mathjax-texvc-mhchem.json
+++ b/test/mathjax-texvc-mhchem.json
@@ -494,7 +494,7 @@
 	{
 		"id": 99,
 		"input": "\\ce{H_2HHHHH\\bond{...}H}",
-		"texvcjs": "{\\ce {H_2HHHHH\\bond {...}H}}"
+		"texvcjs": "{\\ce {H_2HHHHH{\\bond {...}}H}}"
 	},
 	{
 		"id": 100,
@@ -514,7 +514,7 @@
 	{
 		"id": 103,
 		"input": "\\ce{\\underbrace{O2}_{oxygen molecule} -> 2O}",
-		"texvcjs": "{\\ce {{\\underbrace {O2}_{oxygen molecule}}-> 2O}}"
+		"texvcjs": "{\\ce {\\underbrace{O2}_{oxygen molecule}-> 2O}}"
 	},
 	{
 		"id": 104,
@@ -567,10 +567,31 @@
 		"texvcjs": "{\\ce {H2O\\\\ CO2}}"
 	},
 	{
+		"id":114,
+		"input": "\\ce{\\frac{1}{2}H\\bond{-}H \\ce{H2O}}",
+		"texvcjs": "{\\ce {{\\frac {1}{2}}H{\\bond {-}}H {\\ce {H2O}}}}"
+	},
+	{
+		"id":115,
+		"input": "\\ce{\\color{red}{H2O}}",
+		"texvcjs": "{\\ce {{\\color {red}{H2O}}}}"
+	},
+	{
+		"id": 116,
+		"input": "\\ce{CrO4^2-}",
+		"texvcjs": "{\\ce {CrO4^2-}}"
+	},
+	{
 		"id": 117,
 		"input": "\\ce{CrO4^2-}",
 		"texvcjs": "{\\ce {CrO4^2-}}"
 	},
+	{
+		"id": 118,
+		"input": "\\ce{\\underbrace{a}_{b}}",
+		"texvcjs": "{\\ce {\\underbrace{a}_{b}}}"
+	},
+
 	{
 		"id": 119,
 		"input": "\\ce{H+}",
@@ -759,32 +780,32 @@
 	{
 		"id": 157,
 		"input": "\\ce{A\\bond{-}B\\bond{=}C\\bond{#}D}",
-		"texvcjs": "{\\ce {A\\bond {-}B\\bond {=}C\\bond {#}D}}"
+		"texvcjs": "{\\ce {A{\\bond {-}}B{\\bond {=}}C{\\bond {#}}D}}"
 	},
 	{
 		"id": 158,
 		"input": "\\ce{A\\bond{1}B\\bond{2}C\\bond{3}D}",
-		"texvcjs": "{\\ce {A\\bond {1}B\\bond {2}C\\bond {3}D}}"
+		"texvcjs": "{\\ce {A{\\bond {1}}B{\\bond {2}}C{\\bond {3}}D}}"
 	},
 	{
 		"id": 159,
 		"input": "\\ce{A\\bond{~}B\\bond{~-}C}",
-		"texvcjs": "{\\ce {A\\bond {~}B\\bond {~-}C}}"
+		"texvcjs": "{\\ce {A{\\bond {~}}B{\\bond {~-}}C}}"
 	},
 	{
 		"id": 160,
 		"input": "\\ce{A\\bond{~--}B\\bond{~=}C\\bond{-~-}D}",
-		"texvcjs": "{\\ce {A\\bond {~--}B\\bond {~=}C\\bond {-~-}D}}"
+		"texvcjs": "{\\ce {A{\\bond {~--}}B{\\bond {~=}}C{\\bond {-~-}}D}}"
 	},
 	{
 		"id": 161,
 		"input": "\\ce{A\\bond{...}B\\bond{....}C}",
-		"texvcjs": "{\\ce {A\\bond {...}B\\bond {....}C}}"
+		"texvcjs": "{\\ce {A{\\bond {...}}B{\\bond {....}}C}}"
 	},
 	{
 		"id": 162,
 		"input": "\\ce{A\\bond{->}B\\bond{<-}C}",
-		"texvcjs": "{\\ce {A\\bond {->}B\\bond {<-}C}}"
+		"texvcjs": "{\\ce {A{\\bond {->}}B{\\bond {<-}}C}}"
 	},
 	{
 		"id": 163,
@@ -936,5 +957,25 @@
 		"id": 198,
 		"input": "K = \\ce{\\frac{[Hg^2+][Hg]}{[Hg2^2+]}}",
 		"texvcjs": "K={\\ce {{\\frac {[Hg^2+][Hg]}{[Hg2^2+]}}}}"
+	},
+	{
+		"id": 199,
+		"input": "^1",
+		"texvcjs": "^{1}"
+	},
+	{
+		"id": 200,
+		"input": "_1",
+		"texvcjs": "_{1}"
+	},
+	{
+		"id": 201,
+		"input": "1^1",
+		"texvcjs": "1^{1}"
+	},
+	{
+		"id": 202,
+		"input": "1_1",
+		"texvcjs": "1_{1}"
 	}
 ]


### PR DESCRIPTION
Implemented grammar of `mhchem` in the `texvcjs` parser.
To switch to math mode within a chemical formula `\begin{math} some math \end{math}` is used as `$` is not a option (security reasons). Currently only named colors are supported within `\color{}{}` (without a backslash).