### PR TITLE
Allow LaTeX one char command in ce tags

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -411,51 +411,52 @@ module.exports = /*
         peg$c258 = /^[01]/,
         peg$c259 = peg$classExpectation(["0", "1"], false, false),
         peg$c260 = function(f) { return tu.mhchem_single_macro[f]; },
-        peg$c261 = function(f) { return tu.mhchem_bond[f]; },
-        peg$c262 = function(f) { return tu.mhchem_macro_1p[f]; },
-        peg$c263 = function(f) { return tu.mhchem_macro_2p[f]; },
-        peg$c264 = function(f) { return tu.mhchem_macro_2pu[f]; },
-        peg$c265 = function(f) { return tu.mhchem_macro_2pc[f]; },
-        peg$c266 = /^[+-.*']/,
-        peg$c267 = peg$classExpectation([["+", "."], "*", "'"], false, false),
-        peg$c268 = "=",
-        peg$c269 = peg$literalExpectation("=", false),
-        peg$c270 = "#",
-        peg$c271 = peg$literalExpectation("#", false),
-        peg$c272 = "~--",
-        peg$c273 = peg$literalExpectation("~--", false),
-        peg$c274 = "~-",
-        peg$c275 = peg$literalExpectation("~-", false),
-        peg$c276 = "~=",
-        peg$c277 = peg$literalExpectation("~=", false),
-        peg$c278 = "~",
-        peg$c279 = peg$literalExpectation("~", false),
-        peg$c280 = "-~-",
-        peg$c281 = peg$literalExpectation("-~-", false),
-        peg$c282 = "....",
-        peg$c283 = peg$literalExpectation("....", false),
-        peg$c284 = "...",
-        peg$c285 = peg$literalExpectation("...", false),
-        peg$c286 = "<-",
-        peg$c287 = peg$literalExpectation("<-", false),
-        peg$c288 = "->",
-        peg$c289 = peg$literalExpectation("->", false),
-        peg$c290 = "1",
-        peg$c291 = peg$literalExpectation("1", false),
-        peg$c292 = "2",
-        peg$c293 = peg$literalExpectation("2", false),
-        peg$c294 = "3",
-        peg$c295 = peg$literalExpectation("3", false),
-        peg$c296 = "{math}",
-        peg$c297 = peg$literalExpectation("{math}", false),
-        peg$c298 = function(c) { return c; },
-        peg$c299 = "\\}",
-        peg$c300 = peg$literalExpectation("\\}", false),
-        peg$c301 = /^[+-=#().,;\/*<>|@&'[\]]/,
-        peg$c302 = peg$classExpectation([["+", "="], "#", "(", ")", ".", ",", ";", "/", "*", "<", ">", "|", "@", "&", "'", "[", "]"], false, false),
-        peg$c303 = function() { return "{}"; },
-        peg$c304 = function() { return false; },
-        peg$c305 = function() { return peg$currPos === input.length; },
+        peg$c261 = function(c) { return "\\" + c; },
+        peg$c262 = function(f) { return tu.mhchem_bond[f]; },
+        peg$c263 = function(f) { return tu.mhchem_macro_1p[f]; },
+        peg$c264 = function(f) { return tu.mhchem_macro_2p[f]; },
+        peg$c265 = function(f) { return tu.mhchem_macro_2pu[f]; },
+        peg$c266 = function(f) { return tu.mhchem_macro_2pc[f]; },
+        peg$c267 = /^[+-.*']/,
+        peg$c268 = peg$classExpectation([["+", "."], "*", "'"], false, false),
+        peg$c269 = "=",
+        peg$c270 = peg$literalExpectation("=", false),
+        peg$c271 = "#",
+        peg$c272 = peg$literalExpectation("#", false),
+        peg$c273 = "~--",
+        peg$c274 = peg$literalExpectation("~--", false),
+        peg$c275 = "~-",
+        peg$c276 = peg$literalExpectation("~-", false),
+        peg$c277 = "~=",
+        peg$c278 = peg$literalExpectation("~=", false),
+        peg$c279 = "~",
+        peg$c280 = peg$literalExpectation("~", false),
+        peg$c281 = "-~-",
+        peg$c282 = peg$literalExpectation("-~-", false),
+        peg$c283 = "....",
+        peg$c284 = peg$literalExpectation("....", false),
+        peg$c285 = "...",
+        peg$c286 = peg$literalExpectation("...", false),
+        peg$c287 = "<-",
+        peg$c288 = peg$literalExpectation("<-", false),
+        peg$c289 = "->",
+        peg$c290 = peg$literalExpectation("->", false),
+        peg$c291 = "1",
+        peg$c292 = peg$literalExpectation("1", false),
+        peg$c293 = "2",
+        peg$c294 = peg$literalExpectation("2", false),
+        peg$c295 = "3",
+        peg$c296 = peg$literalExpectation("3", false),
+        peg$c297 = "{math}",
+        peg$c298 = peg$literalExpectation("{math}", false),
+        peg$c299 = function(c) { return c; },
+        peg$c300 = "\\}",
+        peg$c301 = peg$literalExpectation("\\}", false),
+        peg$c302 = /^[+-=#().,;\/*<>|@&'[\]]/,
+        peg$c303 = peg$classExpectation([["+", "="], "#", "(", ")", ".", ",", ";", "/", "*", "<", ">", "|", "@", "&", "'", "[", "]"], false, false),
+        peg$c304 = function() { return "{}"; },
+        peg$c305 = function() { return false; },
+        peg$c306 = function() { return peg$currPos === input.length; },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -8480,6 +8481,36 @@ module.exports = /*
         peg$currPos = s0;
         s0 = peg$FAILED;
       }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 92) {
+          s1 = peg$c157;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c158); }
+        }
+        if (s1 !== peg$FAILED) {
+          if (peg$c159.test(input.charAt(peg$currPos))) {
+            s2 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s2 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c160); }
+          }
+          if (s2 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c261(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
@@ -8502,7 +8533,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c261(s1);
+        s2 = peg$c262(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8548,7 +8579,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c262(s1);
+        s2 = peg$c263(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8594,7 +8625,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c263(s1);
+        s2 = peg$c264(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8640,7 +8671,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c264(s1);
+        s2 = peg$c265(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8686,7 +8717,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c265(s1);
+        s2 = peg$c266(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8732,12 +8763,12 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$parseliteral_id();
         if (s0 === peg$FAILED) {
-          if (peg$c266.test(input.charAt(peg$currPos))) {
+          if (peg$c267.test(input.charAt(peg$currPos))) {
             s0 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c267); }
+            if (peg$silentFails === 0) { peg$fail(peg$c268); }
           }
         }
       }
@@ -8794,91 +8825,91 @@ module.exports = /*
       }
 
       if (input.charCodeAt(peg$currPos) === 61) {
-        s0 = peg$c268;
+        s0 = peg$c269;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c269); }
+        if (peg$silentFails === 0) { peg$fail(peg$c270); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 35) {
-          s0 = peg$c270;
+          s0 = peg$c271;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c271); }
+          if (peg$silentFails === 0) { peg$fail(peg$c272); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c272) {
-            s0 = peg$c272;
+          if (input.substr(peg$currPos, 3) === peg$c273) {
+            s0 = peg$c273;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c273); }
+            if (peg$silentFails === 0) { peg$fail(peg$c274); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c274) {
-              s0 = peg$c274;
+            if (input.substr(peg$currPos, 2) === peg$c275) {
+              s0 = peg$c275;
               peg$currPos += 2;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c275); }
+              if (peg$silentFails === 0) { peg$fail(peg$c276); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c276) {
-                s0 = peg$c276;
+              if (input.substr(peg$currPos, 2) === peg$c277) {
+                s0 = peg$c277;
                 peg$currPos += 2;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c277); }
+                if (peg$silentFails === 0) { peg$fail(peg$c278); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 126) {
-                  s0 = peg$c278;
+                  s0 = peg$c279;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c279); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c280); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 3) === peg$c280) {
-                    s0 = peg$c280;
+                  if (input.substr(peg$currPos, 3) === peg$c281) {
+                    s0 = peg$c281;
                     peg$currPos += 3;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c281); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c282); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 4) === peg$c282) {
-                      s0 = peg$c282;
+                    if (input.substr(peg$currPos, 4) === peg$c283) {
+                      s0 = peg$c283;
                       peg$currPos += 4;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c283); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c284); }
                     }
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 3) === peg$c284) {
-                        s0 = peg$c284;
+                      if (input.substr(peg$currPos, 3) === peg$c285) {
+                        s0 = peg$c285;
                         peg$currPos += 3;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c285); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c286); }
                       }
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 2) === peg$c286) {
-                          s0 = peg$c286;
+                        if (input.substr(peg$currPos, 2) === peg$c287) {
+                          s0 = peg$c287;
                           peg$currPos += 2;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c287); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c288); }
                         }
                         if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c288) {
-                            s0 = peg$c288;
+                          if (input.substr(peg$currPos, 2) === peg$c289) {
+                            s0 = peg$c289;
                             peg$currPos += 2;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c290); }
                           }
                           if (s0 === peg$FAILED) {
                             if (input.charCodeAt(peg$currPos) === 45) {
@@ -8890,27 +8921,27 @@ module.exports = /*
                             }
                             if (s0 === peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 49) {
-                                s0 = peg$c290;
+                                s0 = peg$c291;
                                 peg$currPos++;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c291); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c292); }
                               }
                               if (s0 === peg$FAILED) {
                                 if (input.charCodeAt(peg$currPos) === 50) {
-                                  s0 = peg$c292;
+                                  s0 = peg$c293;
                                   peg$currPos++;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c294); }
                                 }
                                 if (s0 === peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 51) {
-                                    s0 = peg$c294;
+                                    s0 = peg$c295;
                                     peg$currPos++;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c295); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c296); }
                                   }
                                 }
                               }
@@ -8947,12 +8978,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c296) {
-          s2 = peg$c296;
+        if (input.substr(peg$currPos, 6) === peg$c297) {
+          s2 = peg$c297;
           peg$currPos += 6;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c297); }
+          if (peg$silentFails === 0) { peg$fail(peg$c298); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -8992,12 +9023,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c296) {
-          s2 = peg$c296;
+        if (input.substr(peg$currPos, 6) === peg$c297) {
+          s2 = peg$c297;
           peg$currPos += 6;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c297); }
+          if (peg$silentFails === 0) { peg$fail(peg$c298); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -9069,21 +9100,21 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c298(s1);
+        s1 = peg$c299(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c299) {
-          s1 = peg$c299;
+        if (input.substr(peg$currPos, 2) === peg$c300) {
+          s1 = peg$c300;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c300); }
+          if (peg$silentFails === 0) { peg$fail(peg$c301); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c298(s1);
+          s1 = peg$c299(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -9097,21 +9128,21 @@ module.exports = /*
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c298(s1);
+            s1 = peg$c299(s1);
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (peg$c301.test(input.charAt(peg$currPos))) {
+            if (peg$c302.test(input.charAt(peg$currPos))) {
               s1 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c302); }
+              if (peg$silentFails === 0) { peg$fail(peg$c303); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c298(s1);
+              s1 = peg$c299(s1);
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
@@ -9119,7 +9150,7 @@ module.exports = /*
               s1 = peg$parseliteral_mn();
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c298(s1);
+                s1 = peg$c299(s1);
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
@@ -9129,7 +9160,7 @@ module.exports = /*
                   s2 = peg$parseCURLY_CLOSE();
                   if (s2 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c303();
+                    s1 = peg$c304();
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9163,7 +9194,7 @@ module.exports = /*
       }
 
       peg$savedPos = peg$currPos;
-      s0 = peg$c304();
+      s0 = peg$c305();
       if (s0) {
         s0 = void 0;
       } else {
@@ -9188,7 +9219,7 @@ module.exports = /*
       }
 
       peg$savedPos = peg$currPos;
-      s0 = peg$c305();
+      s0 = peg$c306();
       if (s0) {
         s0 = void 0;
       } else {

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -528,7 +528,9 @@ CNUM
 
 
 // MHCHEM LEXER RULES
-CHEM_SINGLE_MACRO = f:generic_func &{ return tu.mhchem_single_macro[f]; } { return f; }
+CHEM_SINGLE_MACRO
+ = f:generic_func &{ return tu.mhchem_single_macro[f]; } { return f; }
+ / "\\" c:[, ;!_#%$&] { return "\\" + c; }
 
 CHEM_BOND = f:generic_func &{ return tu.mhchem_bond[f]; } _ { return f; }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathoid-texvcjs",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A TeX/LaTeX validator for mediawiki.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/mathjax-texvc.json
+++ b/test/mathjax-texvc.json
@@ -1676,5 +1676,24 @@
     "options": {
       "usemathrm": true
     }
+  },
+  {
+    "id": 205,
+    "input": "\\ ",
+    "texvcjs": "\\ ",
+    "options": {
+      "usemathrm": true,
+      "usemhchem": true
+    }
+  },
+  {
+    "id": 206,
+    "input": "\\ce {\\ }",
+    "texvcjs": "{\\ce {\\ }}",
+    "comment": "Bug T183557",
+    "options": {
+      "usemathrm": true,
+      "usemhchem": true
+    }
   }
 ]


### PR DESCRIPTION
Add the following one char commands in ce mode
`, ;!_#%$&`

The absence of the $\ $ LaTeX command would have
caused a regression.

cf. https://phabricator.wikimedia.org/T183557