### PR TITLE
Implement deprecation warnings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -85,6 +85,11 @@ var check = module.exports.check = function(input, options, warnings) {
         }
         return result;
     } catch (e) {
+        if(e instanceof Parser.SyntaxError && !options.oldtexvc && e.message.startsWith("Deprecation")){
+            warnings.push( {type: 'texvc-deprecation', details:handleTexError(e,options)});
+            options.oldtexvc = true;
+            return check(input, options, warnings);
+        }
         if(e instanceof Parser.SyntaxError && options.usemhchem && !options.oldmhchem ){
             warnings.push( {type: 'mhchem-deprecation', details:handleTexError(e,options)});
             options.oldmhchem = true;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -169,295 +169,314 @@ module.exports = /*
              console.assert(Array.isArray(ast) && ast.length === 1);
              return ast[0];
            },
-        peg$c24 = function(b, r) { return ast.Tex.BIG(b, r); },
-        peg$c25 = function(b) { return ast.Tex.BIG(b, ast.RenderT.TEX_ONLY( "]")); },
-        peg$c26 = function(l, e, r) { return ast.Tex.LR(l, r, e.toArray()); },
-        peg$c27 = function(name, e, l) { return ast.Tex.FUN2sq(name, ast.Tex.CURLY(e.toArray()), l); },
-        peg$c28 = function(name, l) { return ast.Tex.FUN1(name, l); },
-        peg$c29 = function(name, l) { return ast.Tex.FUN1nb(name, l); },
-        peg$c30 = function(name, l) { return ast.Tex.MHCHEM(name, l); },
-        peg$c31 = function(name, l1, l2) { return ast.Tex.FUN2(name, l1, l2); },
-        peg$c32 = function(name, l1, l2) { return ast.Tex.FUN2nb(name, l1, l2); },
-        peg$c33 = function(e) { return ast.Tex.CURLY(e.toArray()); },
-        peg$c34 = function(e1, name, e2) { return ast.Tex.INFIX(name, e1.toArray(), e2.toArray()); },
-        peg$c35 = function(e1, f, e2) { return ast.Tex.INFIXh(f[0], f[1], e1.toArray(), e2.toArray()); },
-        peg$c36 = function(m) { return ast.Tex.MATRIX("matrix", lst2arr(m)); },
-        peg$c37 = function(m) { return ast.Tex.MATRIX("pmatrix", lst2arr(m)); },
-        peg$c38 = function(m) { return ast.Tex.MATRIX("bmatrix", lst2arr(m)); },
-        peg$c39 = function(m) { return ast.Tex.MATRIX("Bmatrix", lst2arr(m)); },
-        peg$c40 = function(m) { return ast.Tex.MATRIX("vmatrix", lst2arr(m)); },
-        peg$c41 = function(m) { return ast.Tex.MATRIX("Vmatrix", lst2arr(m)); },
-        peg$c42 = function(m) { return ast.Tex.MATRIX("array", lst2arr(m)); },
-        peg$c43 = function(m) { return ast.Tex.MATRIX("aligned", lst2arr(m)); },
-        peg$c44 = function(m) { return ast.Tex.MATRIX("alignedat", lst2arr(m)); },
-        peg$c45 = function(m) { return ast.Tex.MATRIX("smallmatrix", lst2arr(m)); },
-        peg$c46 = function(m) { return ast.Tex.MATRIX("cases", lst2arr(m)); },
-        peg$c47 = "\\begin{",
-        peg$c48 = peg$literalExpectation("\\begin{", false),
-        peg$c49 = "}",
-        peg$c50 = peg$literalExpectation("}", false),
-        peg$c51 = function() { throw new peg$SyntaxError("Illegal TeX function", [], text(), location()); },
-        peg$c52 = function(f) { return !tu.all_functions[f]; },
-        peg$c53 = function(f) { throw new peg$SyntaxError("Illegal TeX function", [], f, location()); },
-        peg$c54 = function(cs, m) { m.head[0].unshift(cs); return m; },
-        peg$c55 = function(as, m) { m.head[0].unshift(as); return m; },
-        peg$c56 = function(l, m) { return m; },
-        peg$c57 = function(l, tail) { return { head: lst2arr(l), tail: tail }; },
-        peg$c58 = function(f, l) { l.head.unshift(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(f + " "))); return l;},
-        peg$c59 = function(e, l) { return l; },
-        peg$c60 = function(e, tail) { return { head: e.toArray(), tail: tail }; },
-        peg$c61 = function() { return text(); },
-        peg$c62 = function(cs) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs))]); },
-        peg$c63 = /^[lrc]/,
-        peg$c64 = peg$classExpectation(["l", "r", "c"], false, false),
-        peg$c65 = "p",
-        peg$c66 = peg$literalExpectation("p", false),
-        peg$c67 = "*",
-        peg$c68 = peg$literalExpectation("*", false),
-        peg$c69 = /^[0-9]/,
-        peg$c70 = peg$classExpectation([["0", "9"]], false, false),
-        peg$c71 = "||",
-        peg$c72 = peg$literalExpectation("||", false),
-        peg$c73 = "|",
-        peg$c74 = peg$literalExpectation("|", false),
-        peg$c75 = "@",
-        peg$c76 = peg$literalExpectation("@", false),
-        peg$c77 = function(num) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(num))]); },
-        peg$c78 = "[",
-        peg$c79 = peg$literalExpectation("[", false),
-        peg$c80 = /^[tcb]/,
-        peg$c81 = peg$classExpectation(["t", "c", "b"], false, false),
-        peg$c82 = "]",
-        peg$c83 = peg$literalExpectation("]", false),
-        peg$c84 = " ",
-        peg$c85 = peg$literalExpectation(" ", false),
-        peg$c86 = function(p, s) { return ast.LList(p,ast.LList(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(" ")),s)); },
-        peg$c87 = function(p) { return ast.LList(p,ast.LList.EMPTY); },
-        peg$c88 = "(^)",
-        peg$c89 = peg$literalExpectation("(^)", false),
-        peg$c90 = function(m) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); },
-        peg$c91 = function(m, n) { return ast.Tex.CHEM_WORD(m, ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(n))); },
-        peg$c92 = function(m) { return m; },
-        peg$c93 = "^",
-        peg$c94 = peg$literalExpectation("^", false),
-        peg$c95 = function(m, n) { return ast.Tex.CHEM_WORD(m, n); },
-        peg$c96 = function(m, n, o) { return ast.Tex.CHEM_WORD(ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)), n), o); },
-        peg$c97 = function() { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("")); },
-        peg$c98 = function(m) { return m;},
-        peg$c99 = function(c) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) },
-        peg$c100 = function(c) { return ast.Tex.CURLY([c]); },
-        peg$c101 = function(c) { return ast.Tex.DOLLAR(c.toArray()); },
-        peg$c102 = function(e) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(e))]); },
-        peg$c103 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(b))); },
-        peg$c104 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), b); },
-        peg$c105 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.DOLLAR(b.toArray())); },
-        peg$c106 = "_",
-        peg$c107 = peg$literalExpectation("_", false),
-        peg$c108 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2u(name, l1, l2); },
-        peg$c109 = function(cs) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); },
-        peg$c110 = "{",
-        peg$c111 = peg$literalExpectation("{", false),
-        peg$c112 = function(name) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(name.join(''))); },
-        peg$c113 = /^[a-zA-Z]/,
-        peg$c114 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
-        peg$c115 = /^[,:;?!']/,
-        peg$c116 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
-        peg$c117 = /^[().]/,
-        peg$c118 = peg$classExpectation(["(", ")", "."], false, false),
-        peg$c119 = /^[\-+*=]/,
-        peg$c120 = peg$classExpectation(["-", "+", "*", "="], false, false),
-        peg$c121 = /^[\/|]/,
-        peg$c122 = peg$classExpectation(["/", "|"], false, false),
-        peg$c123 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
-        peg$c124 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
-        peg$c125 = /^[\uD800-\uDBFF]/,
-        peg$c126 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
-        peg$c127 = /^[\uDC00-\uDFFF]/,
-        peg$c128 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
-        peg$c129 = function(l, h) { return text(); },
-        peg$c130 = function(b) { return tu.box_functions[b]; },
-        peg$c131 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
-        peg$c132 = "-",
-        peg$c133 = peg$literalExpectation("-", false),
-        peg$c134 = function(c) { return ast.RenderT.TEX_ONLY(c); },
-        peg$c135 = function(f) { return tu.latex_function_names[f]; },
-        peg$c136 = "(",
-        peg$c137 = peg$literalExpectation("(", false),
-        peg$c138 = "\\{",
-        peg$c139 = peg$literalExpectation("\\{", false),
-        peg$c140 = function(f) { return " ";},
-        peg$c141 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
-        peg$c142 = function(f) { return tu.mediawiki_function_names[f]; },
-        peg$c143 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
-        peg$c144 = function(f) { return tu.nullary_macro[f]; },
-        peg$c145 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
-        peg$c146 = function(f) { return options.usemathrm && tu.nullary_macro_in_mbox[f]; },
-        peg$c147 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c148 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
-        peg$c149 = function(mathrm, f) { return options.usemathrm && tu.nullary_macro_in_mbox[f]; },
-        peg$c150 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
-        peg$c151 = function(f) { return tu.nullary_macro_in_mbox[f]; },
-        peg$c152 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c153 = function(mbox) { return mbox === "\\mbox"; },
-        peg$c154 = function(mbox, f) { return tu.nullary_macro_in_mbox[f]; },
-        peg$c155 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
-        peg$c156 = function(f) { return ast.RenderT.TEX_ONLY(f); },
-        peg$c157 = "\\",
-        peg$c158 = peg$literalExpectation("\\", false),
-        peg$c159 = /^[, ;!_#%$&]/,
-        peg$c160 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
-        peg$c161 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
-        peg$c162 = /^[><~]/,
-        peg$c163 = peg$classExpectation([">", "<", "~"], false, false),
-        peg$c164 = /^[%$]/,
-        peg$c165 = peg$classExpectation(["%", "$"], false, false),
-        peg$c166 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */},
-        peg$c167 = /^[{}|]/,
-        peg$c168 = peg$classExpectation(["{", "}", "|"], false, false),
-        peg$c169 = function(f) { return tu.other_delimiters1[f]; },
-        peg$c170 = function(f) { return tu.other_delimiters2[f]; },
-        peg$c171 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
+        peg$c24 = function(f) { return tu.deprecated_nullary_macro_aliase[f]; },
+        peg$c25 = function(f) {
+             var ast = peg$parse(tu.deprecated_nullary_macro_aliase[f]);
+             console.assert(Array.isArray(ast) && ast.length === 1);
+             if (options.oldtexvc){
+               return ast[0];
+             } else {
+                  throw new peg$SyntaxError("Deprecation: Alias no longer supported.", [], text(), location());
+             }
+           },
+        peg$c26 = function(b, r) { return ast.Tex.BIG(b, r); },
+        peg$c27 = function(b) { return ast.Tex.BIG(b, ast.RenderT.TEX_ONLY( "]")); },
+        peg$c28 = function(l, e, r) { return ast.Tex.LR(l, r, e.toArray()); },
+        peg$c29 = function(name, e, l) { return ast.Tex.FUN2sq(name, ast.Tex.CURLY(e.toArray()), l); },
+        peg$c30 = function(name, l) { return ast.Tex.FUN1(name, l); },
+        peg$c31 = function(name, l) { return ast.Tex.FUN1nb(name, l); },
+        peg$c32 = function(name, l) { return ast.Tex.MHCHEM(name, l); },
+        peg$c33 = function(name, l1, l2) { return ast.Tex.FUN2(name, l1, l2); },
+        peg$c34 = function(name, l1, l2) { return ast.Tex.FUN2nb(name, l1, l2); },
+        peg$c35 = function(e) { return ast.Tex.CURLY(e.toArray()); },
+        peg$c36 = function(e1, name, e2) { return ast.Tex.INFIX(name, e1.toArray(), e2.toArray()); },
+        peg$c37 = function(e1, f, e2) { return ast.Tex.INFIXh(f[0], f[1], e1.toArray(), e2.toArray()); },
+        peg$c38 = function(m) { return ast.Tex.MATRIX("matrix", lst2arr(m)); },
+        peg$c39 = function(m) { return ast.Tex.MATRIX("pmatrix", lst2arr(m)); },
+        peg$c40 = function(m) { return ast.Tex.MATRIX("bmatrix", lst2arr(m)); },
+        peg$c41 = function(m) { return ast.Tex.MATRIX("Bmatrix", lst2arr(m)); },
+        peg$c42 = function(m) { return ast.Tex.MATRIX("vmatrix", lst2arr(m)); },
+        peg$c43 = function(m) { return ast.Tex.MATRIX("Vmatrix", lst2arr(m)); },
+        peg$c44 = function(m) { return ast.Tex.MATRIX("array", lst2arr(m)); },
+        peg$c45 = function(m) { return ast.Tex.MATRIX("aligned", lst2arr(m)); },
+        peg$c46 = function(m) { return ast.Tex.MATRIX("alignedat", lst2arr(m)); },
+        peg$c47 = function(m) { return ast.Tex.MATRIX("smallmatrix", lst2arr(m)); },
+        peg$c48 = function(m) { return ast.Tex.MATRIX("cases", lst2arr(m)); },
+        peg$c49 = "\\begin{",
+        peg$c50 = peg$literalExpectation("\\begin{", false),
+        peg$c51 = "}",
+        peg$c52 = peg$literalExpectation("}", false),
+        peg$c53 = function() { throw new peg$SyntaxError("Illegal TeX function", [], text(), location()); },
+        peg$c54 = function(f) { return !tu.all_functions[f]; },
+        peg$c55 = function(f) { throw new peg$SyntaxError("Illegal TeX function", [], f, location()); },
+        peg$c56 = function(cs, m) { m.head[0].unshift(cs); return m; },
+        peg$c57 = function(as, m) { m.head[0].unshift(as); return m; },
+        peg$c58 = function(l, m) { return m; },
+        peg$c59 = function(l, tail) { return { head: lst2arr(l), tail: tail }; },
+        peg$c60 = function(f, l) { l.head.unshift(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(f + " "))); return l;},
+        peg$c61 = function(e, l) { return l; },
+        peg$c62 = function(e, tail) { return { head: e.toArray(), tail: tail }; },
+        peg$c63 = function() { return text(); },
+        peg$c64 = function(cs) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs))]); },
+        peg$c65 = /^[lrc]/,
+        peg$c66 = peg$classExpectation(["l", "r", "c"], false, false),
+        peg$c67 = "p",
+        peg$c68 = peg$literalExpectation("p", false),
+        peg$c69 = "*",
+        peg$c70 = peg$literalExpectation("*", false),
+        peg$c71 = /^[0-9]/,
+        peg$c72 = peg$classExpectation([["0", "9"]], false, false),
+        peg$c73 = "||",
+        peg$c74 = peg$literalExpectation("||", false),
+        peg$c75 = "|",
+        peg$c76 = peg$literalExpectation("|", false),
+        peg$c77 = "@",
+        peg$c78 = peg$literalExpectation("@", false),
+        peg$c79 = function(num) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(num))]); },
+        peg$c80 = "[",
+        peg$c81 = peg$literalExpectation("[", false),
+        peg$c82 = /^[tcb]/,
+        peg$c83 = peg$classExpectation(["t", "c", "b"], false, false),
+        peg$c84 = "]",
+        peg$c85 = peg$literalExpectation("]", false),
+        peg$c86 = " ",
+        peg$c87 = peg$literalExpectation(" ", false),
+        peg$c88 = function(p, s) { return ast.LList(p,ast.LList(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(" ")),s)); },
+        peg$c89 = function(p) { return ast.LList(p,ast.LList.EMPTY); },
+        peg$c90 = "(^)",
+        peg$c91 = peg$literalExpectation("(^)", false),
+        peg$c92 = function(m) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)); },
+        peg$c93 = function(m, n) { return ast.Tex.CHEM_WORD(m, ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(n))); },
+        peg$c94 = function(m) { return m; },
+        peg$c95 = "^",
+        peg$c96 = peg$literalExpectation("^", false),
+        peg$c97 = function(m, n) { return ast.Tex.CHEM_WORD(m, n); },
+        peg$c98 = function(m, n, o) { return ast.Tex.CHEM_WORD(ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(m)), n), o); },
+        peg$c99 = function() { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY("")); },
+        peg$c100 = function(m) { return m;},
+        peg$c101 = function(c) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(c)) },
+        peg$c102 = function(c) { return ast.Tex.CURLY([c]); },
+        peg$c103 = function(c) { return ast.Tex.DOLLAR(c.toArray()); },
+        peg$c104 = function(e) { return ast.Tex.CURLY([ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(e))]); },
+        peg$c105 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(b))); },
+        peg$c106 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), b); },
+        peg$c107 = function(a, b) { return ast.Tex.CHEM_WORD(ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(a)), ast.Tex.DOLLAR(b.toArray())); },
+        peg$c108 = "_",
+        peg$c109 = peg$literalExpectation("_", false),
+        peg$c110 = function(name, l1, l2) { return ast.Tex.CHEM_FUN2u(name, l1, l2); },
+        peg$c111 = function(cs) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(cs.join(''))); },
+        peg$c112 = "{",
+        peg$c113 = peg$literalExpectation("{", false),
+        peg$c114 = function(name) { return ast.Tex.LITERAL(ast.RenderT.TEX_ONLY(name.join(''))); },
+        peg$c115 = /^[a-zA-Z]/,
+        peg$c116 = peg$classExpectation([["a", "z"], ["A", "Z"]], false, false),
+        peg$c117 = /^[,:;?!']/,
+        peg$c118 = peg$classExpectation([",", ":", ";", "?", "!", "'"], false, false),
+        peg$c119 = /^[().]/,
+        peg$c120 = peg$classExpectation(["(", ")", "."], false, false),
+        peg$c121 = /^[\-+*=]/,
+        peg$c122 = peg$classExpectation(["-", "+", "*", "="], false, false),
+        peg$c123 = /^[\/|]/,
+        peg$c124 = peg$classExpectation(["/", "|"], false, false),
+        peg$c125 = /^[\-0-9a-zA-Z+*,=():\/;?.!'` [\]\x80-\uD7FF\uE000-\uFFFF]/,
+        peg$c126 = peg$classExpectation(["-", ["0", "9"], ["a", "z"], ["A", "Z"], "+", "*", ",", "=", "(", ")", ":", "/", ";", "?", ".", "!", "'", "`", " ", "[", "]", ["\x80", "\uD7FF"], ["\uE000", "\uFFFF"]], false, false),
+        peg$c127 = /^[\uD800-\uDBFF]/,
+        peg$c128 = peg$classExpectation([["\uD800", "\uDBFF"]], false, false),
+        peg$c129 = /^[\uDC00-\uDFFF]/,
+        peg$c130 = peg$classExpectation([["\uDC00", "\uDFFF"]], false, false),
+        peg$c131 = function(l, h) { return text(); },
+        peg$c132 = function(b) { return tu.box_functions[b]; },
+        peg$c133 = function(b, cs) { return ast.Tex.BOX(b, cs.join('')); },
+        peg$c134 = "-",
+        peg$c135 = peg$literalExpectation("-", false),
+        peg$c136 = function(c) { return ast.RenderT.TEX_ONLY(c); },
+        peg$c137 = function(f) { return tu.latex_function_names[f]; },
+        peg$c138 = "(",
+        peg$c139 = peg$literalExpectation("(", false),
+        peg$c140 = "\\{",
+        peg$c141 = peg$literalExpectation("\\{", false),
+        peg$c142 = function(f) { return " ";},
+        peg$c143 = function(f, c) { return ast.RenderT.TEX_ONLY(f + c); },
+        peg$c144 = function(f) { return tu.mediawiki_function_names[f]; },
+        peg$c145 = function(f, c) { return ast.RenderT.TEX_ONLY("\\operatorname {" + f.slice(1) + "}" + c); },
+        peg$c146 = function(f) { return tu.nullary_macro[f]; },
+        peg$c147 = function(f) { return ast.RenderT.TEX_ONLY(f + " "); },
+        peg$c148 = function(f) { return options.usemathrm && tu.nullary_macro_in_mbox[f]; },
+        peg$c149 = function(f) { return ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c150 = function(mathrm) { return options.usemathrm && mathrm === "\\mathrm"; },
+        peg$c151 = function(mathrm, f) { return options.usemathrm && tu.nullary_macro_in_mbox[f]; },
+        peg$c152 = function(mathrm, f) { return options.usemathrm && ast.RenderT.TEX_ONLY("\\mathrm {" + f + "} "); },
+        peg$c153 = function(f) { return tu.nullary_macro_in_mbox[f]; },
+        peg$c154 = function(f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c155 = function(mbox) { return mbox === "\\mbox"; },
+        peg$c156 = function(mbox, f) { return tu.nullary_macro_in_mbox[f]; },
+        peg$c157 = function(mbox, f) { return ast.RenderT.TEX_ONLY("\\mbox{" + f + "} "); },
+        peg$c158 = function(f) { return ast.RenderT.TEX_ONLY(f); },
+        peg$c159 = "\\",
+        peg$c160 = peg$literalExpectation("\\", false),
+        peg$c161 = /^[, ;!_#%$&]/,
+        peg$c162 = peg$classExpectation([",", " ", ";", "!", "_", "#", "%", "$", "&"], false, false),
+        peg$c163 = function(c) { return ast.RenderT.TEX_ONLY("\\" + c); },
+        peg$c164 = /^[><~]/,
+        peg$c165 = peg$classExpectation([">", "<", "~"], false, false),
+        peg$c166 = /^[%$]/,
+        peg$c167 = peg$classExpectation(["%", "$"], false, false),
+        peg$c168 = function(c) { if(options.oldtexvc) {
+            return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */
+            } else {
+             throw new peg$SyntaxError("Deprecation: % and $ need to be escaped.", [], text(), location());
+            }},
+        peg$c169 = /^[{}|]/,
+        peg$c170 = peg$classExpectation(["{", "}", "|"], false, false),
+        peg$c171 = function(f) { return tu.other_delimiters1[f]; },
+        peg$c172 = function(f) { return tu.other_delimiters2[f]; },
+        peg$c173 = function(f) { var p = peg$parse(tu.other_delimiters2[f]);
              console.assert(Array.isArray(p) && p.length === 1);
              console.assert(p[0].constructor === ast.Tex.LITERAL);
              console.assert(p[0][0].constructor === ast.RenderT.TEX_ONLY);
              return p[0][0];
            },
-        peg$c172 = function(f) { return tu.fun_ar1nb[f]; },
-        peg$c173 = function(f) { return f; },
-        peg$c174 = function(f) { return tu.fun_ar1opt[f]; },
-        peg$c175 = "&",
-        peg$c176 = peg$literalExpectation("&", false),
-        peg$c177 = "\\\\",
-        peg$c178 = peg$literalExpectation("\\\\", false),
-        peg$c179 = "\\begin",
-        peg$c180 = peg$literalExpectation("\\begin", false),
-        peg$c181 = "\\end",
-        peg$c182 = peg$literalExpectation("\\end", false),
-        peg$c183 = "{matrix}",
-        peg$c184 = peg$literalExpectation("{matrix}", false),
-        peg$c185 = "{pmatrix}",
-        peg$c186 = peg$literalExpectation("{pmatrix}", false),
-        peg$c187 = "{bmatrix}",
-        peg$c188 = peg$literalExpectation("{bmatrix}", false),
-        peg$c189 = "{Bmatrix}",
-        peg$c190 = peg$literalExpectation("{Bmatrix}", false),
-        peg$c191 = "{vmatrix}",
-        peg$c192 = peg$literalExpectation("{vmatrix}", false),
-        peg$c193 = "{Vmatrix}",
-        peg$c194 = peg$literalExpectation("{Vmatrix}", false),
-        peg$c195 = "{array}",
-        peg$c196 = peg$literalExpectation("{array}", false),
-        peg$c197 = "{align}",
-        peg$c198 = peg$literalExpectation("{align}", false),
-        peg$c199 = "{aligned}",
-        peg$c200 = peg$literalExpectation("{aligned}", false),
-        peg$c201 = "{alignat}",
-        peg$c202 = peg$literalExpectation("{alignat}", false),
-        peg$c203 = "{alignedat}",
-        peg$c204 = peg$literalExpectation("{alignedat}", false),
-        peg$c205 = "{smallmatrix}",
-        peg$c206 = peg$literalExpectation("{smallmatrix}", false),
-        peg$c207 = "{cases}",
-        peg$c208 = peg$literalExpectation("{cases}", false),
-        peg$c209 = function(f) { return tu.big_literals[f]; },
-        peg$c210 = function(f) { return tu.fun_ar1[f]; },
-        peg$c211 = function(f) { return options.oldmhchem && tu.fun_mhchem[f]},
-        peg$c212 = function(f) { return tu.other_fun_ar1[f]; },
-        peg$c213 = function(f) { return tu.fun_mhchem[f]; },
-        peg$c214 = function(f) { return tu.fun_ar2[f]; },
-        peg$c215 = function(f) { return tu.fun_infix[f]; },
-        peg$c216 = function(f) { return tu.declh_function[f]; },
-        peg$c217 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
-        peg$c218 = function(f) { return tu.fun_ar2nb[f]; },
-        peg$c219 = function(f) { return tu.left_function[f]; },
-        peg$c220 = function(f) { return tu.right_function[f]; },
-        peg$c221 = function(f) { return tu.hline_function[f]; },
-        peg$c222 = function(f) { return tu.color_function[f]; },
-        peg$c223 = function(f, cs) { return f + " " + cs; },
-        peg$c224 = function(f) { return tu.definecolor_function[f]; },
-        peg$c225 = "named",
-        peg$c226 = peg$literalExpectation("named", true),
-        peg$c227 = function(f, name, cs) { return "{named}" + cs; },
-        peg$c228 = "gray",
-        peg$c229 = peg$literalExpectation("gray", true),
-        peg$c230 = function(f, name, cs) { return "{gray}" + cs; },
-        peg$c231 = "rgb",
-        peg$c232 = peg$literalExpectation("rgb", false),
-        peg$c233 = function(f, name, cs) { return "{rgb}" + cs; },
-        peg$c234 = "RGB",
-        peg$c235 = peg$literalExpectation("RGB", false),
-        peg$c236 = "cmyk",
-        peg$c237 = peg$literalExpectation("cmyk", true),
-        peg$c238 = function(f, name, cs) { return "{cmyk}" + cs; },
-        peg$c239 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
-        peg$c240 = function(cs) { return "[named]" + cs; },
-        peg$c241 = function(cs) { return "[gray]" + cs; },
-        peg$c242 = function(cs) { return "[rgb]" + cs; },
-        peg$c243 = function(cs) { return "[cmyk]" + cs; },
-        peg$c244 = function(name) { return "{" + name.join('') + "}"; },
-        peg$c245 = function(k) { return "{"+k+"}"; },
-        peg$c246 = ",",
-        peg$c247 = peg$literalExpectation(",", false),
-        peg$c248 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
-        peg$c249 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
-        peg$c250 = "0",
-        peg$c251 = peg$literalExpectation("0", false),
-        peg$c252 = /^[1-9]/,
-        peg$c253 = peg$classExpectation([["1", "9"]], false, false),
-        peg$c254 = function(n) { return parseInt(n, 10) <= 255; },
-        peg$c255 = function(n) { return n / 255; },
-        peg$c256 = ".",
-        peg$c257 = peg$literalExpectation(".", false),
-        peg$c258 = function(n) { return n; },
-        peg$c259 = /^[01]/,
-        peg$c260 = peg$classExpectation(["0", "1"], false, false),
-        peg$c261 = function(f) { return tu.mhchem_single_macro[f]; },
-        peg$c262 = function(c) { return "\\" + c; },
-        peg$c263 = function(f) { return tu.mhchem_bond[f]; },
-        peg$c264 = function(f) { return tu.mhchem_macro_1p[f]; },
-        peg$c265 = function(f) { return tu.mhchem_macro_2p[f]; },
-        peg$c266 = function(f) { return tu.mhchem_macro_2pu[f]; },
-        peg$c267 = function(f) { return tu.mhchem_macro_2pc[f]; },
-        peg$c268 = /^[+-.*']/,
-        peg$c269 = peg$classExpectation([["+", "."], "*", "'"], false, false),
-        peg$c270 = "=",
-        peg$c271 = peg$literalExpectation("=", false),
-        peg$c272 = "#",
-        peg$c273 = peg$literalExpectation("#", false),
-        peg$c274 = "~--",
-        peg$c275 = peg$literalExpectation("~--", false),
-        peg$c276 = "~-",
-        peg$c277 = peg$literalExpectation("~-", false),
-        peg$c278 = "~=",
-        peg$c279 = peg$literalExpectation("~=", false),
-        peg$c280 = "~",
-        peg$c281 = peg$literalExpectation("~", false),
-        peg$c282 = "-~-",
-        peg$c283 = peg$literalExpectation("-~-", false),
-        peg$c284 = "....",
-        peg$c285 = peg$literalExpectation("....", false),
-        peg$c286 = "...",
-        peg$c287 = peg$literalExpectation("...", false),
-        peg$c288 = "<-",
-        peg$c289 = peg$literalExpectation("<-", false),
-        peg$c290 = "->",
-        peg$c291 = peg$literalExpectation("->", false),
-        peg$c292 = "1",
-        peg$c293 = peg$literalExpectation("1", false),
-        peg$c294 = "2",
-        peg$c295 = peg$literalExpectation("2", false),
-        peg$c296 = "3",
-        peg$c297 = peg$literalExpectation("3", false),
-        peg$c298 = "{math}",
-        peg$c299 = peg$literalExpectation("{math}", false),
-        peg$c300 = function(c) { return c; },
-        peg$c301 = "\\}",
-        peg$c302 = peg$literalExpectation("\\}", false),
-        peg$c303 = /^[+-=#().,;\/*<>|@&'[\]]/,
-        peg$c304 = peg$classExpectation([["+", "="], "#", "(", ")", ".", ",", ";", "/", "*", "<", ">", "|", "@", "&", "'", "[", "]"], false, false),
-        peg$c305 = function() { return "{}"; },
-        peg$c306 = function() { return false; },
-        peg$c307 = function() { return peg$currPos === input.length; },
+        peg$c174 = function(f) { return tu.fun_ar1nb[f]; },
+        peg$c175 = function(f) { return f; },
+        peg$c176 = function(f) { return tu.fun_ar1opt[f]; },
+        peg$c177 = "&",
+        peg$c178 = peg$literalExpectation("&", false),
+        peg$c179 = "\\\\",
+        peg$c180 = peg$literalExpectation("\\\\", false),
+        peg$c181 = "\\begin",
+        peg$c182 = peg$literalExpectation("\\begin", false),
+        peg$c183 = "\\end",
+        peg$c184 = peg$literalExpectation("\\end", false),
+        peg$c185 = "{matrix}",
+        peg$c186 = peg$literalExpectation("{matrix}", false),
+        peg$c187 = "{pmatrix}",
+        peg$c188 = peg$literalExpectation("{pmatrix}", false),
+        peg$c189 = "{bmatrix}",
+        peg$c190 = peg$literalExpectation("{bmatrix}", false),
+        peg$c191 = "{Bmatrix}",
+        peg$c192 = peg$literalExpectation("{Bmatrix}", false),
+        peg$c193 = "{vmatrix}",
+        peg$c194 = peg$literalExpectation("{vmatrix}", false),
+        peg$c195 = "{Vmatrix}",
+        peg$c196 = peg$literalExpectation("{Vmatrix}", false),
+        peg$c197 = "{array}",
+        peg$c198 = peg$literalExpectation("{array}", false),
+        peg$c199 = "{align}",
+        peg$c200 = peg$literalExpectation("{align}", false),
+        peg$c201 = "{aligned}",
+        peg$c202 = peg$literalExpectation("{aligned}", false),
+        peg$c203 = "{alignat}",
+        peg$c204 = peg$literalExpectation("{alignat}", false),
+        peg$c205 = "{alignedat}",
+        peg$c206 = peg$literalExpectation("{alignedat}", false),
+        peg$c207 = "{smallmatrix}",
+        peg$c208 = peg$literalExpectation("{smallmatrix}", false),
+        peg$c209 = "{cases}",
+        peg$c210 = peg$literalExpectation("{cases}", false),
+        peg$c211 = function(f) { return tu.big_literals[f]; },
+        peg$c212 = function(f) { return tu.fun_ar1[f]; },
+        peg$c213 = function(f) { return options.oldmhchem && tu.fun_mhchem[f]},
+        peg$c214 = function(f) { return tu.other_fun_ar1[f]; },
+        peg$c215 = function(f) { if (options.oldtexvc) {
+                return tu.other_fun_ar1[f];
+             } else {
+                throw new peg$SyntaxError("Deprecation: \\Bbb and \\bold are not allowed in math mode.", [], text(), location());
+               }},
+        peg$c216 = function(f) { return tu.fun_mhchem[f]; },
+        peg$c217 = function(f) { return tu.fun_ar2[f]; },
+        peg$c218 = function(f) { return tu.fun_infix[f]; },
+        peg$c219 = function(f) { return tu.declh_function[f]; },
+        peg$c220 = function(f) { return ast.Tex.DECLh(f, ast.FontForce.RM(), []); /*see bug 54818*/ },
+        peg$c221 = function(f) { return tu.fun_ar2nb[f]; },
+        peg$c222 = function(f) { return tu.left_function[f]; },
+        peg$c223 = function(f) { return tu.right_function[f]; },
+        peg$c224 = function(f) { return tu.hline_function[f]; },
+        peg$c225 = function(f) { return tu.color_function[f]; },
+        peg$c226 = function(f, cs) { return f + " " + cs; },
+        peg$c227 = function(f) { return tu.definecolor_function[f]; },
+        peg$c228 = "named",
+        peg$c229 = peg$literalExpectation("named", true),
+        peg$c230 = function(f, name, cs) { return "{named}" + cs; },
+        peg$c231 = "gray",
+        peg$c232 = peg$literalExpectation("gray", true),
+        peg$c233 = function(f, name, cs) { return "{gray}" + cs; },
+        peg$c234 = "rgb",
+        peg$c235 = peg$literalExpectation("rgb", false),
+        peg$c236 = function(f, name, cs) { return "{rgb}" + cs; },
+        peg$c237 = "RGB",
+        peg$c238 = peg$literalExpectation("RGB", false),
+        peg$c239 = "cmyk",
+        peg$c240 = peg$literalExpectation("cmyk", true),
+        peg$c241 = function(f, name, cs) { return "{cmyk}" + cs; },
+        peg$c242 = function(f, name, a) { return f + " {" + name.join('') + "}" + a; },
+        peg$c243 = function(cs) { return "[named]" + cs; },
+        peg$c244 = function(cs) { return "[gray]" + cs; },
+        peg$c245 = function(cs) { return "[rgb]" + cs; },
+        peg$c246 = function(cs) { return "[cmyk]" + cs; },
+        peg$c247 = function(name) { return "{" + name.join('') + "}"; },
+        peg$c248 = function(k) { return "{"+k+"}"; },
+        peg$c249 = ",",
+        peg$c250 = peg$literalExpectation(",", false),
+        peg$c251 = function(r, g, b) { return "{"+r+","+g+","+b+"}"; },
+        peg$c252 = function(c, m, y, k) { return "{"+c+","+m+","+y+","+k+"}"; },
+        peg$c253 = "0",
+        peg$c254 = peg$literalExpectation("0", false),
+        peg$c255 = /^[1-9]/,
+        peg$c256 = peg$classExpectation([["1", "9"]], false, false),
+        peg$c257 = function(n) { return parseInt(n, 10) <= 255; },
+        peg$c258 = function(n) { return n / 255; },
+        peg$c259 = ".",
+        peg$c260 = peg$literalExpectation(".", false),
+        peg$c261 = function(n) { return n; },
+        peg$c262 = /^[01]/,
+        peg$c263 = peg$classExpectation(["0", "1"], false, false),
+        peg$c264 = function(f) { return tu.mhchem_single_macro[f]; },
+        peg$c265 = function(c) { return "\\" + c; },
+        peg$c266 = function(f) { return tu.mhchem_bond[f]; },
+        peg$c267 = function(f) { return tu.mhchem_macro_1p[f]; },
+        peg$c268 = function(f) { return tu.mhchem_macro_2p[f]; },
+        peg$c269 = function(f) { return tu.mhchem_macro_2pu[f]; },
+        peg$c270 = function(f) { return tu.mhchem_macro_2pc[f]; },
+        peg$c271 = /^[+-.*']/,
+        peg$c272 = peg$classExpectation([["+", "."], "*", "'"], false, false),
+        peg$c273 = "=",
+        peg$c274 = peg$literalExpectation("=", false),
+        peg$c275 = "#",
+        peg$c276 = peg$literalExpectation("#", false),
+        peg$c277 = "~--",
+        peg$c278 = peg$literalExpectation("~--", false),
+        peg$c279 = "~-",
+        peg$c280 = peg$literalExpectation("~-", false),
+        peg$c281 = "~=",
+        peg$c282 = peg$literalExpectation("~=", false),
+        peg$c283 = "~",
+        peg$c284 = peg$literalExpectation("~", false),
+        peg$c285 = "-~-",
+        peg$c286 = peg$literalExpectation("-~-", false),
+        peg$c287 = "....",
+        peg$c288 = peg$literalExpectation("....", false),
+        peg$c289 = "...",
+        peg$c290 = peg$literalExpectation("...", false),
+        peg$c291 = "<-",
+        peg$c292 = peg$literalExpectation("<-", false),
+        peg$c293 = "->",
+        peg$c294 = peg$literalExpectation("->", false),
+        peg$c295 = "1",
+        peg$c296 = peg$literalExpectation("1", false),
+        peg$c297 = "2",
+        peg$c298 = peg$literalExpectation("2", false),
+        peg$c299 = "3",
+        peg$c300 = peg$literalExpectation("3", false),
+        peg$c301 = "{math}",
+        peg$c302 = peg$literalExpectation("{math}", false),
+        peg$c303 = function(c) { return c; },
+        peg$c304 = "\\}",
+        peg$c305 = peg$literalExpectation("\\}", false),
+        peg$c306 = /^[+-=#().,;\/*<>|@&'[\]]/,
+        peg$c307 = peg$classExpectation([["+", "="], "#", "(", ")", ".", ",", ";", "/", "*", "<", ">", "|", "@", "&", "'", "[", "]"], false, false),
+        peg$c308 = function() { return "{}"; },
+        peg$c309 = function() { return false; },
+        peg$c310 = function() { return peg$currPos === input.length; },
 
         peg$currPos          = 0,
         peg$savedPos         = 0,
@@ -1523,20 +1542,20 @@ module.exports = /*
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$parseDELIMITER();
+          s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
-            peg$savedPos = s0;
-            s1 = peg$c21(s1);
-          }
-          s0 = s1;
-          if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            s1 = peg$parseBIG();
-            if (s1 !== peg$FAILED) {
-              s2 = peg$parseDELIMITER();
-              if (s2 !== peg$FAILED) {
+            peg$savedPos = peg$currPos;
+            s2 = peg$c24(s1);
+            if (s2) {
+              s2 = void 0;
+            } else {
+              s2 = peg$FAILED;
+            }
+            if (s2 !== peg$FAILED) {
+              s3 = peg$parse_();
+              if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c24(s1, s2);
+                s1 = peg$c25(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -1546,14 +1565,26 @@ module.exports = /*
               peg$currPos = s0;
               s0 = peg$FAILED;
             }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            s1 = peg$parseDELIMITER();
+            if (s1 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c21(s1);
+            }
+            s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               s1 = peg$parseBIG();
               if (s1 !== peg$FAILED) {
-                s2 = peg$parseSQ_CLOSE();
+                s2 = peg$parseDELIMITER();
                 if (s2 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c25(s1);
+                  s1 = peg$c26(s1, s2);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1565,19 +1596,13 @@ module.exports = /*
               }
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                s1 = peg$parseleft();
+                s1 = peg$parseBIG();
                 if (s1 !== peg$FAILED) {
-                  s2 = peg$parseexpr();
+                  s2 = peg$parseSQ_CLOSE();
                   if (s2 !== peg$FAILED) {
-                    s3 = peg$parseright();
-                    if (s3 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c26(s1, s2, s3);
-                      s0 = s1;
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
+                    peg$savedPos = s0;
+                    s1 = peg$c27(s1);
+                    s0 = s1;
                   } else {
                     peg$currPos = s0;
                     s0 = peg$FAILED;
@@ -1588,21 +1613,15 @@ module.exports = /*
                 }
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
-                  s1 = peg$parseFUN_AR1opt();
+                  s1 = peg$parseleft();
                   if (s1 !== peg$FAILED) {
-                    s2 = peg$parseexpr_nosqc();
+                    s2 = peg$parseexpr();
                     if (s2 !== peg$FAILED) {
-                      s3 = peg$parseSQ_CLOSE();
+                      s3 = peg$parseright();
                       if (s3 !== peg$FAILED) {
-                        s4 = peg$parselit();
-                        if (s4 !== peg$FAILED) {
-                          peg$savedPos = s0;
-                          s1 = peg$c27(s1, s2, s4);
-                          s0 = s1;
-                        } else {
-                          peg$currPos = s0;
-                          s0 = peg$FAILED;
-                        }
+                        peg$savedPos = s0;
+                        s1 = peg$c28(s1, s2, s3);
+                        s0 = s1;
                       } else {
                         peg$currPos = s0;
                         s0 = peg$FAILED;
@@ -1617,13 +1636,25 @@ module.exports = /*
                   }
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
-                    s1 = peg$parseFUN_AR1();
+                    s1 = peg$parseFUN_AR1opt();
                     if (s1 !== peg$FAILED) {
-                      s2 = peg$parselit();
+                      s2 = peg$parseexpr_nosqc();
                       if (s2 !== peg$FAILED) {
-                        peg$savedPos = s0;
-                        s1 = peg$c28(s1, s2);
-                        s0 = s1;
+                        s3 = peg$parseSQ_CLOSE();
+                        if (s3 !== peg$FAILED) {
+                          s4 = peg$parselit();
+                          if (s4 !== peg$FAILED) {
+                            peg$savedPos = s0;
+                            s1 = peg$c29(s1, s2, s4);
+                            s0 = s1;
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
                       } else {
                         peg$currPos = s0;
                         s0 = peg$FAILED;
@@ -1634,12 +1665,12 @@ module.exports = /*
                     }
                     if (s0 === peg$FAILED) {
                       s0 = peg$currPos;
-                      s1 = peg$parseFUN_AR1nb();
+                      s1 = peg$parseFUN_AR1();
                       if (s1 !== peg$FAILED) {
                         s2 = peg$parselit();
                         if (s2 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c29(s1, s2);
+                          s1 = peg$c30(s1, s2);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -1651,12 +1682,12 @@ module.exports = /*
                       }
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
-                        s1 = peg$parseFUN_MHCHEM();
+                        s1 = peg$parseFUN_AR1nb();
                         if (s1 !== peg$FAILED) {
-                          s2 = peg$parsechem_lit();
+                          s2 = peg$parselit();
                           if (s2 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c30(s1, s2);
+                            s1 = peg$c31(s1, s2);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -1668,19 +1699,13 @@ module.exports = /*
                         }
                         if (s0 === peg$FAILED) {
                           s0 = peg$currPos;
-                          s1 = peg$parseFUN_AR2();
+                          s1 = peg$parseFUN_MHCHEM();
                           if (s1 !== peg$FAILED) {
-                            s2 = peg$parselit();
+                            s2 = peg$parsechem_lit();
                             if (s2 !== peg$FAILED) {
-                              s3 = peg$parselit();
-                              if (s3 !== peg$FAILED) {
-                                peg$savedPos = s0;
-                                s1 = peg$c31(s1, s2, s3);
-                                s0 = s1;
-                              } else {
-                                peg$currPos = s0;
-                                s0 = peg$FAILED;
-                              }
+                              peg$savedPos = s0;
+                              s1 = peg$c32(s1, s2);
+                              s0 = s1;
                             } else {
                               peg$currPos = s0;
                               s0 = peg$FAILED;
@@ -1691,14 +1716,14 @@ module.exports = /*
                           }
                           if (s0 === peg$FAILED) {
                             s0 = peg$currPos;
-                            s1 = peg$parseFUN_AR2nb();
+                            s1 = peg$parseFUN_AR2();
                             if (s1 !== peg$FAILED) {
                               s2 = peg$parselit();
                               if (s2 !== peg$FAILED) {
                                 s3 = peg$parselit();
                                 if (s3 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c32(s1, s2, s3);
+                                  s1 = peg$c33(s1, s2, s3);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -1713,22 +1738,16 @@ module.exports = /*
                               s0 = peg$FAILED;
                             }
                             if (s0 === peg$FAILED) {
-                              s0 = peg$parseBOX();
-                              if (s0 === peg$FAILED) {
-                                s0 = peg$currPos;
-                                s1 = peg$parseCURLY_OPEN();
-                                if (s1 !== peg$FAILED) {
-                                  s2 = peg$parseexpr();
-                                  if (s2 !== peg$FAILED) {
-                                    s3 = peg$parseCURLY_CLOSE();
-                                    if (s3 !== peg$FAILED) {
-                                      peg$savedPos = s0;
-                                      s1 = peg$c33(s2);
-                                      s0 = s1;
-                                    } else {
-                                      peg$currPos = s0;
-                                      s0 = peg$FAILED;
-                                    }
+                              s0 = peg$currPos;
+                              s1 = peg$parseFUN_AR2nb();
+                              if (s1 !== peg$FAILED) {
+                                s2 = peg$parselit();
+                                if (s2 !== peg$FAILED) {
+                                  s3 = peg$parselit();
+                                  if (s3 !== peg$FAILED) {
+                                    peg$savedPos = s0;
+                                    s1 = peg$c34(s1, s2, s3);
+                                    s0 = s1;
                                   } else {
                                     peg$currPos = s0;
                                     s0 = peg$FAILED;
@@ -1737,29 +1756,23 @@ module.exports = /*
                                   peg$currPos = s0;
                                   s0 = peg$FAILED;
                                 }
+                              } else {
+                                peg$currPos = s0;
+                                s0 = peg$FAILED;
+                              }
+                              if (s0 === peg$FAILED) {
+                                s0 = peg$parseBOX();
                                 if (s0 === peg$FAILED) {
                                   s0 = peg$currPos;
                                   s1 = peg$parseCURLY_OPEN();
                                   if (s1 !== peg$FAILED) {
-                                    s2 = peg$parsene_expr();
+                                    s2 = peg$parseexpr();
                                     if (s2 !== peg$FAILED) {
-                                      s3 = peg$parseFUN_INFIX();
+                                      s3 = peg$parseCURLY_CLOSE();
                                       if (s3 !== peg$FAILED) {
-                                        s4 = peg$parsene_expr();
-                                        if (s4 !== peg$FAILED) {
-                                          s5 = peg$parseCURLY_CLOSE();
-                                          if (s5 !== peg$FAILED) {
-                                            peg$savedPos = s0;
-                                            s1 = peg$c34(s2, s3, s4);
-                                            s0 = s1;
-                                          } else {
-                                            peg$currPos = s0;
-                                            s0 = peg$FAILED;
-                                          }
-                                        } else {
-                                          peg$currPos = s0;
-                                          s0 = peg$FAILED;
-                                        }
+                                        peg$savedPos = s0;
+                                        s1 = peg$c35(s2);
+                                        s0 = s1;
                                       } else {
                                         peg$currPos = s0;
                                         s0 = peg$FAILED;
@@ -1778,14 +1791,14 @@ module.exports = /*
                                     if (s1 !== peg$FAILED) {
                                       s2 = peg$parsene_expr();
                                       if (s2 !== peg$FAILED) {
-                                        s3 = peg$parseimpossible();
+                                        s3 = peg$parseFUN_INFIX();
                                         if (s3 !== peg$FAILED) {
                                           s4 = peg$parsene_expr();
                                           if (s4 !== peg$FAILED) {
                                             s5 = peg$parseCURLY_CLOSE();
                                             if (s5 !== peg$FAILED) {
                                               peg$savedPos = s0;
-                                              s1 = peg$c35(s2, s3, s4);
+                                              s1 = peg$c36(s2, s3, s4);
                                               s0 = s1;
                                             } else {
                                               peg$currPos = s0;
@@ -1809,18 +1822,27 @@ module.exports = /*
                                     }
                                     if (s0 === peg$FAILED) {
                                       s0 = peg$currPos;
-                                      s1 = peg$parseBEGIN_MATRIX();
+                                      s1 = peg$parseCURLY_OPEN();
                                       if (s1 !== peg$FAILED) {
-                                        s2 = peg$parsearray();
-                                        if (s2 === peg$FAILED) {
-                                          s2 = peg$parsematrix();
-                                        }
+                                        s2 = peg$parsene_expr();
                                         if (s2 !== peg$FAILED) {
-                                          s3 = peg$parseEND_MATRIX();
+                                          s3 = peg$parseimpossible();
                                           if (s3 !== peg$FAILED) {
-                                            peg$savedPos = s0;
-                                            s1 = peg$c36(s2);
-                                            s0 = s1;
+                                            s4 = peg$parsene_expr();
+                                            if (s4 !== peg$FAILED) {
+                                              s5 = peg$parseCURLY_CLOSE();
+                                              if (s5 !== peg$FAILED) {
+                                                peg$savedPos = s0;
+                                                s1 = peg$c37(s2, s3, s4);
+                                                s0 = s1;
+                                              } else {
+                                                peg$currPos = s0;
+                                                s0 = peg$FAILED;
+                                              }
+                                            } else {
+                                              peg$currPos = s0;
+                                              s0 = peg$FAILED;
+                                            }
                                           } else {
                                             peg$currPos = s0;
                                             s0 = peg$FAILED;
@@ -1835,17 +1857,17 @@ module.exports = /*
                                       }
                                       if (s0 === peg$FAILED) {
                                         s0 = peg$currPos;
-                                        s1 = peg$parseBEGIN_PMATRIX();
+                                        s1 = peg$parseBEGIN_MATRIX();
                                         if (s1 !== peg$FAILED) {
                                           s2 = peg$parsearray();
                                           if (s2 === peg$FAILED) {
                                             s2 = peg$parsematrix();
                                           }
                                           if (s2 !== peg$FAILED) {
-                                            s3 = peg$parseEND_PMATRIX();
+                                            s3 = peg$parseEND_MATRIX();
                                             if (s3 !== peg$FAILED) {
                                               peg$savedPos = s0;
-                                              s1 = peg$c37(s2);
+                                              s1 = peg$c38(s2);
                                               s0 = s1;
                                             } else {
                                               peg$currPos = s0;
@@ -1861,17 +1883,17 @@ module.exports = /*
                                         }
                                         if (s0 === peg$FAILED) {
                                           s0 = peg$currPos;
-                                          s1 = peg$parseBEGIN_BMATRIX();
+                                          s1 = peg$parseBEGIN_PMATRIX();
                                           if (s1 !== peg$FAILED) {
                                             s2 = peg$parsearray();
                                             if (s2 === peg$FAILED) {
                                               s2 = peg$parsematrix();
                                             }
                                             if (s2 !== peg$FAILED) {
-                                              s3 = peg$parseEND_BMATRIX();
+                                              s3 = peg$parseEND_PMATRIX();
                                               if (s3 !== peg$FAILED) {
                                                 peg$savedPos = s0;
-                                                s1 = peg$c38(s2);
+                                                s1 = peg$c39(s2);
                                                 s0 = s1;
                                               } else {
                                                 peg$currPos = s0;
@@ -1887,17 +1909,17 @@ module.exports = /*
                                           }
                                           if (s0 === peg$FAILED) {
                                             s0 = peg$currPos;
-                                            s1 = peg$parseBEGIN_BBMATRIX();
+                                            s1 = peg$parseBEGIN_BMATRIX();
                                             if (s1 !== peg$FAILED) {
                                               s2 = peg$parsearray();
                                               if (s2 === peg$FAILED) {
                                                 s2 = peg$parsematrix();
                                               }
                                               if (s2 !== peg$FAILED) {
-                                                s3 = peg$parseEND_BBMATRIX();
+                                                s3 = peg$parseEND_BMATRIX();
                                                 if (s3 !== peg$FAILED) {
                                                   peg$savedPos = s0;
-                                                  s1 = peg$c39(s2);
+                                                  s1 = peg$c40(s2);
                                                   s0 = s1;
                                                 } else {
                                                   peg$currPos = s0;
@@ -1913,17 +1935,17 @@ module.exports = /*
                                             }
                                             if (s0 === peg$FAILED) {
                                               s0 = peg$currPos;
-                                              s1 = peg$parseBEGIN_VMATRIX();
+                                              s1 = peg$parseBEGIN_BBMATRIX();
                                               if (s1 !== peg$FAILED) {
                                                 s2 = peg$parsearray();
                                                 if (s2 === peg$FAILED) {
                                                   s2 = peg$parsematrix();
                                                 }
                                                 if (s2 !== peg$FAILED) {
-                                                  s3 = peg$parseEND_VMATRIX();
+                                                  s3 = peg$parseEND_BBMATRIX();
                                                   if (s3 !== peg$FAILED) {
                                                     peg$savedPos = s0;
-                                                    s1 = peg$c40(s2);
+                                                    s1 = peg$c41(s2);
                                                     s0 = s1;
                                                   } else {
                                                     peg$currPos = s0;
@@ -1939,17 +1961,17 @@ module.exports = /*
                                               }
                                               if (s0 === peg$FAILED) {
                                                 s0 = peg$currPos;
-                                                s1 = peg$parseBEGIN_VVMATRIX();
+                                                s1 = peg$parseBEGIN_VMATRIX();
                                                 if (s1 !== peg$FAILED) {
                                                   s2 = peg$parsearray();
                                                   if (s2 === peg$FAILED) {
                                                     s2 = peg$parsematrix();
                                                   }
                                                   if (s2 !== peg$FAILED) {
-                                                    s3 = peg$parseEND_VVMATRIX();
+                                                    s3 = peg$parseEND_VMATRIX();
                                                     if (s3 !== peg$FAILED) {
                                                       peg$savedPos = s0;
-                                                      s1 = peg$c41(s2);
+                                                      s1 = peg$c42(s2);
                                                       s0 = s1;
                                                     } else {
                                                       peg$currPos = s0;
@@ -1965,21 +1987,18 @@ module.exports = /*
                                                 }
                                                 if (s0 === peg$FAILED) {
                                                   s0 = peg$currPos;
-                                                  s1 = peg$parseBEGIN_ARRAY();
+                                                  s1 = peg$parseBEGIN_VVMATRIX();
                                                   if (s1 !== peg$FAILED) {
-                                                    s2 = peg$parseopt_pos();
+                                                    s2 = peg$parsearray();
+                                                    if (s2 === peg$FAILED) {
+                                                      s2 = peg$parsematrix();
+                                                    }
                                                     if (s2 !== peg$FAILED) {
-                                                      s3 = peg$parsearray();
+                                                      s3 = peg$parseEND_VVMATRIX();
                                                       if (s3 !== peg$FAILED) {
-                                                        s4 = peg$parseEND_ARRAY();
-                                                        if (s4 !== peg$FAILED) {
-                                                          peg$savedPos = s0;
-                                                          s1 = peg$c42(s3);
-                                                          s0 = s1;
-                                                        } else {
-                                                          peg$currPos = s0;
-                                                          s0 = peg$FAILED;
-                                                        }
+                                                        peg$savedPos = s0;
+                                                        s1 = peg$c43(s2);
+                                                        s0 = s1;
                                                       } else {
                                                         peg$currPos = s0;
                                                         s0 = peg$FAILED;
@@ -1994,16 +2013,16 @@ module.exports = /*
                                                   }
                                                   if (s0 === peg$FAILED) {
                                                     s0 = peg$currPos;
-                                                    s1 = peg$parseBEGIN_ALIGN();
+                                                    s1 = peg$parseBEGIN_ARRAY();
                                                     if (s1 !== peg$FAILED) {
                                                       s2 = peg$parseopt_pos();
                                                       if (s2 !== peg$FAILED) {
-                                                        s3 = peg$parsematrix();
+                                                        s3 = peg$parsearray();
                                                         if (s3 !== peg$FAILED) {
-                                                          s4 = peg$parseEND_ALIGN();
+                                                          s4 = peg$parseEND_ARRAY();
                                                           if (s4 !== peg$FAILED) {
                                                             peg$savedPos = s0;
-                                                            s1 = peg$c43(s3);
+                                                            s1 = peg$c44(s3);
                                                             s0 = s1;
                                                           } else {
                                                             peg$currPos = s0;
@@ -2023,16 +2042,16 @@ module.exports = /*
                                                     }
                                                     if (s0 === peg$FAILED) {
                                                       s0 = peg$currPos;
-                                                      s1 = peg$parseBEGIN_ALIGNED();
+                                                      s1 = peg$parseBEGIN_ALIGN();
                                                       if (s1 !== peg$FAILED) {
                                                         s2 = peg$parseopt_pos();
                                                         if (s2 !== peg$FAILED) {
                                                           s3 = peg$parsematrix();
                                                           if (s3 !== peg$FAILED) {
-                                                            s4 = peg$parseEND_ALIGNED();
+                                                            s4 = peg$parseEND_ALIGN();
                                                             if (s4 !== peg$FAILED) {
                                                               peg$savedPos = s0;
-                                                              s1 = peg$c43(s3);
+                                                              s1 = peg$c45(s3);
                                                               s0 = s1;
                                                             } else {
                                                               peg$currPos = s0;
@@ -2052,15 +2071,21 @@ module.exports = /*
                                                       }
                                                       if (s0 === peg$FAILED) {
                                                         s0 = peg$currPos;
-                                                        s1 = peg$parseBEGIN_ALIGNAT();
+                                                        s1 = peg$parseBEGIN_ALIGNED();
                                                         if (s1 !== peg$FAILED) {
-                                                          s2 = peg$parsealignat();
+                                                          s2 = peg$parseopt_pos();
                                                           if (s2 !== peg$FAILED) {
-                                                            s3 = peg$parseEND_ALIGNAT();
+                                                            s3 = peg$parsematrix();
                                                             if (s3 !== peg$FAILED) {
-                                                              peg$savedPos = s0;
-                                                              s1 = peg$c44(s2);
-                                                              s0 = s1;
+                                                              s4 = peg$parseEND_ALIGNED();
+                                                              if (s4 !== peg$FAILED) {
+                                                                peg$savedPos = s0;
+                                                                s1 = peg$c45(s3);
+                                                                s0 = s1;
+                                                              } else {
+                                                                peg$currPos = s0;
+                                                                s0 = peg$FAILED;
+                                                              }
                                                             } else {
                                                               peg$currPos = s0;
                                                               s0 = peg$FAILED;
@@ -2075,14 +2100,14 @@ module.exports = /*
                                                         }
                                                         if (s0 === peg$FAILED) {
                                                           s0 = peg$currPos;
-                                                          s1 = peg$parseBEGIN_ALIGNEDAT();
+                                                          s1 = peg$parseBEGIN_ALIGNAT();
                                                           if (s1 !== peg$FAILED) {
                                                             s2 = peg$parsealignat();
                                                             if (s2 !== peg$FAILED) {
-                                                              s3 = peg$parseEND_ALIGNEDAT();
+                                                              s3 = peg$parseEND_ALIGNAT();
                                                               if (s3 !== peg$FAILED) {
                                                                 peg$savedPos = s0;
-                                                                s1 = peg$c44(s2);
+                                                                s1 = peg$c46(s2);
                                                                 s0 = s1;
                                                               } else {
                                                                 peg$currPos = s0;
@@ -2098,17 +2123,14 @@ module.exports = /*
                                                           }
                                                           if (s0 === peg$FAILED) {
                                                             s0 = peg$currPos;
-                                                            s1 = peg$parseBEGIN_SMALLMATRIX();
+                                                            s1 = peg$parseBEGIN_ALIGNEDAT();
                                                             if (s1 !== peg$FAILED) {
-                                                              s2 = peg$parsearray();
-                                                              if (s2 === peg$FAILED) {
-                                                                s2 = peg$parsematrix();
-                                                              }
+                                                              s2 = peg$parsealignat();
                                                               if (s2 !== peg$FAILED) {
-                                                                s3 = peg$parseEND_SMALLMATRIX();
+                                                                s3 = peg$parseEND_ALIGNEDAT();
                                                                 if (s3 !== peg$FAILED) {
                                                                   peg$savedPos = s0;
-                                                                  s1 = peg$c45(s2);
+                                                                  s1 = peg$c46(s2);
                                                                   s0 = s1;
                                                                 } else {
                                                                   peg$currPos = s0;
@@ -2124,14 +2146,17 @@ module.exports = /*
                                                             }
                                                             if (s0 === peg$FAILED) {
                                                               s0 = peg$currPos;
-                                                              s1 = peg$parseBEGIN_CASES();
+                                                              s1 = peg$parseBEGIN_SMALLMATRIX();
                                                               if (s1 !== peg$FAILED) {
-                                                                s2 = peg$parsematrix();
+                                                                s2 = peg$parsearray();
+                                                                if (s2 === peg$FAILED) {
+                                                                  s2 = peg$parsematrix();
+                                                                }
                                                                 if (s2 !== peg$FAILED) {
-                                                                  s3 = peg$parseEND_CASES();
+                                                                  s3 = peg$parseEND_SMALLMATRIX();
                                                                   if (s3 !== peg$FAILED) {
                                                                     peg$savedPos = s0;
-                                                                    s1 = peg$c46(s2);
+                                                                    s1 = peg$c47(s2);
                                                                     s0 = s1;
                                                                   } else {
                                                                     peg$currPos = s0;
@@ -2147,35 +2172,14 @@ module.exports = /*
                                                               }
                                                               if (s0 === peg$FAILED) {
                                                                 s0 = peg$currPos;
-                                                                if (input.substr(peg$currPos, 7) === peg$c47) {
-                                                                  s1 = peg$c47;
-                                                                  peg$currPos += 7;
-                                                                } else {
-                                                                  s1 = peg$FAILED;
-                                                                  if (peg$silentFails === 0) { peg$fail(peg$c48); }
-                                                                }
+                                                                s1 = peg$parseBEGIN_CASES();
                                                                 if (s1 !== peg$FAILED) {
-                                                                  s2 = [];
-                                                                  s3 = peg$parsealpha();
-                                                                  if (s3 !== peg$FAILED) {
-                                                                    while (s3 !== peg$FAILED) {
-                                                                      s2.push(s3);
-                                                                      s3 = peg$parsealpha();
-                                                                    }
-                                                                  } else {
-                                                                    s2 = peg$FAILED;
-                                                                  }
+                                                                  s2 = peg$parsematrix();
                                                                   if (s2 !== peg$FAILED) {
-                                                                    if (input.charCodeAt(peg$currPos) === 125) {
-                                                                      s3 = peg$c49;
-                                                                      peg$currPos++;
-                                                                    } else {
-                                                                      s3 = peg$FAILED;
-                                                                      if (peg$silentFails === 0) { peg$fail(peg$c50); }
-                                                                    }
+                                                                    s3 = peg$parseEND_CASES();
                                                                     if (s3 !== peg$FAILED) {
                                                                       peg$savedPos = s0;
-                                                                      s1 = peg$c51();
+                                                                      s1 = peg$c48(s2);
                                                                       s0 = s1;
                                                                     } else {
                                                                       peg$currPos = s0;
@@ -2191,19 +2195,40 @@ module.exports = /*
                                                                 }
                                                                 if (s0 === peg$FAILED) {
                                                                   s0 = peg$currPos;
-                                                                  s1 = peg$parsegeneric_func();
+                                                                  if (input.substr(peg$currPos, 7) === peg$c49) {
+                                                                    s1 = peg$c49;
+                                                                    peg$currPos += 7;
+                                                                  } else {
+                                                                    s1 = peg$FAILED;
+                                                                    if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                                                                  }
                                                                   if (s1 !== peg$FAILED) {
-                                                                    peg$savedPos = peg$currPos;
-                                                                    s2 = peg$c52(s1);
-                                                                    if (s2) {
-                                                                      s2 = void 0;
+                                                                    s2 = [];
+                                                                    s3 = peg$parsealpha();
+                                                                    if (s3 !== peg$FAILED) {
+                                                                      while (s3 !== peg$FAILED) {
+                                                                        s2.push(s3);
+                                                                        s3 = peg$parsealpha();
+                                                                      }
                                                                     } else {
                                                                       s2 = peg$FAILED;
                                                                     }
                                                                     if (s2 !== peg$FAILED) {
-                                                                      peg$savedPos = s0;
-                                                                      s1 = peg$c53(s1);
-                                                                      s0 = s1;
+                                                                      if (input.charCodeAt(peg$currPos) === 125) {
+                                                                        s3 = peg$c51;
+                                                                        peg$currPos++;
+                                                                      } else {
+                                                                        s3 = peg$FAILED;
+                                                                        if (peg$silentFails === 0) { peg$fail(peg$c52); }
+                                                                      }
+                                                                      if (s3 !== peg$FAILED) {
+                                                                        peg$savedPos = s0;
+                                                                        s1 = peg$c53();
+                                                                        s0 = s1;
+                                                                      } else {
+                                                                        peg$currPos = s0;
+                                                                        s0 = peg$FAILED;
+                                                                      }
                                                                     } else {
                                                                       peg$currPos = s0;
                                                                       s0 = peg$FAILED;
@@ -2211,6 +2236,30 @@ module.exports = /*
                                                                   } else {
                                                                     peg$currPos = s0;
                                                                     s0 = peg$FAILED;
+                                                                  }
+                                                                  if (s0 === peg$FAILED) {
+                                                                    s0 = peg$currPos;
+                                                                    s1 = peg$parsegeneric_func();
+                                                                    if (s1 !== peg$FAILED) {
+                                                                      peg$savedPos = peg$currPos;
+                                                                      s2 = peg$c54(s1);
+                                                                      if (s2) {
+                                                                        s2 = void 0;
+                                                                      } else {
+                                                                        s2 = peg$FAILED;
+                                                                      }
+                                                                      if (s2 !== peg$FAILED) {
+                                                                        peg$savedPos = s0;
+                                                                        s1 = peg$c55(s1);
+                                                                        s0 = s1;
+                                                                      } else {
+                                                                        peg$currPos = s0;
+                                                                        s0 = peg$FAILED;
+                                                                      }
+                                                                    } else {
+                                                                      peg$currPos = s0;
+                                                                      s0 = peg$FAILED;
+                                                                    }
                                                                   }
                                                                 }
                                                               }
@@ -2266,7 +2315,7 @@ module.exports = /*
         s2 = peg$parsematrix();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c54(s1, s2);
+          s1 = peg$c56(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2300,7 +2349,7 @@ module.exports = /*
         s2 = peg$parsematrix();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c55(s1, s2);
+          s1 = peg$c57(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2337,7 +2386,7 @@ module.exports = /*
           s4 = peg$parsematrix();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c56(s1, s4);
+            s3 = peg$c58(s1, s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -2352,7 +2401,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c57(s1, s2);
+          s1 = peg$c59(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2386,7 +2435,7 @@ module.exports = /*
         s2 = peg$parseline_start();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c58(s1, s2);
+          s1 = peg$c60(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2426,7 +2475,7 @@ module.exports = /*
           s4 = peg$parseline();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s2;
-            s3 = peg$c59(s1, s4);
+            s3 = peg$c61(s1, s4);
             s2 = s3;
           } else {
             peg$currPos = s2;
@@ -2441,7 +2490,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c60(s1, s2);
+          s1 = peg$c62(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2485,14 +2534,14 @@ module.exports = /*
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c61();
+          s3 = peg$c63();
         }
         s2 = s3;
         if (s2 !== peg$FAILED) {
           s3 = peg$parseCURLY_CLOSE();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c62(s2);
+            s1 = peg$c64(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2525,12 +2574,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (peg$c63.test(input.charAt(peg$currPos))) {
+      if (peg$c65.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c64); }
+        if (peg$silentFails === 0) { peg$fail(peg$c66); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -2548,11 +2597,11 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 112) {
-          s1 = peg$c65;
+          s1 = peg$c67;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c66); }
+          if (peg$silentFails === 0) { peg$fail(peg$c68); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseCURLY_OPEN();
@@ -2591,32 +2640,32 @@ module.exports = /*
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 42) {
-            s1 = peg$c67;
+            s1 = peg$c69;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c68); }
+            if (peg$silentFails === 0) { peg$fail(peg$c70); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseCURLY_OPEN();
             if (s2 !== peg$FAILED) {
               s3 = [];
-              if (peg$c69.test(input.charAt(peg$currPos))) {
+              if (peg$c71.test(input.charAt(peg$currPos))) {
                 s4 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c70); }
+                if (peg$silentFails === 0) { peg$fail(peg$c72); }
               }
               if (s4 !== peg$FAILED) {
                 while (s4 !== peg$FAILED) {
                   s3.push(s4);
-                  if (peg$c69.test(input.charAt(peg$currPos))) {
+                  if (peg$c71.test(input.charAt(peg$currPos))) {
                     s4 = input.charAt(peg$currPos);
                     peg$currPos++;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c70); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c72); }
                   }
                 }
               } else {
@@ -2689,12 +2738,12 @@ module.exports = /*
           }
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c71) {
-              s1 = peg$c71;
+            if (input.substr(peg$currPos, 2) === peg$c73) {
+              s1 = peg$c73;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c72); }
+              if (peg$silentFails === 0) { peg$fail(peg$c74); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$parse_();
@@ -2712,11 +2761,11 @@ module.exports = /*
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 124) {
-                s1 = peg$c73;
+                s1 = peg$c75;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c74); }
+                if (peg$silentFails === 0) { peg$fail(peg$c76); }
               }
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse_();
@@ -2734,11 +2783,11 @@ module.exports = /*
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 64) {
-                  s1 = peg$c75;
+                  s1 = peg$c77;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c76); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c78); }
                 }
                 if (s1 !== peg$FAILED) {
                   s2 = peg$parse_();
@@ -2808,22 +2857,22 @@ module.exports = /*
       if (s1 !== peg$FAILED) {
         s2 = peg$currPos;
         s3 = [];
-        if (peg$c69.test(input.charAt(peg$currPos))) {
+        if (peg$c71.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c70); }
+          if (peg$silentFails === 0) { peg$fail(peg$c72); }
         }
         if (s4 !== peg$FAILED) {
           while (s4 !== peg$FAILED) {
             s3.push(s4);
-            if (peg$c69.test(input.charAt(peg$currPos))) {
+            if (peg$c71.test(input.charAt(peg$currPos))) {
               s4 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c70); }
+              if (peg$silentFails === 0) { peg$fail(peg$c72); }
             }
           }
         } else {
@@ -2831,7 +2880,7 @@ module.exports = /*
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s2;
-          s3 = peg$c61();
+          s3 = peg$c63();
         }
         s2 = s3;
         if (s2 !== peg$FAILED) {
@@ -2840,7 +2889,7 @@ module.exports = /*
             s4 = peg$parseCURLY_CLOSE();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c77(s2);
+              s1 = peg$c79(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2878,31 +2927,31 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c78;
+        s1 = peg$c80;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c79); }
+        if (peg$silentFails === 0) { peg$fail(peg$c81); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
-          if (peg$c80.test(input.charAt(peg$currPos))) {
+          if (peg$c82.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c81); }
+            if (peg$silentFails === 0) { peg$fail(peg$c83); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parse_();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 93) {
-                s5 = peg$c82;
+                s5 = peg$c84;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c83); }
+                if (peg$silentFails === 0) { peg$fail(peg$c85); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = peg$parse_();
@@ -2962,7 +3011,7 @@ module.exports = /*
           s3 = peg$parseCURLY_CLOSE();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c33(s2);
+            s1 = peg$c35(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3000,17 +3049,17 @@ module.exports = /*
         s2 = peg$parsechem_phrase();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 32) {
-            s3 = peg$c84;
+            s3 = peg$c86;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c85); }
+            if (peg$silentFails === 0) { peg$fail(peg$c87); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parsechem_sentence();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c86(s2, s4);
+              s1 = peg$c88(s2, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3037,7 +3086,7 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c87(s2);
+              s1 = peg$c89(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3071,16 +3120,16 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 3) === peg$c88) {
-        s1 = peg$c88;
+      if (input.substr(peg$currPos, 3) === peg$c90) {
+        s1 = peg$c90;
         peg$currPos += 3;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c89); }
+        if (peg$silentFails === 0) { peg$fail(peg$c91); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c90(s1);
+        s1 = peg$c92(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -3090,7 +3139,7 @@ module.exports = /*
           s2 = peg$parseCHEM_SINGLE_MACRO();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c91(s1, s2);
+            s1 = peg$c93(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3105,7 +3154,7 @@ module.exports = /*
           s1 = peg$parsechem_word();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c92(s1);
+            s1 = peg$c94(s1);
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
@@ -3113,21 +3162,21 @@ module.exports = /*
             s1 = peg$parseCHEM_SINGLE_MACRO();
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c90(s1);
+              s1 = peg$c92(s1);
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 94) {
-                s1 = peg$c93;
+                s1 = peg$c95;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c94); }
+                if (peg$silentFails === 0) { peg$fail(peg$c96); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c90(s1);
+                s1 = peg$c92(s1);
               }
               s0 = s1;
             }
@@ -3158,7 +3207,7 @@ module.exports = /*
         s2 = peg$parsechem_word_nt();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c95(s1, s2);
+          s1 = peg$c97(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3177,7 +3226,7 @@ module.exports = /*
             s3 = peg$parsechem_word_nt();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c96(s1, s2, s3);
+              s1 = peg$c98(s1, s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3214,7 +3263,7 @@ module.exports = /*
       s1 = peg$parsechem_word();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c92(s1);
+        s1 = peg$c94(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -3222,7 +3271,7 @@ module.exports = /*
         s1 = peg$c6;
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c97();
+          s1 = peg$c99();
         }
         s0 = s1;
       }
@@ -3248,7 +3297,7 @@ module.exports = /*
       s1 = peg$parsechem_char_nl();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c98(s1);
+        s1 = peg$c100(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -3256,7 +3305,7 @@ module.exports = /*
         s1 = peg$parseCHEM_LETTER();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c99(s1);
+          s1 = peg$c101(s1);
         }
         s0 = s1;
       }
@@ -3282,7 +3331,7 @@ module.exports = /*
       s1 = peg$parsechem_script();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c98(s1);
+        s1 = peg$c100(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -3294,7 +3343,7 @@ module.exports = /*
             s3 = peg$parseCURLY_CLOSE();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c100(s2);
+              s1 = peg$c102(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3317,7 +3366,7 @@ module.exports = /*
               s3 = peg$parseEND_MATH();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c101(s2);
+                s1 = peg$c103(s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3338,7 +3387,7 @@ module.exports = /*
               s2 = peg$parsechem_bond();
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c28(s1, s2);
+                s1 = peg$c30(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3353,7 +3402,7 @@ module.exports = /*
               s1 = peg$parsechem_macro();
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c92(s1);
+                s1 = peg$c94(s1);
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
@@ -3361,7 +3410,7 @@ module.exports = /*
                 s1 = peg$parseCHEM_NONLETTER();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c99(s1);
+                  s1 = peg$c101(s1);
                 }
                 s0 = s1;
               }
@@ -3395,7 +3444,7 @@ module.exports = /*
           s3 = peg$parseCURLY_CLOSE();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c102(s2);
+            s1 = peg$c104(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3433,7 +3482,7 @@ module.exports = /*
         s2 = peg$parseCHEM_SCRIPT_FOLLOW();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c103(s1, s2);
+          s1 = peg$c105(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3450,7 +3499,7 @@ module.exports = /*
           s2 = peg$parsechem_lit();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c104(s1, s2);
+            s1 = peg$c106(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3471,7 +3520,7 @@ module.exports = /*
                 s4 = peg$parseEND_MATH();
                 if (s4 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c105(s1, s3);
+                  s1 = peg$c107(s1, s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3515,17 +3564,17 @@ module.exports = /*
         s2 = peg$parsechem_lit();
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 95) {
-            s3 = peg$c106;
+            s3 = peg$c108;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c107); }
+            if (peg$silentFails === 0) { peg$fail(peg$c109); }
           }
           if (s3 !== peg$FAILED) {
             s4 = peg$parsechem_lit();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c108(s1, s2, s4);
+              s1 = peg$c110(s1, s2, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3552,7 +3601,7 @@ module.exports = /*
             s3 = peg$parsechem_lit();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c31(s1, s2, s3);
+              s1 = peg$c33(s1, s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3575,7 +3624,7 @@ module.exports = /*
               s3 = peg$parsechem_lit();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c31(s1, s2, s3);
+                s1 = peg$c33(s1, s2, s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3596,7 +3645,7 @@ module.exports = /*
               s2 = peg$parsechem_lit();
               if (s2 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c28(s1, s2);
+                s1 = peg$c30(s1, s2);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3640,7 +3689,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c109(s1);
+        s1 = peg$c111(s1);
       }
       s0 = s1;
 
@@ -3663,11 +3712,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c110;
+        s1 = peg$c112;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c111); }
+        if (peg$silentFails === 0) { peg$fail(peg$c113); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -3686,17 +3735,17 @@ module.exports = /*
             s4 = peg$parse_();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 125) {
-                s5 = peg$c49;
+                s5 = peg$c51;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                if (peg$silentFails === 0) { peg$fail(peg$c52); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = peg$parse_();
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c112(s3);
+                  s1 = peg$c114(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3740,12 +3789,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c113.test(input.charAt(peg$currPos))) {
+      if (peg$c115.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c114); }
+        if (peg$silentFails === 0) { peg$fail(peg$c116); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3757,56 +3806,6 @@ module.exports = /*
       var s0;
 
       var key    = peg$currPos * 125 + 42,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      if (peg$c113.test(input.charAt(peg$currPos))) {
-        s0 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c114); }
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseliteral_mn() {
-      var s0;
-
-      var key    = peg$currPos * 125 + 43,
-          cached = peg$resultsCache[key];
-
-      if (cached) {
-        peg$currPos = cached.nextPos;
-
-        return cached.result;
-      }
-
-      if (peg$c69.test(input.charAt(peg$currPos))) {
-        s0 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c70); }
-      }
-
-      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
-
-      return s0;
-    }
-
-    function peg$parseliteral_uf_lt() {
-      var s0;
-
-      var key    = peg$currPos * 125 + 44,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3828,10 +3827,35 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parsedelimiter_uf_lt() {
+    function peg$parseliteral_mn() {
       var s0;
 
-      var key    = peg$currPos * 125 + 45,
+      var key    = peg$currPos * 125 + 43,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (peg$c71.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c72); }
+      }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseliteral_uf_lt() {
+      var s0;
+
+      var key    = peg$currPos * 125 + 44,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3853,10 +3877,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseliteral_uf_op() {
+    function peg$parsedelimiter_uf_lt() {
       var s0;
 
-      var key    = peg$currPos * 125 + 46,
+      var key    = peg$currPos * 125 + 45,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3878,10 +3902,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parsedelimiter_uf_op() {
+    function peg$parseliteral_uf_op() {
       var s0;
 
-      var key    = peg$currPos * 125 + 47,
+      var key    = peg$currPos * 125 + 46,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3903,10 +3927,10 @@ module.exports = /*
       return s0;
     }
 
-    function peg$parseboxchars() {
-      var s0, s1, s2;
+    function peg$parsedelimiter_uf_op() {
+      var s0;
 
-      var key    = peg$currPos * 125 + 48,
+      var key    = peg$currPos * 125 + 47,
           cached = peg$resultsCache[key];
 
       if (cached) {
@@ -3922,26 +3946,51 @@ module.exports = /*
         s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c124); }
       }
+
+      peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+      return s0;
+    }
+
+    function peg$parseboxchars() {
+      var s0, s1, s2;
+
+      var key    = peg$currPos * 125 + 48,
+          cached = peg$resultsCache[key];
+
+      if (cached) {
+        peg$currPos = cached.nextPos;
+
+        return cached.result;
+      }
+
+      if (peg$c125.test(input.charAt(peg$currPos))) {
+        s0 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c126); }
+      }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (peg$c125.test(input.charAt(peg$currPos))) {
+        if (peg$c127.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c126); }
+          if (peg$silentFails === 0) { peg$fail(peg$c128); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c127.test(input.charAt(peg$currPos))) {
+          if (peg$c129.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c128); }
+            if (peg$silentFails === 0) { peg$fail(peg$c130); }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c129(s1, s2);
+            s1 = peg$c131(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3974,7 +4023,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c130(s1);
+        s2 = peg$c132(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -3984,11 +4033,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c110;
+              s4 = peg$c112;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c111); }
+              if (peg$silentFails === 0) { peg$fail(peg$c113); }
             }
             if (s4 !== peg$FAILED) {
               s5 = [];
@@ -4003,17 +4052,17 @@ module.exports = /*
               }
               if (s5 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 125) {
-                  s6 = peg$c49;
+                  s6 = peg$c51;
                   peg$currPos++;
                 } else {
                   s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c52); }
                 }
                 if (s6 !== peg$FAILED) {
                   s7 = peg$parse_();
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c131(s1, s5);
+                    s1 = peg$c133(s1, s5);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4069,11 +4118,11 @@ module.exports = /*
           s1 = peg$parseliteral_uf_lt();
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 45) {
-              s1 = peg$c132;
+              s1 = peg$c134;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c133); }
+              if (peg$silentFails === 0) { peg$fail(peg$c135); }
             }
             if (s1 === peg$FAILED) {
               s1 = peg$parseliteral_uf_op();
@@ -4085,7 +4134,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c134(s1);
+          s1 = peg$c136(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4100,7 +4149,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c135(s1);
+          s2 = peg$c137(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -4110,34 +4159,34 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 40) {
-                s4 = peg$c136;
+                s4 = peg$c138;
                 peg$currPos++;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c137); }
+                if (peg$silentFails === 0) { peg$fail(peg$c139); }
               }
               if (s4 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 91) {
-                  s4 = peg$c78;
+                  s4 = peg$c80;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c79); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c81); }
                 }
                 if (s4 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c138) {
-                    s4 = peg$c138;
+                  if (input.substr(peg$currPos, 2) === peg$c140) {
+                    s4 = peg$c140;
                     peg$currPos += 2;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c139); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c141); }
                   }
                   if (s4 === peg$FAILED) {
                     s4 = peg$currPos;
                     s5 = peg$c6;
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s4;
-                      s5 = peg$c140(s1);
+                      s5 = peg$c142(s1);
                     }
                     s4 = s5;
                   }
@@ -4147,7 +4196,7 @@ module.exports = /*
                 s5 = peg$parse_();
                 if (s5 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c141(s1, s4);
+                  s1 = peg$c143(s1, s4);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4174,7 +4223,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c142(s1);
+            s2 = peg$c144(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -4184,34 +4233,34 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 40) {
-                  s4 = peg$c136;
+                  s4 = peg$c138;
                   peg$currPos++;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c137); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c139); }
                 }
                 if (s4 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 91) {
-                    s4 = peg$c78;
+                    s4 = peg$c80;
                     peg$currPos++;
                   } else {
                     s4 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c79); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c81); }
                   }
                   if (s4 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 2) === peg$c138) {
-                      s4 = peg$c138;
+                    if (input.substr(peg$currPos, 2) === peg$c140) {
+                      s4 = peg$c140;
                       peg$currPos += 2;
                     } else {
                       s4 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c139); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c141); }
                     }
                     if (s4 === peg$FAILED) {
                       s4 = peg$currPos;
                       s5 = peg$c6;
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s4;
-                        s5 = peg$c140(s1);
+                        s5 = peg$c142(s1);
                       }
                       s4 = s5;
                     }
@@ -4221,7 +4270,7 @@ module.exports = /*
                   s5 = peg$parse_();
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c143(s1, s4);
+                    s1 = peg$c145(s1, s4);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4248,7 +4297,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c144(s1);
+              s2 = peg$c146(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -4258,7 +4307,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c145(s1);
+                  s1 = peg$c147(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4277,7 +4326,7 @@ module.exports = /*
               s1 = peg$parsegeneric_func();
               if (s1 !== peg$FAILED) {
                 peg$savedPos = peg$currPos;
-                s2 = peg$c146(s1);
+                s2 = peg$c148(s1);
                 if (s2) {
                   s2 = void 0;
                 } else {
@@ -4287,7 +4336,7 @@ module.exports = /*
                   s3 = peg$parse_();
                   if (s3 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c147(s1);
+                    s1 = peg$c149(s1);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4306,7 +4355,7 @@ module.exports = /*
                 s1 = peg$parsegeneric_func();
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = peg$currPos;
-                  s2 = peg$c148(s1);
+                  s2 = peg$c150(s1);
                   if (s2) {
                     s2 = void 0;
                   } else {
@@ -4316,17 +4365,17 @@ module.exports = /*
                     s3 = peg$parse_();
                     if (s3 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 123) {
-                        s4 = peg$c110;
+                        s4 = peg$c112;
                         peg$currPos++;
                       } else {
                         s4 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c111); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c113); }
                       }
                       if (s4 !== peg$FAILED) {
                         s5 = peg$parsegeneric_func();
                         if (s5 !== peg$FAILED) {
                           peg$savedPos = peg$currPos;
-                          s6 = peg$c149(s1, s5);
+                          s6 = peg$c151(s1, s5);
                           if (s6) {
                             s6 = void 0;
                           } else {
@@ -4336,17 +4385,17 @@ module.exports = /*
                             s7 = peg$parse_();
                             if (s7 !== peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 125) {
-                                s8 = peg$c49;
+                                s8 = peg$c51;
                                 peg$currPos++;
                               } else {
                                 s8 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c52); }
                               }
                               if (s8 !== peg$FAILED) {
                                 s9 = peg$parse_();
                                 if (s9 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c150(s1, s5);
+                                  s1 = peg$c152(s1, s5);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -4389,7 +4438,7 @@ module.exports = /*
                   s1 = peg$parsegeneric_func();
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = peg$currPos;
-                    s2 = peg$c151(s1);
+                    s2 = peg$c153(s1);
                     if (s2) {
                       s2 = void 0;
                     } else {
@@ -4399,7 +4448,7 @@ module.exports = /*
                       s3 = peg$parse_();
                       if (s3 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c152(s1);
+                        s1 = peg$c154(s1);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -4418,7 +4467,7 @@ module.exports = /*
                     s1 = peg$parsegeneric_func();
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = peg$currPos;
-                      s2 = peg$c153(s1);
+                      s2 = peg$c155(s1);
                       if (s2) {
                         s2 = void 0;
                       } else {
@@ -4428,17 +4477,17 @@ module.exports = /*
                         s3 = peg$parse_();
                         if (s3 !== peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 123) {
-                            s4 = peg$c110;
+                            s4 = peg$c112;
                             peg$currPos++;
                           } else {
                             s4 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c111); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c113); }
                           }
                           if (s4 !== peg$FAILED) {
                             s5 = peg$parsegeneric_func();
                             if (s5 !== peg$FAILED) {
                               peg$savedPos = peg$currPos;
-                              s6 = peg$c154(s1, s5);
+                              s6 = peg$c156(s1, s5);
                               if (s6) {
                                 s6 = void 0;
                               } else {
@@ -4448,17 +4497,17 @@ module.exports = /*
                                 s7 = peg$parse_();
                                 if (s7 !== peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 125) {
-                                    s8 = peg$c49;
+                                    s8 = peg$c51;
                                     peg$currPos++;
                                   } else {
                                     s8 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c52); }
                                   }
                                   if (s8 !== peg$FAILED) {
                                     s9 = peg$parse_();
                                     if (s9 !== peg$FAILED) {
                                       peg$savedPos = s0;
-                                      s1 = peg$c155(s1, s5);
+                                      s1 = peg$c157(s1, s5);
                                       s0 = s1;
                                     } else {
                                       peg$currPos = s0;
@@ -4504,31 +4553,31 @@ module.exports = /*
                       }
                       if (s1 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c156(s1);
+                        s1 = peg$c158(s1);
                       }
                       s0 = s1;
                       if (s0 === peg$FAILED) {
                         s0 = peg$currPos;
                         if (input.charCodeAt(peg$currPos) === 92) {
-                          s1 = peg$c157;
+                          s1 = peg$c159;
                           peg$currPos++;
                         } else {
                           s1 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c158); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c160); }
                         }
                         if (s1 !== peg$FAILED) {
-                          if (peg$c159.test(input.charAt(peg$currPos))) {
+                          if (peg$c161.test(input.charAt(peg$currPos))) {
                             s2 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s2 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c160); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c162); }
                           }
                           if (s2 !== peg$FAILED) {
                             s3 = peg$parse_();
                             if (s3 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c161(s2);
+                              s1 = peg$c163(s2);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -4544,18 +4593,18 @@ module.exports = /*
                         }
                         if (s0 === peg$FAILED) {
                           s0 = peg$currPos;
-                          if (peg$c162.test(input.charAt(peg$currPos))) {
+                          if (peg$c164.test(input.charAt(peg$currPos))) {
                             s1 = input.charAt(peg$currPos);
                             peg$currPos++;
                           } else {
                             s1 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c163); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c165); }
                           }
                           if (s1 !== peg$FAILED) {
                             s2 = peg$parse_();
                             if (s2 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c134(s1);
+                              s1 = peg$c136(s1);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -4567,18 +4616,18 @@ module.exports = /*
                           }
                           if (s0 === peg$FAILED) {
                             s0 = peg$currPos;
-                            if (peg$c164.test(input.charAt(peg$currPos))) {
+                            if (peg$c166.test(input.charAt(peg$currPos))) {
                               s1 = input.charAt(peg$currPos);
                               peg$currPos++;
                             } else {
                               s1 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c165); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c167); }
                             }
                             if (s1 !== peg$FAILED) {
                               s2 = peg$parse_();
                               if (s2 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c166(s1);
+                                s1 = peg$c168(s1);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -4623,11 +4672,11 @@ module.exports = /*
         s1 = peg$parsedelimiter_uf_op();
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c78;
+            s1 = peg$c80;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c79); }
+            if (peg$silentFails === 0) { peg$fail(peg$c81); }
           }
         }
       }
@@ -4635,7 +4684,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c134(s1);
+          s1 = peg$c136(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4648,25 +4697,25 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c157;
+          s1 = peg$c159;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c158); }
+          if (peg$silentFails === 0) { peg$fail(peg$c160); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c167.test(input.charAt(peg$currPos))) {
+          if (peg$c169.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c168); }
+            if (peg$silentFails === 0) { peg$fail(peg$c170); }
           }
           if (s2 !== peg$FAILED) {
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c161(s2);
+              s1 = peg$c163(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4685,7 +4734,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c169(s1);
+            s2 = peg$c171(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -4695,7 +4744,7 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c145(s1);
+                s1 = peg$c147(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4714,7 +4763,7 @@ module.exports = /*
             s1 = peg$parsegeneric_func();
             if (s1 !== peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s2 = peg$c170(s1);
+              s2 = peg$c172(s1);
               if (s2) {
                 s2 = void 0;
               } else {
@@ -4724,7 +4773,7 @@ module.exports = /*
                 s3 = peg$parse_();
                 if (s3 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c171(s1);
+                  s1 = peg$c173(s1);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4763,7 +4812,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c172(s1);
+        s2 = peg$c174(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -4773,7 +4822,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4809,7 +4858,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c174(s1);
+        s2 = peg$c176(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -4819,17 +4868,17 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 91) {
-              s4 = peg$c78;
+              s4 = peg$c80;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c79); }
+              if (peg$silentFails === 0) { peg$fail(peg$c81); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c173(s1);
+                s1 = peg$c175(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4871,11 +4920,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 38) {
-        s1 = peg$c175;
+        s1 = peg$c177;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c176); }
+        if (peg$silentFails === 0) { peg$fail(peg$c178); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4909,12 +4958,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c177) {
-        s1 = peg$c177;
+      if (input.substr(peg$currPos, 2) === peg$c179) {
+        s1 = peg$c179;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c178); }
+        if (peg$silentFails === 0) { peg$fail(peg$c180); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4948,12 +4997,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 6) === peg$c179) {
-        s1 = peg$c179;
+      if (input.substr(peg$currPos, 6) === peg$c181) {
+        s1 = peg$c181;
         peg$currPos += 6;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c180); }
+        if (peg$silentFails === 0) { peg$fail(peg$c182); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4987,12 +5036,12 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 4) === peg$c181) {
-        s1 = peg$c181;
+      if (input.substr(peg$currPos, 4) === peg$c183) {
+        s1 = peg$c183;
         peg$currPos += 4;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c182); }
+        if (peg$silentFails === 0) { peg$fail(peg$c184); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -5028,12 +5077,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c183) {
-          s2 = peg$c183;
+        if (input.substr(peg$currPos, 8) === peg$c185) {
+          s2 = peg$c185;
           peg$currPos += 8;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c184); }
+          if (peg$silentFails === 0) { peg$fail(peg$c186); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5073,12 +5122,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 8) === peg$c183) {
-          s2 = peg$c183;
+        if (input.substr(peg$currPos, 8) === peg$c185) {
+          s2 = peg$c185;
           peg$currPos += 8;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c184); }
+          if (peg$silentFails === 0) { peg$fail(peg$c186); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5118,12 +5167,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c185) {
-          s2 = peg$c185;
+        if (input.substr(peg$currPos, 9) === peg$c187) {
+          s2 = peg$c187;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c186); }
+          if (peg$silentFails === 0) { peg$fail(peg$c188); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5163,12 +5212,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c185) {
-          s2 = peg$c185;
+        if (input.substr(peg$currPos, 9) === peg$c187) {
+          s2 = peg$c187;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c186); }
+          if (peg$silentFails === 0) { peg$fail(peg$c188); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5208,12 +5257,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c187) {
-          s2 = peg$c187;
+        if (input.substr(peg$currPos, 9) === peg$c189) {
+          s2 = peg$c189;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c188); }
+          if (peg$silentFails === 0) { peg$fail(peg$c190); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5253,12 +5302,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c187) {
-          s2 = peg$c187;
+        if (input.substr(peg$currPos, 9) === peg$c189) {
+          s2 = peg$c189;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c188); }
+          if (peg$silentFails === 0) { peg$fail(peg$c190); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5298,12 +5347,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c189) {
-          s2 = peg$c189;
+        if (input.substr(peg$currPos, 9) === peg$c191) {
+          s2 = peg$c191;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c190); }
+          if (peg$silentFails === 0) { peg$fail(peg$c192); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5343,12 +5392,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c189) {
-          s2 = peg$c189;
+        if (input.substr(peg$currPos, 9) === peg$c191) {
+          s2 = peg$c191;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c190); }
+          if (peg$silentFails === 0) { peg$fail(peg$c192); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5388,12 +5437,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c191) {
-          s2 = peg$c191;
+        if (input.substr(peg$currPos, 9) === peg$c193) {
+          s2 = peg$c193;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c192); }
+          if (peg$silentFails === 0) { peg$fail(peg$c194); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5433,12 +5482,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c191) {
-          s2 = peg$c191;
+        if (input.substr(peg$currPos, 9) === peg$c193) {
+          s2 = peg$c193;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c192); }
+          if (peg$silentFails === 0) { peg$fail(peg$c194); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5478,12 +5527,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c193) {
-          s2 = peg$c193;
+        if (input.substr(peg$currPos, 9) === peg$c195) {
+          s2 = peg$c195;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c194); }
+          if (peg$silentFails === 0) { peg$fail(peg$c196); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5523,12 +5572,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c193) {
-          s2 = peg$c193;
+        if (input.substr(peg$currPos, 9) === peg$c195) {
+          s2 = peg$c195;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c194); }
+          if (peg$silentFails === 0) { peg$fail(peg$c196); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5568,12 +5617,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c195) {
-          s2 = peg$c195;
+        if (input.substr(peg$currPos, 7) === peg$c197) {
+          s2 = peg$c197;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c196); }
+          if (peg$silentFails === 0) { peg$fail(peg$c198); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5613,12 +5662,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c195) {
-          s2 = peg$c195;
+        if (input.substr(peg$currPos, 7) === peg$c197) {
+          s2 = peg$c197;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c196); }
+          if (peg$silentFails === 0) { peg$fail(peg$c198); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5658,12 +5707,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c197) {
-          s2 = peg$c197;
+        if (input.substr(peg$currPos, 7) === peg$c199) {
+          s2 = peg$c199;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c198); }
+          if (peg$silentFails === 0) { peg$fail(peg$c200); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5703,12 +5752,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c197) {
-          s2 = peg$c197;
+        if (input.substr(peg$currPos, 7) === peg$c199) {
+          s2 = peg$c199;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c198); }
+          if (peg$silentFails === 0) { peg$fail(peg$c200); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5748,12 +5797,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c199) {
-          s2 = peg$c199;
+        if (input.substr(peg$currPos, 9) === peg$c201) {
+          s2 = peg$c201;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c200); }
+          if (peg$silentFails === 0) { peg$fail(peg$c202); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5793,12 +5842,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c199) {
-          s2 = peg$c199;
+        if (input.substr(peg$currPos, 9) === peg$c201) {
+          s2 = peg$c201;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c200); }
+          if (peg$silentFails === 0) { peg$fail(peg$c202); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5838,12 +5887,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c201) {
-          s2 = peg$c201;
+        if (input.substr(peg$currPos, 9) === peg$c203) {
+          s2 = peg$c203;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c202); }
+          if (peg$silentFails === 0) { peg$fail(peg$c204); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5883,12 +5932,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 9) === peg$c201) {
-          s2 = peg$c201;
+        if (input.substr(peg$currPos, 9) === peg$c203) {
+          s2 = peg$c203;
           peg$currPos += 9;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c202); }
+          if (peg$silentFails === 0) { peg$fail(peg$c204); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5928,12 +5977,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c203) {
-          s2 = peg$c203;
+        if (input.substr(peg$currPos, 11) === peg$c205) {
+          s2 = peg$c205;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c204); }
+          if (peg$silentFails === 0) { peg$fail(peg$c206); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -5973,12 +6022,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 11) === peg$c203) {
-          s2 = peg$c203;
+        if (input.substr(peg$currPos, 11) === peg$c205) {
+          s2 = peg$c205;
           peg$currPos += 11;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c204); }
+          if (peg$silentFails === 0) { peg$fail(peg$c206); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6018,12 +6067,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c205) {
-          s2 = peg$c205;
+        if (input.substr(peg$currPos, 13) === peg$c207) {
+          s2 = peg$c207;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c206); }
+          if (peg$silentFails === 0) { peg$fail(peg$c208); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6063,12 +6112,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 13) === peg$c205) {
-          s2 = peg$c205;
+        if (input.substr(peg$currPos, 13) === peg$c207) {
+          s2 = peg$c207;
           peg$currPos += 13;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c206); }
+          if (peg$silentFails === 0) { peg$fail(peg$c208); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6108,12 +6157,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c207) {
-          s2 = peg$c207;
+        if (input.substr(peg$currPos, 7) === peg$c209) {
+          s2 = peg$c209;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c208); }
+          if (peg$silentFails === 0) { peg$fail(peg$c210); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6153,12 +6202,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c207) {
-          s2 = peg$c207;
+        if (input.substr(peg$currPos, 7) === peg$c209) {
+          s2 = peg$c209;
           peg$currPos += 7;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c208); }
+          if (peg$silentFails === 0) { peg$fail(peg$c210); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -6197,11 +6246,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 93) {
-        s1 = peg$c82;
+        s1 = peg$c84;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c83); }
+        if (peg$silentFails === 0) { peg$fail(peg$c85); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6236,11 +6285,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c110;
+        s1 = peg$c112;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c111); }
+        if (peg$silentFails === 0) { peg$fail(peg$c113); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6275,11 +6324,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 125) {
-        s1 = peg$c49;
+        s1 = peg$c51;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c50); }
+        if (peg$silentFails === 0) { peg$fail(peg$c52); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6314,11 +6363,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 94) {
-        s1 = peg$c93;
+        s1 = peg$c95;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c94); }
+        if (peg$silentFails === 0) { peg$fail(peg$c96); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6353,11 +6402,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 95) {
-        s1 = peg$c106;
+        s1 = peg$c108;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c107); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -6392,11 +6441,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c157;
+        s1 = peg$c159;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c158); }
+        if (peg$silentFails === 0) { peg$fail(peg$c160); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -6411,7 +6460,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c61();
+          s1 = peg$c63();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6443,7 +6492,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c209(s1);
+        s2 = peg$c211(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6453,7 +6502,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6489,7 +6538,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c210(s1);
+        s2 = peg$c212(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6499,7 +6548,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6518,7 +6567,7 @@ module.exports = /*
         s1 = peg$parsegeneric_func();
         if (s1 !== peg$FAILED) {
           peg$savedPos = peg$currPos;
-          s2 = peg$c211(s1);
+          s2 = peg$c213(s1);
           if (s2) {
             s2 = void 0;
           } else {
@@ -6528,7 +6577,7 @@ module.exports = /*
             s3 = peg$parse_();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c173(s1);
+              s1 = peg$c175(s1);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6547,7 +6596,7 @@ module.exports = /*
           s1 = peg$parsegeneric_func();
           if (s1 !== peg$FAILED) {
             peg$savedPos = peg$currPos;
-            s2 = peg$c212(s1);
+            s2 = peg$c214(s1);
             if (s2) {
               s2 = void 0;
             } else {
@@ -6557,7 +6606,7 @@ module.exports = /*
               s3 = peg$parse_();
               if (s3 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c212(s1);
+                s1 = peg$c215(s1);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -6595,7 +6644,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c213(s1);
+        s2 = peg$c216(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6605,7 +6654,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6641,7 +6690,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c214(s1);
+        s2 = peg$c217(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6651,7 +6700,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6687,7 +6736,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c215(s1);
+        s2 = peg$c218(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6697,7 +6746,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6733,7 +6782,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c216(s1);
+        s2 = peg$c219(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6743,7 +6792,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c217(s1);
+            s1 = peg$c220(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6779,7 +6828,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c218(s1);
+        s2 = peg$c221(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6789,7 +6838,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6825,7 +6874,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c219(s1);
+        s2 = peg$c222(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6870,7 +6919,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c220(s1);
+        s2 = peg$c223(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6915,7 +6964,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c221(s1);
+        s2 = peg$c224(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6925,7 +6974,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6961,7 +7010,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c222(s1);
+        s2 = peg$c225(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -6973,7 +7022,7 @@ module.exports = /*
             s4 = peg$parseCOLOR_SPEC();
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c223(s1, s4);
+              s1 = peg$c226(s1, s4);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7013,7 +7062,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c224(s1);
+        s2 = peg$c227(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -7023,11 +7072,11 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 123) {
-              s4 = peg$c110;
+              s4 = peg$c112;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c111); }
+              if (peg$silentFails === 0) { peg$fail(peg$c113); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7046,42 +7095,42 @@ module.exports = /*
                   s7 = peg$parse_();
                   if (s7 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 125) {
-                      s8 = peg$c49;
+                      s8 = peg$c51;
                       peg$currPos++;
                     } else {
                       s8 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c52); }
                     }
                     if (s8 !== peg$FAILED) {
                       s9 = peg$parse_();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 123) {
-                          s10 = peg$c110;
+                          s10 = peg$c112;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c111); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c113); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             s12 = peg$currPos;
-                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c225) {
+                            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c228) {
                               s13 = input.substr(peg$currPos, 5);
                               peg$currPos += 5;
                             } else {
                               s13 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c226); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c229); }
                             }
                             if (s13 !== peg$FAILED) {
                               s14 = peg$parse_();
                               if (s14 !== peg$FAILED) {
                                 if (input.charCodeAt(peg$currPos) === 125) {
-                                  s15 = peg$c49;
+                                  s15 = peg$c51;
                                   peg$currPos++;
                                 } else {
                                   s15 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c52); }
                                 }
                                 if (s15 !== peg$FAILED) {
                                   s16 = peg$parse_();
@@ -7089,7 +7138,7 @@ module.exports = /*
                                     s17 = peg$parseCOLOR_SPEC_NAMED();
                                     if (s17 !== peg$FAILED) {
                                       peg$savedPos = s12;
-                                      s13 = peg$c227(s1, s6, s17);
+                                      s13 = peg$c230(s1, s6, s17);
                                       s12 = s13;
                                     } else {
                                       peg$currPos = s12;
@@ -7113,22 +7162,22 @@ module.exports = /*
                             }
                             if (s12 === peg$FAILED) {
                               s12 = peg$currPos;
-                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c228) {
+                              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c231) {
                                 s13 = input.substr(peg$currPos, 4);
                                 peg$currPos += 4;
                               } else {
                                 s13 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c229); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c232); }
                               }
                               if (s13 !== peg$FAILED) {
                                 s14 = peg$parse_();
                                 if (s14 !== peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 125) {
-                                    s15 = peg$c49;
+                                    s15 = peg$c51;
                                     peg$currPos++;
                                   } else {
                                     s15 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c52); }
                                   }
                                   if (s15 !== peg$FAILED) {
                                     s16 = peg$parse_();
@@ -7136,7 +7185,7 @@ module.exports = /*
                                       s17 = peg$parseCOLOR_SPEC_GRAY();
                                       if (s17 !== peg$FAILED) {
                                         peg$savedPos = s12;
-                                        s13 = peg$c230(s1, s6, s17);
+                                        s13 = peg$c233(s1, s6, s17);
                                         s12 = s13;
                                       } else {
                                         peg$currPos = s12;
@@ -7160,22 +7209,22 @@ module.exports = /*
                               }
                               if (s12 === peg$FAILED) {
                                 s12 = peg$currPos;
-                                if (input.substr(peg$currPos, 3) === peg$c231) {
-                                  s13 = peg$c231;
+                                if (input.substr(peg$currPos, 3) === peg$c234) {
+                                  s13 = peg$c234;
                                   peg$currPos += 3;
                                 } else {
                                   s13 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c232); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c235); }
                                 }
                                 if (s13 !== peg$FAILED) {
                                   s14 = peg$parse_();
                                   if (s14 !== peg$FAILED) {
                                     if (input.charCodeAt(peg$currPos) === 125) {
-                                      s15 = peg$c49;
+                                      s15 = peg$c51;
                                       peg$currPos++;
                                     } else {
                                       s15 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c52); }
                                     }
                                     if (s15 !== peg$FAILED) {
                                       s16 = peg$parse_();
@@ -7183,7 +7232,7 @@ module.exports = /*
                                         s17 = peg$parseCOLOR_SPEC_rgb();
                                         if (s17 !== peg$FAILED) {
                                           peg$savedPos = s12;
-                                          s13 = peg$c233(s1, s6, s17);
+                                          s13 = peg$c236(s1, s6, s17);
                                           s12 = s13;
                                         } else {
                                           peg$currPos = s12;
@@ -7207,22 +7256,22 @@ module.exports = /*
                                 }
                                 if (s12 === peg$FAILED) {
                                   s12 = peg$currPos;
-                                  if (input.substr(peg$currPos, 3) === peg$c234) {
-                                    s13 = peg$c234;
+                                  if (input.substr(peg$currPos, 3) === peg$c237) {
+                                    s13 = peg$c237;
                                     peg$currPos += 3;
                                   } else {
                                     s13 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c235); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c238); }
                                   }
                                   if (s13 !== peg$FAILED) {
                                     s14 = peg$parse_();
                                     if (s14 !== peg$FAILED) {
                                       if (input.charCodeAt(peg$currPos) === 125) {
-                                        s15 = peg$c49;
+                                        s15 = peg$c51;
                                         peg$currPos++;
                                       } else {
                                         s15 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c52); }
                                       }
                                       if (s15 !== peg$FAILED) {
                                         s16 = peg$parse_();
@@ -7230,7 +7279,7 @@ module.exports = /*
                                           s17 = peg$parseCOLOR_SPEC_RGB();
                                           if (s17 !== peg$FAILED) {
                                             peg$savedPos = s12;
-                                            s13 = peg$c233(s1, s6, s17);
+                                            s13 = peg$c236(s1, s6, s17);
                                             s12 = s13;
                                           } else {
                                             peg$currPos = s12;
@@ -7254,22 +7303,22 @@ module.exports = /*
                                   }
                                   if (s12 === peg$FAILED) {
                                     s12 = peg$currPos;
-                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c236) {
+                                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c239) {
                                       s13 = input.substr(peg$currPos, 4);
                                       peg$currPos += 4;
                                     } else {
                                       s13 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c237); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c240); }
                                     }
                                     if (s13 !== peg$FAILED) {
                                       s14 = peg$parse_();
                                       if (s14 !== peg$FAILED) {
                                         if (input.charCodeAt(peg$currPos) === 125) {
-                                          s15 = peg$c49;
+                                          s15 = peg$c51;
                                           peg$currPos++;
                                         } else {
                                           s15 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c52); }
                                         }
                                         if (s15 !== peg$FAILED) {
                                           s16 = peg$parse_();
@@ -7277,7 +7326,7 @@ module.exports = /*
                                             s17 = peg$parseCOLOR_SPEC_CMYK();
                                             if (s17 !== peg$FAILED) {
                                               peg$savedPos = s12;
-                                              s13 = peg$c238(s1, s6, s17);
+                                              s13 = peg$c241(s1, s6, s17);
                                               s12 = s13;
                                             } else {
                                               peg$currPos = s12;
@@ -7305,7 +7354,7 @@ module.exports = /*
                             }
                             if (s12 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c239(s1, s6, s12);
+                              s1 = peg$c242(s1, s6, s12);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -7377,31 +7426,31 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c78;
+          s1 = peg$c80;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c79); }
+          if (peg$silentFails === 0) { peg$fail(peg$c81); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c225) {
+            if (input.substr(peg$currPos, 5).toLowerCase() === peg$c228) {
               s3 = input.substr(peg$currPos, 5);
               peg$currPos += 5;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c226); }
+              if (peg$silentFails === 0) { peg$fail(peg$c229); }
             }
             if (s3 !== peg$FAILED) {
               s4 = peg$parse_();
               if (s4 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s5 = peg$c82;
+                  s5 = peg$c84;
                   peg$currPos++;
                 } else {
                   s5 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c83); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c85); }
                 }
                 if (s5 !== peg$FAILED) {
                   s6 = peg$parse_();
@@ -7409,7 +7458,7 @@ module.exports = /*
                     s7 = peg$parseCOLOR_SPEC_NAMED();
                     if (s7 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c240(s7);
+                      s1 = peg$c243(s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -7442,31 +7491,31 @@ module.exports = /*
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 91) {
-            s1 = peg$c78;
+            s1 = peg$c80;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c79); }
+            if (peg$silentFails === 0) { peg$fail(peg$c81); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
             if (s2 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c228) {
+              if (input.substr(peg$currPos, 4).toLowerCase() === peg$c231) {
                 s3 = input.substr(peg$currPos, 4);
                 peg$currPos += 4;
               } else {
                 s3 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c229); }
+                if (peg$silentFails === 0) { peg$fail(peg$c232); }
               }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse_();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s5 = peg$c82;
+                    s5 = peg$c84;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c83); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c85); }
                   }
                   if (s5 !== peg$FAILED) {
                     s6 = peg$parse_();
@@ -7474,7 +7523,7 @@ module.exports = /*
                       s7 = peg$parseCOLOR_SPEC_GRAY();
                       if (s7 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c241(s7);
+                        s1 = peg$c244(s7);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -7507,31 +7556,31 @@ module.exports = /*
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 91) {
-              s1 = peg$c78;
+              s1 = peg$c80;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c79); }
+              if (peg$silentFails === 0) { peg$fail(peg$c81); }
             }
             if (s1 !== peg$FAILED) {
               s2 = peg$parse_();
               if (s2 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 3) === peg$c231) {
-                  s3 = peg$c231;
+                if (input.substr(peg$currPos, 3) === peg$c234) {
+                  s3 = peg$c234;
                   peg$currPos += 3;
                 } else {
                   s3 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c232); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c235); }
                 }
                 if (s3 !== peg$FAILED) {
                   s4 = peg$parse_();
                   if (s4 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 93) {
-                      s5 = peg$c82;
+                      s5 = peg$c84;
                       peg$currPos++;
                     } else {
                       s5 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c83); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c85); }
                     }
                     if (s5 !== peg$FAILED) {
                       s6 = peg$parse_();
@@ -7539,7 +7588,7 @@ module.exports = /*
                         s7 = peg$parseCOLOR_SPEC_rgb();
                         if (s7 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c242(s7);
+                          s1 = peg$c245(s7);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -7572,31 +7621,31 @@ module.exports = /*
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
               if (input.charCodeAt(peg$currPos) === 91) {
-                s1 = peg$c78;
+                s1 = peg$c80;
                 peg$currPos++;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c79); }
+                if (peg$silentFails === 0) { peg$fail(peg$c81); }
               }
               if (s1 !== peg$FAILED) {
                 s2 = peg$parse_();
                 if (s2 !== peg$FAILED) {
-                  if (input.substr(peg$currPos, 3) === peg$c234) {
-                    s3 = peg$c234;
+                  if (input.substr(peg$currPos, 3) === peg$c237) {
+                    s3 = peg$c237;
                     peg$currPos += 3;
                   } else {
                     s3 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c235); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c238); }
                   }
                   if (s3 !== peg$FAILED) {
                     s4 = peg$parse_();
                     if (s4 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 93) {
-                        s5 = peg$c82;
+                        s5 = peg$c84;
                         peg$currPos++;
                       } else {
                         s5 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c83); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c85); }
                       }
                       if (s5 !== peg$FAILED) {
                         s6 = peg$parse_();
@@ -7604,7 +7653,7 @@ module.exports = /*
                           s7 = peg$parseCOLOR_SPEC_RGB();
                           if (s7 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c242(s7);
+                            s1 = peg$c245(s7);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7637,31 +7686,31 @@ module.exports = /*
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
                 if (input.charCodeAt(peg$currPos) === 91) {
-                  s1 = peg$c78;
+                  s1 = peg$c80;
                   peg$currPos++;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c79); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c81); }
                 }
                 if (s1 !== peg$FAILED) {
                   s2 = peg$parse_();
                   if (s2 !== peg$FAILED) {
-                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c236) {
+                    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c239) {
                       s3 = input.substr(peg$currPos, 4);
                       peg$currPos += 4;
                     } else {
                       s3 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c237); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c240); }
                     }
                     if (s3 !== peg$FAILED) {
                       s4 = peg$parse_();
                       if (s4 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 93) {
-                          s5 = peg$c82;
+                          s5 = peg$c84;
                           peg$currPos++;
                         } else {
                           s5 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c83); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c85); }
                         }
                         if (s5 !== peg$FAILED) {
                           s6 = peg$parse_();
@@ -7669,7 +7718,7 @@ module.exports = /*
                             s7 = peg$parseCOLOR_SPEC_CMYK();
                             if (s7 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c243(s7);
+                              s1 = peg$c246(s7);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -7724,11 +7773,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c110;
+        s1 = peg$c112;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c111); }
+        if (peg$silentFails === 0) { peg$fail(peg$c113); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7747,17 +7796,17 @@ module.exports = /*
             s4 = peg$parse_();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 125) {
-                s5 = peg$c49;
+                s5 = peg$c51;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                if (peg$silentFails === 0) { peg$fail(peg$c52); }
               }
               if (s5 !== peg$FAILED) {
                 s6 = peg$parse_();
                 if (s6 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c244(s3);
+                  s1 = peg$c247(s3);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -7803,11 +7852,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c110;
+        s1 = peg$c112;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c111); }
+        if (peg$silentFails === 0) { peg$fail(peg$c113); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7824,15 +7873,15 @@ module.exports = /*
           }
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s4 = peg$c49;
+              s4 = peg$c51;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c50); }
+              if (peg$silentFails === 0) { peg$fail(peg$c52); }
             }
             if (s4 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c245(s3);
+              s1 = peg$c248(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7870,11 +7919,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c110;
+        s1 = peg$c112;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c111); }
+        if (peg$silentFails === 0) { peg$fail(peg$c113); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7882,11 +7931,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c246;
+              s4 = peg$c249;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c247); }
+              if (peg$silentFails === 0) { peg$fail(peg$c250); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -7894,11 +7943,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c246;
+                    s7 = peg$c249;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c247); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c250); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -7906,17 +7955,17 @@ module.exports = /*
                       s9 = peg$parseCNUM();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 125) {
-                          s10 = peg$c49;
+                          s10 = peg$c51;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c52); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c248(s3, s6, s9);
+                            s1 = peg$c251(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -7982,11 +8031,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c110;
+        s1 = peg$c112;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c111); }
+        if (peg$silentFails === 0) { peg$fail(peg$c113); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -7994,11 +8043,11 @@ module.exports = /*
           s3 = peg$parseCNUM255();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c246;
+              s4 = peg$c249;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c247); }
+              if (peg$silentFails === 0) { peg$fail(peg$c250); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -8006,11 +8055,11 @@ module.exports = /*
                 s6 = peg$parseCNUM255();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c246;
+                    s7 = peg$c249;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c247); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c250); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -8018,17 +8067,17 @@ module.exports = /*
                       s9 = peg$parseCNUM255();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 125) {
-                          s10 = peg$c49;
+                          s10 = peg$c51;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c52); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
                           if (s11 !== peg$FAILED) {
                             peg$savedPos = s0;
-                            s1 = peg$c248(s3, s6, s9);
+                            s1 = peg$c251(s3, s6, s9);
                             s0 = s1;
                           } else {
                             peg$currPos = s0;
@@ -8094,11 +8143,11 @@ module.exports = /*
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c110;
+        s1 = peg$c112;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c111); }
+        if (peg$silentFails === 0) { peg$fail(peg$c113); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -8106,11 +8155,11 @@ module.exports = /*
           s3 = peg$parseCNUM();
           if (s3 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s4 = peg$c246;
+              s4 = peg$c249;
               peg$currPos++;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c247); }
+              if (peg$silentFails === 0) { peg$fail(peg$c250); }
             }
             if (s4 !== peg$FAILED) {
               s5 = peg$parse_();
@@ -8118,11 +8167,11 @@ module.exports = /*
                 s6 = peg$parseCNUM();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s7 = peg$c246;
+                    s7 = peg$c249;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c247); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c250); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse_();
@@ -8130,11 +8179,11 @@ module.exports = /*
                       s9 = peg$parseCNUM();
                       if (s9 !== peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 44) {
-                          s10 = peg$c246;
+                          s10 = peg$c249;
                           peg$currPos++;
                         } else {
                           s10 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c247); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c250); }
                         }
                         if (s10 !== peg$FAILED) {
                           s11 = peg$parse_();
@@ -8142,17 +8191,17 @@ module.exports = /*
                             s12 = peg$parseCNUM();
                             if (s12 !== peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 125) {
-                                s13 = peg$c49;
+                                s13 = peg$c51;
                                 peg$currPos++;
                               } else {
                                 s13 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c52); }
                               }
                               if (s13 !== peg$FAILED) {
                                 s14 = peg$parse_();
                                 if (s14 !== peg$FAILED) {
                                   peg$savedPos = s0;
-                                  s1 = peg$c249(s3, s6, s9, s12);
+                                  s1 = peg$c252(s3, s6, s9, s12);
                                   s0 = s1;
                                 } else {
                                   peg$currPos = s0;
@@ -8231,37 +8280,37 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s2 = peg$c250;
+        s2 = peg$c253;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c251); }
+        if (peg$silentFails === 0) { peg$fail(peg$c254); }
       }
       if (s2 === peg$FAILED) {
         s2 = peg$currPos;
-        if (peg$c252.test(input.charAt(peg$currPos))) {
+        if (peg$c255.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c253); }
+          if (peg$silentFails === 0) { peg$fail(peg$c256); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$currPos;
-          if (peg$c69.test(input.charAt(peg$currPos))) {
+          if (peg$c71.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c70); }
+            if (peg$silentFails === 0) { peg$fail(peg$c72); }
           }
           if (s5 !== peg$FAILED) {
-            if (peg$c69.test(input.charAt(peg$currPos))) {
+            if (peg$c71.test(input.charAt(peg$currPos))) {
               s6 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c70); }
+              if (peg$silentFails === 0) { peg$fail(peg$c72); }
             }
             if (s6 === peg$FAILED) {
               s6 = null;
@@ -8299,7 +8348,7 @@ module.exports = /*
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c254(s1);
+        s2 = peg$c257(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8309,7 +8358,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c255(s1);
+            s1 = peg$c258(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8345,41 +8394,41 @@ module.exports = /*
       s1 = peg$currPos;
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 48) {
-        s3 = peg$c250;
+        s3 = peg$c253;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c251); }
+        if (peg$silentFails === 0) { peg$fail(peg$c254); }
       }
       if (s3 === peg$FAILED) {
         s3 = null;
       }
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 46) {
-          s4 = peg$c256;
+          s4 = peg$c259;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c257); }
+          if (peg$silentFails === 0) { peg$fail(peg$c260); }
         }
         if (s4 !== peg$FAILED) {
           s5 = [];
-          if (peg$c69.test(input.charAt(peg$currPos))) {
+          if (peg$c71.test(input.charAt(peg$currPos))) {
             s6 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c70); }
+            if (peg$silentFails === 0) { peg$fail(peg$c72); }
           }
           if (s6 !== peg$FAILED) {
             while (s6 !== peg$FAILED) {
               s5.push(s6);
-              if (peg$c69.test(input.charAt(peg$currPos))) {
+              if (peg$c71.test(input.charAt(peg$currPos))) {
                 s6 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c70); }
+                if (peg$silentFails === 0) { peg$fail(peg$c72); }
               }
             }
           } else {
@@ -8409,7 +8458,7 @@ module.exports = /*
         s2 = peg$parse_();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c258(s1);
+          s1 = peg$c261(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8423,20 +8472,20 @@ module.exports = /*
         s0 = peg$currPos;
         s1 = peg$currPos;
         s2 = peg$currPos;
-        if (peg$c259.test(input.charAt(peg$currPos))) {
+        if (peg$c262.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c260); }
+          if (peg$silentFails === 0) { peg$fail(peg$c263); }
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 46) {
-            s4 = peg$c256;
+            s4 = peg$c259;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c257); }
+            if (peg$silentFails === 0) { peg$fail(peg$c260); }
           }
           if (s4 === peg$FAILED) {
             s4 = null;
@@ -8461,7 +8510,7 @@ module.exports = /*
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c258(s1);
+            s1 = peg$c261(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8494,7 +8543,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c261(s1);
+        s2 = peg$c264(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8502,7 +8551,7 @@ module.exports = /*
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c173(s1);
+          s1 = peg$c175(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -8515,23 +8564,23 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c157;
+          s1 = peg$c159;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c158); }
+          if (peg$silentFails === 0) { peg$fail(peg$c160); }
         }
         if (s1 !== peg$FAILED) {
-          if (peg$c159.test(input.charAt(peg$currPos))) {
+          if (peg$c161.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c160); }
+            if (peg$silentFails === 0) { peg$fail(peg$c162); }
           }
           if (s2 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c262(s2);
+            s1 = peg$c265(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8564,7 +8613,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c263(s1);
+        s2 = peg$c266(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8574,7 +8623,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8610,7 +8659,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c264(s1);
+        s2 = peg$c267(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8620,7 +8669,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8656,7 +8705,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c265(s1);
+        s2 = peg$c268(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8666,7 +8715,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8702,7 +8751,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c266(s1);
+        s2 = peg$c269(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8712,7 +8761,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8748,7 +8797,7 @@ module.exports = /*
       s1 = peg$parsegeneric_func();
       if (s1 !== peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s2 = peg$c267(s1);
+        s2 = peg$c270(s1);
         if (s2) {
           s2 = void 0;
         } else {
@@ -8758,7 +8807,7 @@ module.exports = /*
           s3 = peg$parse_();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c173(s1);
+            s1 = peg$c175(s1);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -8794,12 +8843,12 @@ module.exports = /*
       if (s0 === peg$FAILED) {
         s0 = peg$parseliteral_id();
         if (s0 === peg$FAILED) {
-          if (peg$c268.test(input.charAt(peg$currPos))) {
+          if (peg$c271.test(input.charAt(peg$currPos))) {
             s0 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c269); }
+            if (peg$silentFails === 0) { peg$fail(peg$c272); }
           }
         }
       }
@@ -8822,19 +8871,19 @@ module.exports = /*
       }
 
       if (input.charCodeAt(peg$currPos) === 95) {
-        s0 = peg$c106;
+        s0 = peg$c108;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c107); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 94) {
-          s0 = peg$c93;
+          s0 = peg$c95;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c94); }
+          if (peg$silentFails === 0) { peg$fail(peg$c96); }
         }
       }
 
@@ -8856,123 +8905,123 @@ module.exports = /*
       }
 
       if (input.charCodeAt(peg$currPos) === 61) {
-        s0 = peg$c270;
+        s0 = peg$c273;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c271); }
+        if (peg$silentFails === 0) { peg$fail(peg$c274); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 35) {
-          s0 = peg$c272;
+          s0 = peg$c275;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c273); }
+          if (peg$silentFails === 0) { peg$fail(peg$c276); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c274) {
-            s0 = peg$c274;
+          if (input.substr(peg$currPos, 3) === peg$c277) {
+            s0 = peg$c277;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c275); }
+            if (peg$silentFails === 0) { peg$fail(peg$c278); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c276) {
-              s0 = peg$c276;
+            if (input.substr(peg$currPos, 2) === peg$c279) {
+              s0 = peg$c279;
               peg$currPos += 2;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c277); }
+              if (peg$silentFails === 0) { peg$fail(peg$c280); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c278) {
-                s0 = peg$c278;
+              if (input.substr(peg$currPos, 2) === peg$c281) {
+                s0 = peg$c281;
                 peg$currPos += 2;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c279); }
+                if (peg$silentFails === 0) { peg$fail(peg$c282); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 126) {
-                  s0 = peg$c280;
+                  s0 = peg$c283;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c281); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c284); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 3) === peg$c282) {
-                    s0 = peg$c282;
+                  if (input.substr(peg$currPos, 3) === peg$c285) {
+                    s0 = peg$c285;
                     peg$currPos += 3;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c283); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c286); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 4) === peg$c284) {
-                      s0 = peg$c284;
+                    if (input.substr(peg$currPos, 4) === peg$c287) {
+                      s0 = peg$c287;
                       peg$currPos += 4;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c285); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c288); }
                     }
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 3) === peg$c286) {
-                        s0 = peg$c286;
+                      if (input.substr(peg$currPos, 3) === peg$c289) {
+                        s0 = peg$c289;
                         peg$currPos += 3;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c287); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c290); }
                       }
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 2) === peg$c288) {
-                          s0 = peg$c288;
+                        if (input.substr(peg$currPos, 2) === peg$c291) {
+                          s0 = peg$c291;
                           peg$currPos += 2;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c289); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c292); }
                         }
                         if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c290) {
-                            s0 = peg$c290;
+                          if (input.substr(peg$currPos, 2) === peg$c293) {
+                            s0 = peg$c293;
                             peg$currPos += 2;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c291); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c294); }
                           }
                           if (s0 === peg$FAILED) {
                             if (input.charCodeAt(peg$currPos) === 45) {
-                              s0 = peg$c132;
+                              s0 = peg$c134;
                               peg$currPos++;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c133); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c135); }
                             }
                             if (s0 === peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 49) {
-                                s0 = peg$c292;
+                                s0 = peg$c295;
                                 peg$currPos++;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c293); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c296); }
                               }
                               if (s0 === peg$FAILED) {
                                 if (input.charCodeAt(peg$currPos) === 50) {
-                                  s0 = peg$c294;
+                                  s0 = peg$c297;
                                   peg$currPos++;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c295); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c298); }
                                 }
                                 if (s0 === peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 51) {
-                                    s0 = peg$c296;
+                                    s0 = peg$c299;
                                     peg$currPos++;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c297); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c300); }
                                   }
                                 }
                               }
@@ -9009,12 +9058,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseBEGIN();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c298) {
-          s2 = peg$c298;
+        if (input.substr(peg$currPos, 6) === peg$c301) {
+          s2 = peg$c301;
           peg$currPos += 6;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c299); }
+          if (peg$silentFails === 0) { peg$fail(peg$c302); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -9054,12 +9103,12 @@ module.exports = /*
       s0 = peg$currPos;
       s1 = peg$parseEND();
       if (s1 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 6) === peg$c298) {
-          s2 = peg$c298;
+        if (input.substr(peg$currPos, 6) === peg$c301) {
+          s2 = peg$c301;
           peg$currPos += 6;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c299); }
+          if (peg$silentFails === 0) { peg$fail(peg$c302); }
         }
         if (s2 !== peg$FAILED) {
           s3 = peg$parse_();
@@ -9096,12 +9145,12 @@ module.exports = /*
         return cached.result;
       }
 
-      if (peg$c113.test(input.charAt(peg$currPos))) {
+      if (peg$c115.test(input.charAt(peg$currPos))) {
         s0 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c114); }
+        if (peg$silentFails === 0) { peg$fail(peg$c116); }
       }
 
       peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -9122,58 +9171,58 @@ module.exports = /*
       }
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c138) {
-        s1 = peg$c138;
+      if (input.substr(peg$currPos, 2) === peg$c140) {
+        s1 = peg$c140;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c139); }
+        if (peg$silentFails === 0) { peg$fail(peg$c141); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c300(s1);
+        s1 = peg$c303(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c301) {
-          s1 = peg$c301;
+        if (input.substr(peg$currPos, 2) === peg$c304) {
+          s1 = peg$c304;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c302); }
+          if (peg$silentFails === 0) { peg$fail(peg$c305); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c300(s1);
+          s1 = peg$c303(s1);
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c177) {
-            s1 = peg$c177;
+          if (input.substr(peg$currPos, 2) === peg$c179) {
+            s1 = peg$c179;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c178); }
+            if (peg$silentFails === 0) { peg$fail(peg$c180); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c300(s1);
+            s1 = peg$c303(s1);
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (peg$c303.test(input.charAt(peg$currPos))) {
+            if (peg$c306.test(input.charAt(peg$currPos))) {
               s1 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c304); }
+              if (peg$silentFails === 0) { peg$fail(peg$c307); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c300(s1);
+              s1 = peg$c303(s1);
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
@@ -9181,7 +9230,7 @@ module.exports = /*
               s1 = peg$parseliteral_mn();
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c300(s1);
+                s1 = peg$c303(s1);
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
@@ -9191,7 +9240,7 @@ module.exports = /*
                   s2 = peg$parseCURLY_CLOSE();
                   if (s2 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c305();
+                    s1 = peg$c308();
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -9225,7 +9274,7 @@ module.exports = /*
       }
 
       peg$savedPos = peg$currPos;
-      s0 = peg$c306();
+      s0 = peg$c309();
       if (s0) {
         s0 = void 0;
       } else {
@@ -9250,7 +9299,7 @@ module.exports = /*
       }
 
       peg$savedPos = peg$currPos;
-      s0 = peg$c307();
+      s0 = peg$c310();
       if (s0) {
         s0 = void 0;
       } else {

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -123,6 +123,16 @@ lit
      console.assert(Array.isArray(ast) && ast.length === 1);
      return ast[0];
    }
+  / f:generic_func &{ return tu.deprecated_nullary_macro_aliase[f]; } _ // from Texutil.find(...)
+   {
+     var ast = peg$parse(tu.deprecated_nullary_macro_aliase[f]);
+     console.assert(Array.isArray(ast) && ast.length === 1);
+     if (options.oldtexvc){
+       return ast[0];
+     } else {
+          throw new peg$SyntaxError("Deprecation: Alias no longer supported.", [], text(), location());
+     }
+   }
   / r:DELIMITER                 { return ast.Tex.LITERAL(r); }
   / b:BIG r:DELIMITER           { return ast.Tex.BIG(b, r); }
   / b:BIG SQ_CLOSE              { return ast.Tex.BIG(b, ast.RenderT.TEX_ONLY( "]")); }
@@ -325,7 +335,11 @@ LITERAL
  / c:[><~] _
    { return ast.RenderT.TEX_ONLY(c); }
  / c:[%$] _
-   { return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */}
+   { if(options.oldtexvc) {
+    return ast.RenderT.TEX_ONLY("\\" + c); /* escape dangerous chars */
+    } else {
+     throw new peg$SyntaxError("Deprecation: % and $ need to be escaped.", [], text(), location());
+    }}
 
 // returns a RenderT
 DELIMITER
@@ -438,7 +452,11 @@ FUN_AR1
  / f:generic_func &{ return options.oldmhchem && tu.fun_mhchem[f]} _
    { return f; }
  / f:generic_func &{ return tu.other_fun_ar1[f]; } _
-   { return tu.other_fun_ar1[f]; }
+   { if (options.oldtexvc) {
+        return tu.other_fun_ar1[f];
+     } else {
+        throw new peg$SyntaxError("Deprecation: \\Bbb and \\bold are not allowed in math mode.", [], text(), location());
+       }}
 
 FUN_MHCHEM
  = f:generic_func &{ return tu.fun_mhchem[f]; } _

--- a/lib/texutil.js
+++ b/lib/texutil.js
@@ -514,8 +514,6 @@ module.exports.nullary_macro_in_mbox = arr2set([
 ]);
 
 module.exports.nullary_macro_aliase = obj2map({
-    "\\C": "\\mathbb{C}",
-    "\\H": "\\mathbb{H}",
     "\\N": "\\mathbb{N}",
     "\\Q": "\\mathbb{Q}",
     "\\R": "\\mathbb{R}",
@@ -523,8 +521,6 @@ module.exports.nullary_macro_aliase = obj2map({
     "\\alef": "\\aleph",
     "\\alefsym": "\\aleph",
     "\\Alpha": "\\mathrm{A}",
-    "\\and": "\\land",
-    "\\ang": "\\angle",
     "\\Beta": "\\mathrm{B}",
     "\\bull": "\\bullet",
     "\\Chi": "\\mathrm{X}",
@@ -565,8 +561,6 @@ module.exports.nullary_macro_aliase = obj2map({
     "\\O": "\\emptyset",
     "\\omicron": "\\mathrm{o}",
     "\\Omicron": "\\mathrm{O}",
-    "\\or": "\\lor",
-    "\\part": "\\partial",
     "\\plusmn": "\\pm",
     "\\rarr": "\\rightarrow",
     "\\Rarr": "\\Rightarrow",
@@ -587,6 +581,16 @@ module.exports.nullary_macro_aliase = obj2map({
     "\\varcoppa": "\\mbox{\\coppa}",
     "\\weierp": "\\wp",
     "\\Zeta": "\\mathrm{Z}"
+});
+
+// Deprecated via T197842
+module.exports.deprecated_nullary_macro_aliase = obj2map({
+    "\\C": "\\mathbb{C}",
+    "\\H": "\\mathbb{H}",
+    "\\and": "\\land",
+    "\\ang": "\\angle",
+    "\\or": "\\lor",
+    "\\part": "\\partial",
 });
 
 module.exports.big_literals = arr2set([
@@ -700,6 +704,7 @@ module.exports.fun_mhchem = arr2set([
     "\\ce"
 ]);
 
+// Deprecated via T197842
 module.exports.other_fun_ar1 = obj2map({
     "\\Bbb": "\\mathbb",
     "\\bold": "\\mathbf"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathoid-texvcjs",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "A TeX/LaTeX validator for mediawiki.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/all.js
+++ b/test/all.js
@@ -209,6 +209,7 @@ describe('Comprehensive test cases', function() {
             skipOcaml: true
         },
         'Literals (3)': {
+            oldtexvc: true,
             input:
                 '\\C\\H\\N\\Q\\R\\Z\\alef\\alefsym\\Alpha\\and\\ang\\Beta' +
                 '\\bull\\Chi\\clubs\\cnums\\Complex\\Dagger\\diamonds\\Doteq' +
@@ -317,6 +318,7 @@ describe('Comprehensive test cases', function() {
             skipOcaml: 'double spacing and extra braces'
         },
         'FUN_AR1 (2)': {
+            oldtexvc: true,
             input: '\\Bbb{foo}\\bold{bar}',
             output: '{\\mathbb {foo}}{\\mathbf {bar}}',
             skipOcaml: 'double spacing',
@@ -452,7 +454,7 @@ describe('Comprehensive test cases', function() {
             tc.output = tc.output || tc.input;
             if (!tc.skipJs) {
                 it('output should be correct', function() {
-                    var result = texvcjs.check(tc.input, { debug: true, usemathrm:tc.usemathrm});
+                    var result = texvcjs.check(tc.input, { debug: true, usemathrm:tc.usemathrm, oldtexvc: tc.oldtexvc});
                     assert.equal(result.status, '+');
                     assert.equal(result.output, tc.output);
                 });

--- a/test/contains.js
+++ b/test/contains.js
@@ -65,7 +65,7 @@ describe('ast.Tex.contains_func', function() {
             (expected ? tc.yes : tc.no).forEach(function(target) {
                 it('should ' + (expected ? '' : 'not ') + 'find ' + target +
                    ' in ' + tc.input.replace(/\n/g,' '), function() {
-                       var p = texvcjs.parse(tc.input, { debug: true, usemhchem:true });
+                       var p = texvcjs.parse(tc.input, { debug: true, usemhchem:true, oldtexvc:true });
                        assert.equal(texvcjs.contains_func(p, target),
                                     expected ? target : false);
                    });

--- a/test/mathjax-texvc.js
+++ b/test/mathjax-texvc.js
@@ -22,7 +22,7 @@ describe('Run test for all mathjax-texvc commands:', function () {
                         expected: testcase.texvcjs
                     }, null, 2));
                 assert.equal(result.status,'+');
-                assert.equal(result.warnings.length, testcase.warnCount||0);
+                assert.equal(result.warnings.length, testcase.warnCount||0, "incorrect number of warnings");
             });
         }
     });

--- a/test/mathjax-texvc.json
+++ b/test/mathjax-texvc.json
@@ -37,7 +37,8 @@
     "texvcjs": "\\mathbb {C} ",
     "options": {
       "usemathrm": true
-    }
+    },
+    "warnCount": 1
   },
   {
     "id": 6,
@@ -61,7 +62,8 @@
     "texvcjs": "\\mathbb {H} ",
     "options": {
       "usemathrm": true
-    }
+    },
+    "warnCount": 1
   },
   {
     "id": 9,
@@ -181,7 +183,8 @@
     "texvcjs": "\\partial ",
     "options": {
       "usemathrm": true
-    }
+    },
+    "warnCount": 1
   },
   {
     "id": 24,
@@ -213,7 +216,8 @@
     "texvcjs": "\\angle ",
     "options": {
       "usemathrm": true
-    }
+    },
+    "warnCount": 1
   },
   {
     "id": 28,
@@ -269,7 +273,8 @@
     "texvcjs": "\\land ",
     "options": {
       "usemathrm": true
-    }
+    },
+    "warnCount": 1
   },
   {
     "id": 35,
@@ -277,7 +282,8 @@
     "texvcjs": "\\lor ",
     "options": {
       "usemathrm": true
-    }
+    },
+    "warnCount": 1
   },
   {
     "id": 36,
@@ -693,7 +699,8 @@
     "texvcjs": "{\\mathbf {x}}",
     "options": {
       "usemathrm": true
-    }
+    },
+    "warnCount": 1
   },
   {
     "id": 88,
@@ -1587,7 +1594,8 @@
     "options": {
       "usemathrm": true,
       "usemhchem": true
-    }
+    },
+    "warnCount": 1
   },
   {
     "id": 195,
@@ -1737,6 +1745,17 @@
       "usemathrm": true,
       "usemhchem": true
     },
+    "warnCount": 2
+  },
+  {
+    "id": 211,
+    "input": "\\$",
+    "texvcjs": "\\$"
+  },
+  {
+    "id": 212,
+    "input": "$",
+    "texvcjs": "\\$",
     "warnCount": 1
   }
 ]


### PR DESCRIPTION
Generate deprecation warnings in mathoid if deprecated texvc commands are used.

Bug: [T197842](https://phabricator.wikimedia.org/T197842)